### PR TITLE
Fix few water related issues

### DIFF
--- a/source/game_sa/Fx/FxEmitter.cpp
+++ b/source/game_sa/Fx/FxEmitter.cpp
@@ -243,16 +243,17 @@ FxEmitterPrt_c* FxEmitter_c::CreateParticle(EmissionInfo_t* emissionInfo, RwMatr
     if (velOverride) {
         particle->m_Velocity = *velOverride;
     } else {
-        auto index = CGeneral::GetRandomNumberInRange(0.0f, TWO_PI);
+        auto randomAngle = CGeneral::GetRandomNumberInRange(0.0f, TWO_PI);
         auto minAngle = DegreesToRadians(emissionInfo->m_fAngleMin);
         auto maxAngle = DegreesToRadians(emissionInfo->m_fAngleMax);
 
-        auto sinY = (CGeneral::GetRandomNumberInRange(0.0f, 1.0f) * (maxAngle - minAngle) + minAngle) * 40.743664f;
+        auto randomAngleBetweenMinMax = lerp(minAngle, maxAngle, CGeneral::GetRandomNumberInRange(0.0f, 1.0f));
 
-        CVector v37;
-        v37.x = CMaths::ms_SinTable[(uint8)((index * 40.743664f) + 64.0f) + 1] * CMaths::ms_SinTable[(uint8)sinY + 1];
-        v37.y = CMaths::ms_SinTable[(uint8)(sinY + 64.0f) + 1];
-        v37.z = CMaths::ms_SinTable[(uint8)(index * 40.743664f) + 1] * CMaths::ms_SinTable[(uint8)sinY + 1];
+        CVector randomizedAngleVec{
+            CMaths::GetCosFast(randomAngle) * CMaths::GetSinFast(randomAngleBetweenMinMax),
+            CMaths::GetCosFast(randomAngleBetweenMinMax),
+            CMaths::GetSinFast(randomAngle) * CMaths::GetSinFast(randomAngleBetweenMinMax)
+        };
 
         CVector vectorsIn;
         CVector vectorsOut;
@@ -264,7 +265,7 @@ FxEmitterPrt_c* FxEmitter_c::CreateParticle(EmissionInfo_t* emissionInfo, RwMatr
         }
         RwV3dTransformVectors(&vectorsOut, &vectorsIn, 1, wldMat);
         CVector v38;
-        RotateVecIntoVec(&v38, &v37, &vectorsOut);
+        RotateVecIntoVec(&v38, &randomizedAngleVec, &vectorsOut);
         particle->m_Velocity = v38 * ((CGeneral::GetRandomNumberInRange(0.0f, 2.0f) - 1.0f) * emissionInfo->m_fSpeedBias + emissionInfo->m_fSpeed);
     }
 

--- a/source/game_sa/Maths.cpp
+++ b/source/game_sa/Maths.cpp
@@ -10,6 +10,8 @@ void CMaths::InjectHooks()
     RH_ScopedCategoryGlobal();
 
     RH_ScopedInstall(InitMathsTables, 0x59AC90);
+    RH_ScopedInstall(GetSinFast, 0x4A1340); // No callers in the game, inlined in every single instance
+    RH_ScopedInstall(GetCosFast, 0x4A1360); // No callers in the game, inlined in every single instance
 }
 
 void CMaths::InitMathsTables() {
@@ -17,4 +19,13 @@ void CMaths::InitMathsTables() {
 
     for (int32 i = 0; i < 256; ++i)
         ms_SinTable[i] = sin(static_cast<float>(i) * PI / 128.0F);
+}
+
+float CMaths::GetSinFast(float rad) {
+    return ms_SinTable[static_cast<uint8>(rad * RadToSinTableIndex) + 1];
+}
+
+float CMaths::GetCosFast(float rad) {
+    // Table has 256 elements, and spans [0:2PI), 64 index move equals PI/2 move on the X axis, and cos(x) == sin(x + PI/2)
+    return ms_SinTable[static_cast<uint8>(rad * RadToSinTableIndex + 64.f) + 1];
 }

--- a/source/game_sa/Maths.h
+++ b/source/game_sa/Maths.h
@@ -1,10 +1,18 @@
 #pragma once
 
+constexpr float RadToSinTableIndex = 256.0f / TWO_PI;
+
 class CMaths {
 public:
     static float (&ms_SinTable)[256];
 
     static void InjectHooks();
-
     static void InitMathsTables();
+
+    // Originally named `SinTabel` with argument named `Arg` which sucks, so replaced with custom name.
+    static float GetSinFast(float rad);
+
+    // Originally named `CosTabel` with argument named `Arg`, same story as above
+    static float GetCosFast(float rad);
+
 };

--- a/source/game_sa/WaterLevel.cpp
+++ b/source/game_sa/WaterLevel.cpp
@@ -772,9 +772,12 @@ void CWaterLevel::CalculateWavesOnlyForCoordinate2( // TODO: Original name didn'
 void CWaterLevel::BlockHit(int32 blockX, int32 blockY) {
     if (blockX >= 0 && blockX < NUM_WATER_BLOCKS_ROWCOL && blockY >= 0 && blockY < NUM_WATER_BLOCKS_ROWCOL) {
         MarkQuadsAndPolysToBeRendered(blockX, blockY, CGame::currArea != AREA_CODE_NORMAL_WORLD);
-    } else { // Original check was: `blockX <= 0 || blockX >= 11 || blockY <= 0 || blockY >= 11`, but that's erronous (because of `<= 0`)
+    }
+
+    // Blocks at the edge of the world (index 0 and 11) need to be handled both ways, the quads and polys are to be rendered, but also the general ocean plane needs to be rendered on them
+    if (blockX <= 0 || blockX >= (NUM_WATER_BLOCKS_ROWCOL - 1) || blockY <= 0 || blockY >= (NUM_WATER_BLOCKS_ROWCOL - 1)) {
         if (m_NumBlocksOutsideWorldToBeRendered < (uint32)m_MaxNumBlocksOutsideWorldToBeRendered) {
-            const auto idx = m_NumBlocksOutsideWorldToBeRendered++;
+            const auto idx                         = m_NumBlocksOutsideWorldToBeRendered++;
             m_BlocksToBeRenderedOutsideWorldX[idx] = blockX;
             m_BlocksToBeRenderedOutsideWorldY[idx] = blockY;
         }

--- a/source/game_sa/WaterLevel.cpp
+++ b/source/game_sa/WaterLevel.cpp
@@ -856,7 +856,7 @@ struct SortableVtx {
 //! NOTSA
 //! Sort vertices in clockwise order (With a few assumptions)
 template<size_t N>
-auto DoVtxSortAndGetRange(SortableVtx (&verts)[N], bool clockwise) {
+auto DoVtxSortAndGetRange(SortableVtx (&verts)[N]) {
     const auto VertexComparator = [&](SortableVtx& a, SortableVtx& b) {
         if (a.y == b.y) {
             return a.x < b.x; // Sort by x if y is the same
@@ -894,7 +894,7 @@ void CWaterLevel::AddWaterLevelQuad(int32 X1, int32 Y1, CRenPar P1, int32 X2, in
     WaterQuads[NumWaterQuads++] = CWaterQuad{
         (Flags & 1) == 0,
         (Flags & 2) != 0,
-        DoVtxSortAndGetRange(verts, false)
+        DoVtxSortAndGetRange(verts)
     };
 }
 

--- a/source/game_sa/WaterLevel.cpp
+++ b/source/game_sa/WaterLevel.cpp
@@ -675,7 +675,6 @@ void CWaterLevel::CalculateWavesOnlyForCoordinate(
     y = std::abs(y);
     vecNormal = CVector(0.f, 0.f, 1.f);
 
-    constexpr auto argToSinus = 256.0f / TWO_PI; //TODO: Move it to shared space if it is used anywhere else (CMaths most likely)
     const float waveMult = faWaveMultipliersX[(x / 2) % 8] * faWaveMultipliersY[(y / 2) % 8] * CWeather::Wavyness;
     float fX = (float)x, fY = (float)y;
 
@@ -685,10 +684,10 @@ void CWaterLevel::CalculateWavesOnlyForCoordinate(
         const CVector2D waveVector{ TWO_PI * angularFreqX, TWO_PI * angularFreqY }; // w = angular frequency
 
         const auto step  = (CTimer::GetTimeInMS() - m_nWaterTimeOffset) % offset;
-        const auto wavePhase = (step * freqOffsetMult + fX * waveVector.x + fY * waveVector.y) * argToSinus;
+        const auto wavePhase = step * freqOffsetMult + fX * waveVector.x + fY * waveVector.y);
 
-        const auto sinPhase = CMaths::ms_SinTable[static_cast<uint8>(wavePhase) + 1];
-        const auto cosPhase = CMaths::ms_SinTable[static_cast<uint8>(wavePhase + 64.0f) + 1]; // Table has 256 elements, and spans [0:2PI), 64 index move equals PI/2 move on the X axis, and cos(x) == sin(x + PI/2)
+        const auto sinPhase = CMaths::GetSinFast(wavePhase);
+        const auto cosPhase = CMaths::GetCosFast(wavePhase);
         outWave += sinPhase * waveMult * amplitude;
 
         // Wave normal calculation - seems broken but maybe R* just knows something that we don't :D

--- a/source/game_sa/WaterLevel.cpp
+++ b/source/game_sa/WaterLevel.cpp
@@ -684,7 +684,7 @@ void CWaterLevel::CalculateWavesOnlyForCoordinate(
         const CVector2D waveVector{ TWO_PI * angularFreqX, TWO_PI * angularFreqY }; // w = angular frequency
 
         const auto step  = (CTimer::GetTimeInMS() - m_nWaterTimeOffset) % offset;
-        const auto wavePhase = step * freqOffsetMult + fX * waveVector.x + fY * waveVector.y);
+        const auto wavePhase = step * freqOffsetMult + fX * waveVector.x + fY * waveVector.y;
 
         const auto sinPhase = CMaths::GetSinFast(wavePhase);
         const auto cosPhase = CMaths::GetCosFast(wavePhase);

--- a/source/game_sa/WaterLevel.cpp
+++ b/source/game_sa/WaterLevel.cpp
@@ -33,8 +33,8 @@ void CWaterLevel::InjectHooks() {
     // no clue what is the issue
     // one quad that doesn't load can be seen from -1610, 168
     // it's at water.dat:252
-    RH_ScopedGlobalInstall(AddWaterLevelQuad, 0x6E7EF0, { .enabled = true });
-    RH_ScopedGlobalInstall(AddWaterLevelTriangle, 0x6E7D40, { .enabled = true });
+    RH_ScopedGlobalInstall(AddWaterLevelQuad, 0x6E7EF0);
+    RH_ScopedGlobalInstall(AddWaterLevelTriangle, 0x6E7D40);
     RH_ScopedGlobalInstall(AddWaterLevelVertex, 0x6E5A40);
 
     RH_ScopedGlobalInstall(RenderBoatWakes, 0x6ED9A0);

--- a/source/game_sa/WaterLevel.h
+++ b/source/game_sa/WaterLevel.h
@@ -144,8 +144,8 @@ class CWaterLevel {
     static constexpr uint32 NUM_WATER_BLOCKS_ROWCOL                = 6000 / WATER_BLOCK_SIZE; // 6000 => map size
     static inline    int32  m_MaxNumBlocksOutsideWorldToBeRendered = 70; // NOTSA: We just want a variable for the debug tool. Value may never be higher than the below array's size.
     static inline    auto&  m_NumBlocksOutsideWorldToBeRendered    = *(uint32*)0xC215EC;
-    static inline    auto&  m_BlocksToBeRenderedOutsideWorldX      = *(std::array<int32, 70>*)0xC21560;
-    static inline    auto&  m_BlocksToBeRenderedOutsideWorldY      = *(std::array<int32, 70>*)0xC214D0;
+    static inline    auto&  m_BlocksToBeRenderedOutsideWorldX      = *(std::array<int16, 70>*)0xC21560;
+    static inline    auto&  m_BlocksToBeRenderedOutsideWorldY      = *(std::array<int16, 70>*)0xC214D0;
 
     // NOTSA: Color of wake segment parts (So we can make rainbows)
     static inline struct {

--- a/source/game_sa/WaterLevel.h
+++ b/source/game_sa/WaterLevel.h
@@ -267,7 +267,7 @@ public:
     static void FindNearestWaterAndItsFlow();
     static bool GetWaterLevelNoWaves(CVector pos, float * pOutWaterLevel, float * fUnkn1 = nullptr, float * fUnkn2 = nullptr);
     static void RenderWaterFog();
-    static void CalculateWavesOnlyForCoordinate(int32 x, int32 y, float lowFreqMult, float midHighFreqMult, float& outWave, float& colorMult, float& glare, CVector& vecNormal);
+    static void CalculateWavesOnlyForCoordinate(int32 x, int32 y, float bigWavesAmplitude, float smallWavesAmplitude, float& outWave, float& colorMult, float& glare, CVector& vecNormal);
     static void MarkQuadsAndPolysToBeRendered(int32 blockX, int32 blockY, bool isInInterior);
     static void BlockHit(int32 X, int32 Y);
 

--- a/source/game_sa/WaterLevel.h
+++ b/source/game_sa/WaterLevel.h
@@ -140,8 +140,8 @@ class CWaterLevel {
     static inline auto& m_CurrentFlow        = *(CVector2D*)0xC22890;
     static inline auto& m_CurrentDesiredFlow = *(CVector2D*)0xC22898;
 
-    static constexpr uint32 WATER_BLOCK_SIZE                       = 500u;
-    static constexpr uint32 NUM_WATER_BLOCKS_ROWCOL                = 6000 / WATER_BLOCK_SIZE; // 6000 => map size
+    static constexpr int32 WATER_BLOCK_SIZE                       = 500;
+    static constexpr int32 NUM_WATER_BLOCKS_ROWCOL                = 6000 / WATER_BLOCK_SIZE; // 6000 => map size
     static inline    int32  m_MaxNumBlocksOutsideWorldToBeRendered = 70; // NOTSA: We just want a variable for the debug tool. Value may never be higher than the below array's size.
     static inline    auto&  m_NumBlocksOutsideWorldToBeRendered    = *(uint32*)0xC215EC;
     static inline    auto&  m_BlocksToBeRenderedOutsideWorldX      = *(std::array<int16, 70>*)0xC21560;


### PR DESCRIPTION
- Fixes: #533 
- Fixes waves being slightly different from original ones (`faWaveMultipliersX` used by accident instead of `faWaveMultipliersY`), also cleanups to that method
- Fixes `SplitWaterRectangleAlongXLine` and `SplitWaterRectangleAlongYLine` using wrong indices
- Fixes water quads loading incorrectly. It's a hack fix, but results in every single vertice being sorted correctly. I think that the generic solution that was implemented earlier is not the correct fit for this use case, and we should revert back to the original SA logic.
With my changes all quads load correctly, and all but one triangle is loaded correctly. The one remaining incorrect triangle can be found in SF docks:
![waterTriangle](https://github.com/user-attachments/assets/db6452f0-986d-4b5e-aa0c-5bd07725819d)
