### PR TITLE
CI: Use `windows-2025` image [Instead of `windows-2022`]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ windows-2022 ]
+                os: [ windows-2025 ]
                 arch: [ x86 ]
                 conf: [ Debug, Release ]
 


### PR DESCRIPTION
Previous image is quite old, and also, this resolves an [issue](https://github.com/libsdl-org/SDL/issues/11487) that we'd have with SDL3