### PR TITLE
Update StuntJumpManager.cpp

### DIFF
--- a/source/game_sa/StuntJumpManager.cpp
+++ b/source/game_sa/StuntJumpManager.cpp
@@ -105,7 +105,7 @@ void CStuntJumpManager::Update() {
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_BOAT &&
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_PLANE &&
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_HELI &&
-            playerVehicle->m_nNumEntitiesCollided != 0 && // FIXME: https://discord.com/channels/874507673943539752/880913138004938774/1294699278979039264
+            playerVehicle->m_nNumEntitiesCollided == 0 && // Check that vehicle is not colliding when starting the jump
             playerVehicle->m_vecMoveSpeed.Magnitude() * 50.0f >= 20.0f
         ) {
             for (auto jumpIndex = 0; jumpIndex < STUNT_JUMP_COUNT; jumpIndex++) {

--- a/source/game_sa/StuntJumpManager.cpp
+++ b/source/game_sa/StuntJumpManager.cpp
@@ -105,7 +105,13 @@ void CStuntJumpManager::Update() {
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_BOAT &&
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_PLANE &&
             playerVehicle->GetVehicleAppearance() != VEHICLE_APPEARANCE_HELI &&
+            // Game sometimes miss successful jumps: it's somewhat rare but happens quite a lot
+            // while speedrunning. This check here is suspicious, small bumps may cause fail the jump.
+            //
+            // lordmau5 added a grace period allowing the vehicle to be airborne if any wheel
+            // touched ground on his MTA script to fix.
             playerVehicle->m_nNumEntitiesCollided == 0 && // Check that vehicle is not colliding when starting the jump
+            
             playerVehicle->m_vecMoveSpeed.Magnitude() * 50.0f >= 20.0f
         ) {
             for (auto jumpIndex = 0; jumpIndex < STUNT_JUMP_COUNT; jumpIndex++) {


### PR DESCRIPTION
Fix:
`            playerVehicle->m_nNumEntitiesCollided != 0 && // FIXME: https://discord.com/channels/874507673943539752/880913138004938774/1294699278979039264
`
replaced by:

`            playerVehicle->m_nNumEntitiesCollided == 0 && // Check that vehicle is not colliding when starting the jump
`

Unfortunately I don't have access to the original conversation but the logic seems broken that way. If collisions are 0 it should proceed with the bonus, but not if they are non-0.