### PR TITLE
Fix `CAEAudioEnvironment::GetPositionRelativeToCamera`

### DIFF
--- a/source/game_sa/Audio/AESound.cpp
+++ b/source/game_sa/Audio/AESound.cpp
@@ -207,7 +207,9 @@ CVector CAESound::GetRelativePosition() const {
 
 // 0x4EF350 - Matches the original calling convention, to be used by reversible hooks, use the version returning CVector instead in our code
 void CAESound::GetRelativePosition(CVector* outVec) const {
-    *outVec = GetFrontEnd() ? m_vecCurrPosn : CAEAudioEnvironment::GetPositionRelativeToCamera(m_vecCurrPosn);
+    *outVec = GetFrontEnd()
+        ? m_vecCurrPosn
+        : CAEAudioEnvironment::GetPositionRelativeToCamera(m_vecCurrPosn);
 }
 
 // 0x4EF390
@@ -300,10 +302,9 @@ void CAESound::CalculateVolume() {
     if (GetFrontEnd())
         m_fFinalVolume = m_fVolume - m_fSoundHeadRoom;
     else {
-        const auto relativePos = CAEAudioEnvironment::GetPositionRelativeToCamera(m_vecCurrPosn);
-        const auto fDist = CAEAudioEnvironment::GetPositionRelativeToCamera(m_vecCurrPosn).Magnitude() / m_fSoundDistance;
-        const auto fAttenuation = CAEAudioEnvironment::GetDistanceAttenuation(fDist);
-        m_fFinalVolume = CAEAudioEnvironment::GetDirectionalMikeAttenuation(relativePos) + fAttenuation + m_fVolume - m_fSoundHeadRoom;
+        const auto relativeToCamPos = CAEAudioEnvironment::GetPositionRelativeToCamera(m_vecCurrPosn);
+        const auto attenuation      = CAEAudioEnvironment::GetDistanceAttenuation(relativeToCamPos.Magnitude() / m_fSoundDistance);
+        m_fFinalVolume              = CAEAudioEnvironment::GetDirectionalMikeAttenuation(relativeToCamPos) + attenuation + m_fVolume - m_fSoundHeadRoom;
     }
 }
 

--- a/source/game_sa/Core/Matrix.h
+++ b/source/game_sa/Core/Matrix.h
@@ -86,17 +86,16 @@ public:
 public:
     static void InjectHooks();
 
-    CVector& GetRight() { return m_right; }
-    const CVector& GetRight() const { return m_right; }
+    auto& GetRight(this auto&& self) { return self.m_right; }
+    CVector GetLeft() const { return -GetRight(); }
 
-    CVector& GetForward() { return m_forward; }
-    const CVector& GetForward() const { return m_forward; }
+    auto& GetForward(this auto&& self) { return self.m_forward; }
+    CVector GetBackward() const { return -GetForward(); }
 
-    CVector& GetUp() { return m_up; }
-    const CVector& GetUp() const { return m_up; }
+    auto& GetUp(this auto&& self) { return self.m_up; }
+    CVector GetDown() const { return -GetUp(); }
 
-    CVector& GetPosition() { return m_pos; }
-    const CVector& GetPosition() const { return m_pos; }
+    auto& GetPosition(this auto&& self) { return self.m_pos; }
 
     void Attach(RwMatrix* matrix, bool bOwnsMatrix);
     void Detach();
@@ -185,7 +184,7 @@ public:
 
     /*!
      * @notsa
-     * @brief Transform the vector using the inverse of this Matrix
+     * @brief Transform the vector using the inverse of this Matrix (So transform into this matrix's space, without translation)
      * @brief Use this instead of `Multiply3x3(_MV)` (0x59C790)
      * @param pt The vector (direction) to transform
      */

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexRoadRage.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexRoadRage.cpp
@@ -69,6 +69,8 @@ CTask* CTaskComplexRoadRage::CreateSubTask(eTaskType taskType, CPed* ped) {
         return new CTaskComplexDestroyCar{ m_rageWith->m_pVehicle };
     case TASK_COMPLEX_KILL_PED_ON_FOOT:
         return new CTaskComplexKillPedOnFoot{ m_rageWith, -1, 0, 0, 0, true };
+    case TASK_FINISHED:
+        return nullptr;
     default:
         NOTSA_UNREACHABLE();
     }


### PR DESCRIPTION
The abovementioned function was buggy, and caused the sound to be a almost silent in one ear and loud in the other.
Issue was my assumption of `InverseTransformVector({-p.x, p.y, p.z})` being the same as just negating the resulting `x`.
All other changes are mostly cosmetic/make the code be more OG.