### PR TITLE
ImGui DrawListSizes Crash Fix

### DIFF
--- a/source/toolsmenu/DebugModules/CStreamingDebugModule.cpp
+++ b/source/toolsmenu/DebugModules/CStreamingDebugModule.cpp
@@ -73,9 +73,12 @@ void DrawChannelStates() {
 
 void DrawListSizes() {
     constexpr auto GetListSize = [](auto begin, auto end) {
-        uint32 n{};
-        for (auto it = begin->GetNext(); it != end; it = it->GetNext())
-            n++;
+        uint32 n = 0;
+        if (begin && end) {
+            for (auto it = begin->GetNext(); it != end; it = it->GetNext()) {
+                n++;
+            }
+        }
         return n;
     };
     Text("Req. list size: %u", GetListSize(CStreaming::ms_pStartRequestedList, CStreaming::ms_pEndRequestedList));


### PR DESCRIPTION
Small fix for a restart crash.
When running the game after opening up the streaming debug menu, ImGui restores the window visible.
This causes DrawListSizes to run and crash the game due to begin/end inside of GetListSize being null.