### PR TITLE
Fix Edit&Continue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,11 @@ project(GTASA C CXX)
 
 if (MSVC)
     add_compile_options(/bigobj /utf-8)
-
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+    # For Edit&Continue
+    add_compile_options(/ZI)
+    add_link_options(/SAFESEH:NO)
 endif()
 
 option(BUILD_DOC "Build documentation" OFF)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -17,10 +17,6 @@ target_compile_options(${RE_PROJECT_LIB_NAME} PRIVATE
     "$<$<CXX_COMPILER_ID:MSVC>:/MP;/Zc:preprocessor;/wd26812;/wd26495>"
     "$<$<OR:$<CXX_COMPILER_ID:Clang,GCC>,$<CXX_COMPILER_ID:GNU>>:-Wall;>"
 )
-# MSVC Program Database for Edit And Continue ()
-add_compile_options(${RE_PROJECT_LIB_NAME} PRIVATE
-    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<AND:$<CONFIG:DEBUG>>>:/ZI>
-)
 
 function(supress_deps_warnings targets)
     foreach (target ${targets})
@@ -59,7 +55,7 @@ if (${RE_PROJECT}_WITH_SANITIZERS)
     # add_sanitizers(${RE_PROJECT_LIB_NAME})
 endif()
 
-target_link_options(${RE_PROJECT_LIB_NAME} PRIVATE "/SUBSYSTEM:WINDOWS" "/SAFESEH")
+target_link_options(${RE_PROJECT_LIB_NAME} PRIVATE "/SUBSYSTEM:WINDOWS")
 
 target_link_libraries(${RE_PROJECT_LIB_NAME} PRIVATE
     Ogg::ogg


### PR DESCRIPTION
`/SAFESH` is not necessary (We didn't have it with premake either)
`/ZI` was not added for some reason (I think because `add_compile_options` doesn't need a target, but only options)