### PR TITLE
Fix for hard DPI bug Windows 10+

### DIFF
--- a/source/app/platform/win/WinPs.cpp
+++ b/source/app/platform/win/WinPs.cpp
@@ -9,6 +9,15 @@
 #include "LoadingScreen.h"
 #include "C_PcSave.h"
 
+#if _MSC_VER >= 1910 && FIX_BUGS
+#include <windows.h>
+
+void SetDPIAware() {
+    SetProcessDPIAware();
+}
+#endif
+
+
 // NOTE: This macro doesn't do a whole lot. Leaving it here for completeness sake
 #define USE_D3D9
 
@@ -95,14 +104,9 @@ void InitialiseLanguage() {
 
 // 0x747420
 RwBool psInitialize() {
-
-    // Only Vista +
-#if _WIN32_WINNT >= 0x0600
-    #include <windows.h>
-
-    setProcessDPIAware();
+#if _MSC_VER >= 1910 && FIX_BUGS
+    SetDPIAware();
 #endif
-
     auto ps = &PsGlobal;
 
     RsGlobal.ps = ps;

--- a/source/app/platform/win/WinPs.cpp
+++ b/source/app/platform/win/WinPs.cpp
@@ -98,6 +98,8 @@ RwBool psInitialize() {
 
     // Only Vista +
 #if _WIN32_WINNT >= 0x0600
+    #include <windows.h>
+
     setProcessDPIAware();
 #endif
 

--- a/source/app/platform/win/WinPs.cpp
+++ b/source/app/platform/win/WinPs.cpp
@@ -8,14 +8,7 @@
 #include "VideoModeSelectDialog.h"
 #include "LoadingScreen.h"
 #include "C_PcSave.h"
-
-#if _MSC_VER >= 1910 && FIX_BUGS
 #include <windows.h>
-
-void SetDPIAware() {
-    SetProcessDPIAware();
-}
-#endif
 
 
 // NOTE: This macro doesn't do a whole lot. Leaving it here for completeness sake
@@ -104,9 +97,7 @@ void InitialiseLanguage() {
 
 // 0x747420
 RwBool psInitialize() {
-#if _MSC_VER >= 1910 && FIX_BUGS
-    SetDPIAware();
-#endif
+    SetProcessDPIAware();
     auto ps = &PsGlobal;
 
     RsGlobal.ps = ps;

--- a/source/app/platform/win/WinPs.cpp
+++ b/source/app/platform/win/WinPs.cpp
@@ -95,6 +95,22 @@ void InitialiseLanguage() {
 
 // 0x747420
 RwBool psInitialize() {
+
+    // Only Vista +
+#if _WIN32_WINNT >= 0x0600
+    HMODULE hUser32 = LoadLibraryA("user32.dll");
+    if (hUser32)
+    {
+        typedef BOOL (WINAPI *SetProcessDPIAwareFunc)();
+        SetProcessDPIAwareFunc setProcessDPIAware = (SetProcessDPIAwareFunc)GetProcAddress(hUser32, "SetProcessDPIAware");
+        if (setProcessDPIAware)
+        {
+            setProcessDPIAware();
+        }
+        FreeLibrary(hUser32);
+    }
+#endif
+
     auto ps = &PsGlobal;
 
     RsGlobal.ps = ps;

--- a/source/app/platform/win/WinPs.cpp
+++ b/source/app/platform/win/WinPs.cpp
@@ -98,17 +98,7 @@ RwBool psInitialize() {
 
     // Only Vista +
 #if _WIN32_WINNT >= 0x0600
-    HMODULE hUser32 = LoadLibraryA("user32.dll");
-    if (hUser32)
-    {
-        typedef BOOL (WINAPI *SetProcessDPIAwareFunc)();
-        SetProcessDPIAwareFunc setProcessDPIAware = (SetProcessDPIAwareFunc)GetProcAddress(hUser32, "SetProcessDPIAware");
-        if (setProcessDPIAware)
-        {
-            setProcessDPIAware();
-        }
-        FreeLibrary(hUser32);
-    }
+    setProcessDPIAware();
 #endif
 
     auto ps = &PsGlobal;


### PR DESCRIPTION
GTA San Andreas will not work with DPI other than 100, this is because some newer versions of Windows assign the resolution based on the DPI.