### PR TITLE
Wrong assert replaced (maxX >= minX && maxY >= minY)

### DIFF
--- a/source/game_sa/World.h
+++ b/source/game_sa/World.h
@@ -236,7 +236,9 @@ public:
     */
     template<std::predicate<int32, int32> Fn>
     static bool IterateSectors(int32 minX, int32 minY, int32 maxX, int32 maxY, Fn&& fn) {
-        assert(maxX >= minX && maxY >= minY);
+        if (maxX >= minX && maxY >= minY) {
+            return;
+        }
 
         for (auto y = minY; y <= maxY; ++y) {
             for (auto x = minX; x <= maxX; ++x) {

--- a/source/game_sa/World.h
+++ b/source/game_sa/World.h
@@ -237,7 +237,7 @@ public:
     template<std::predicate<int32, int32> Fn>
     static bool IterateSectors(int32 minX, int32 minY, int32 maxX, int32 maxY, Fn&& fn) {
         if (maxX >= minX && maxY >= minY) {
-            return;
+            return false;
         }
 
         for (auto y = minY; y <= maxY; ++y) {


### PR DESCRIPTION
It will happen whenever you get close to the water level and it really doesn't make sense.