### PR TITLE
Fix Build MSVC > `14.44.X` (VS `17.14.X`)

### DIFF
--- a/source/game_sa/Core/Vector.h
+++ b/source/game_sa/Core/Vector.h
@@ -176,11 +176,11 @@ public:
     * @notsa
     * @return Make all component's values absolute (positive).
     */
-    static friend CVector abs(CVector vec) {
+    constexpr friend CVector abs(CVector vec) {
         return { std::abs(vec.x), std::abs(vec.y), std::abs(vec.z) };
     }
 
-    static friend CVector pow(CVector vec, float power) {
+    constexpr friend CVector pow(CVector vec, float power) {
         return { std::pow(vec.x, power), std::pow(vec.y, power), std::pow(vec.z, power) };
     }
     

--- a/source/game_sa/Core/Vector2D.h
+++ b/source/game_sa/Core/Vector2D.h
@@ -185,11 +185,11 @@ public:
     * @notsa
     * @return Make all component's values absolute (positive).
     */
-    static friend CVector2D abs(CVector2D v2) {
+    constexpr friend CVector2D abs(CVector2D v2) {
         return { std::abs(v2.x), std::abs(v2.y) };
     }
 
-    static friend CVector2D pow(CVector2D vec, float power) { // todo/note: maybe use operator^?
+    constexpr friend CVector2D pow(CVector2D vec, float power) { // todo/note: maybe use operator^?
         return { std::pow(vec.x, power), std::pow(vec.y, power) };
     }
 


### PR DESCRIPTION
MSVC `14.44.35207` (VS `17.14.2`) moment:
```shell
..\source\game_sa\Core\Vector2D.h(188,29): error C2216: "friend" cannot be used with "static"
..\source\game_sa\Core\Vector2D.h(192,29): error C2216: "friend" cannot be used with "static"
..\source\game_sa\Core\Vector.h(179,27): error C2216: "friend" cannot be used with "static"
..\source\game_sa\Core\Vector.h(183,27): error C2216: "friend" cannot be used with "static"
```
What exactly to fix it to I don't know, I think `constexpr` will do.