### PR TITLE
Fix `CVector::DotProduct` address, and unhook `CVector2D`/`CMatrix`/`CQuaternion` for better performance

### DIFF
--- a/source/InjectHooksMain.cpp
+++ b/source/InjectHooksMain.cpp
@@ -623,9 +623,14 @@ void InjectHooksMain() {
     CKeyboardState::InjectHooks();
     CMouseControllerState::InjectHooks();
     CRect::InjectHooks();
-    CVector2D::InjectHooks();
-    CQuaternion::InjectHooks();
-    CMatrix::InjectHooks();
+
+    /******* Don't hook these, performance is bad ********
+    /* CVector::InjectHooks();
+    /* CVector2D::InjectHooks();
+    /* CQuaternion::InjectHooks();
+    /* CMatrix::InjectHooks();
+    /****************************************************/
+
     CMatrixLink::InjectHooks();
     CMatrixLinkList::InjectHooks();
     CEntryInfoNode::InjectHooks();

--- a/source/game_sa/Core/Vector.cpp
+++ b/source/game_sa/Core/Vector.cpp
@@ -25,7 +25,7 @@ void CVector::InjectHooks()
     RH_ScopedInstall(FromMultiply, 0x59C670);
     RH_ScopedInstall(FromMultiply3x3, 0x59C6D0);
     RH_ScopedGlobalOverloadedInstall(CrossProduct, "out", 0x59C730, CVector*(*)(CVector*, CVector*, CVector*));
-    RH_ScopedGlobalOverloadedInstall(DotProduct, "v3d*v3d*", 0x59C6D0, float(*)(CVector*, CVector*));
+    RH_ScopedGlobalOverloadedInstall(DotProduct, "v3d*v3d*", 0x40FDB0, float(*)(CVector*, CVector*));
 }
 
 /*!


### PR DESCRIPTION
Fixes #1100 - Turns out `CVector` stuff was never hooked - I did try hooking it, the FPS was terrible with it