### PR TITLE
Fix types and color in `CColourSet` and `CTimeCycle`

### DIFF
--- a/source/app/app_game.cpp
+++ b/source/app/app_game.cpp
@@ -313,7 +313,6 @@ void Idle(void* param) {
         return;
     }
 
-    auto& cc = CTimeCycle::m_CurrentColours;
     if (FrontEndMenuManager.m_bMenuActive || TheCamera.GetScreenFadeStatus() == eNameState::NAME_FADE_IN) {
         CDraw::CalculateAspectRatio();
         CameraSize(Scene.m_pRwCamera, nullptr, SCREEN_VIEW_WINDOW, SCREEN_ASPECT_RATIO);
@@ -341,19 +340,23 @@ void Idle(void* param) {
 
         bool started;
         if (CWeather::LightningFlash) {
-            cc.m_nSkyBottomRed = 255;
-            cc.m_nSkyBottomGreen = 255;
-            cc.m_nSkyBottomBlue = 255;
+            CTimeCycle::SetFogRed(255);
+            CTimeCycle::SetFogGreen(255);
+            CTimeCycle::SetFogBlue(255);
             started = DoRWStuffStartOfFrame_Horizon(255, 255, 255, 255, 255, 255, 255);
         } else {
-            started = DoRWStuffStartOfFrame_Horizon(cc.m_nSkyTopRed, cc.m_nSkyTopGreen, cc.m_nSkyTopBlue, cc.m_nSkyBottomRed, cc.m_nSkyBottomGreen, cc.m_nSkyBottomBlue, 255);
+            started = DoRWStuffStartOfFrame_Horizon(
+                CTimeCycle::GetSkyTopRed(), CTimeCycle::GetSkyTopGreen(), CTimeCycle::GetSkyTopBlue(),
+                CTimeCycle::GetSkyBottomRed(), CTimeCycle::GetSkyBottomGreen(), CTimeCycle::GetSkyBottomBlue(),
+                255
+            );
         }
         if (!started)
             return;
 
         DefinedState();
-        RwCameraSetFarClipPlane(Scene.m_pRwCamera, cc.m_fFarClip);
-        Scene.m_pRwCamera->fogPlane = cc.m_fFogStart;
+        RwCameraSetFarClipPlane(Scene.m_pRwCamera, CTimeCycle::GetFarClip());
+        Scene.m_pRwCamera->fogPlane = CTimeCycle::GetFogStart();
         CMirrors::RenderMirrorBuffer();
         RenderScene();
         CVisibilityPlugins::RenderWeaponPedsForPC();

--- a/source/game_sa/Cam.cpp
+++ b/source/game_sa/Cam.cpp
@@ -999,22 +999,23 @@ bool CCam::Process_WheelCam(const CVector&, float, float, float) {
     return false;
 }
 
+// based on 0x51847C - 0x5184EC
 void CCam::ApplyUnderwaterMotionBlur() {
     static constexpr uint32 UNDERWATER_CAM_BLUR      = 20;    // 0x8CC7A4
     static constexpr float  UNDERWATER_CAM_MAG_LIMIT = 10.0f; // 0x8CC7A8
 
     const auto colorMag = std::sqrt(
-        sq(CTimeCycle::m_CurrentColours.m_fWaterRed) +
-        sq(CTimeCycle::m_CurrentColours.m_fWaterGreen) +
-        sq(CTimeCycle::m_CurrentColours.m_fWaterBlue)
+        sq(CTimeCycle::GetWaterRed()) +
+        sq(CTimeCycle::GetWaterGreen()) +
+        sq(CTimeCycle::GetWaterBlue())
     );
 
     const auto factor = (colorMag <= UNDERWATER_CAM_MAG_LIMIT) ? 1.0f : UNDERWATER_CAM_MAG_LIMIT / colorMag;
 
     TheCamera.SetMotionBlur(
-        static_cast<uint32>(factor * CTimeCycle::m_CurrentColours.m_fWaterRed),
-        static_cast<uint32>(factor * CTimeCycle::m_CurrentColours.m_fWaterGreen),
-        static_cast<uint32>(factor * CTimeCycle::m_CurrentColours.m_fWaterBlue),
+        static_cast<uint32>(factor * CTimeCycle::GetWaterRed()),
+        static_cast<uint32>(factor * CTimeCycle::GetWaterGreen()),
+        static_cast<uint32>(factor * CTimeCycle::GetWaterBlue()),
         UNDERWATER_CAM_BLUR,
         eMotionBlurType::LIGHT_SCENE
     );

--- a/source/game_sa/Collision/ColourSet.cpp
+++ b/source/game_sa/Collision/ColourSet.cpp
@@ -12,13 +12,13 @@ void CColourSet::InjectHooks() {
 
 // 0x55F4B0
 CColourSet::CColourSet(int32 timeId, int32 weatherId) {
-    m_fAmbientRed               = (float)CTimeCycle::m_nAmbientRed[timeId][weatherId];
-    m_fAmbientGreen             = (float)CTimeCycle::m_nAmbientGreen[timeId][weatherId];
-    m_fAmbientBlue              = (float)CTimeCycle::m_nAmbientBlue[timeId][weatherId];
+    m_fAmbientRed               = CTimeCycle::m_nAmbientRed[timeId][weatherId];
+    m_fAmbientGreen             = CTimeCycle::m_nAmbientGreen[timeId][weatherId];
+    m_fAmbientBlue              = CTimeCycle::m_nAmbientBlue[timeId][weatherId];
 
-    m_fAmbientRed_Obj           = (float)CTimeCycle::m_nAmbientRed_Obj[timeId][weatherId];
-    m_fAmbientGreen_Obj         = (float)CTimeCycle::m_nAmbientGreen_Obj[timeId][weatherId];
-    m_fAmbientBlue_Obj          = (float)CTimeCycle::m_nAmbientBlue_Obj[timeId][weatherId];
+    m_fAmbientRed_Obj           = CTimeCycle::m_nAmbientRed_Obj[timeId][weatherId];
+    m_fAmbientGreen_Obj         = CTimeCycle::m_nAmbientGreen_Obj[timeId][weatherId];
+    m_fAmbientBlue_Obj          = CTimeCycle::m_nAmbientBlue_Obj[timeId][weatherId];
 
     m_nSkyTopRed                = CTimeCycle::m_nSkyTopRed[timeId][weatherId];
     m_nSkyTopGreen              = CTimeCycle::m_nSkyTopGreen[timeId][weatherId];
@@ -36,18 +36,18 @@ CColourSet::CColourSet(int32 timeId, int32 weatherId) {
     m_nSunCoronaGreen           = CTimeCycle::m_nSunCoronaGreen[timeId][weatherId];
     m_nSunCoronaBlue            = CTimeCycle::m_nSunCoronaBlue[timeId][weatherId];
 
-    m_fSunSize                  = (float)CTimeCycle::m_fSunSize[timeId][weatherId];
-    m_fSpriteSize               = (float)CTimeCycle::m_fSpriteSize[timeId][weatherId];
+    m_fSunSize                  = CTimeCycle::m_fSunSize[timeId][weatherId];
+    m_fSpriteSize               = CTimeCycle::m_fSpriteSize[timeId][weatherId];
+    m_fSpriteBrightness         = CTimeCycle::m_fSpriteBrightness[timeId][weatherId];
 
-    m_fSpriteBrightness         = (float)CTimeCycle::m_fSpriteBrightness[timeId][weatherId];
     m_nShadowStrength           = CTimeCycle::m_nShadowStrength[timeId][weatherId];
-    m_nLightShadowStrength      = CTimeCycle::m_nPoleShadowStrength[timeId][weatherId];
+    m_nLightShadowStrength      = CTimeCycle::m_nLightShadowStrength[timeId][weatherId];
     m_nPoleShadowStrength       = CTimeCycle::m_nPoleShadowStrength[timeId][weatherId];
 
-    m_fFarClip                  = (float)CTimeCycle::m_fFarClip[timeId][weatherId];
-    m_fFogStart                 = (float)CTimeCycle::m_fFogStart[timeId][weatherId];
+    m_fFarClip                  = CTimeCycle::m_fFarClip[timeId][weatherId];
+    m_fFogStart                 = CTimeCycle::m_fFogStart[timeId][weatherId];
+    m_fLightsOnGroundBrightness = CTimeCycle::m_fLightsOnGroundBrightness[timeId][weatherId];
 
-    m_fLightsOnGroundBrightness = (float)CTimeCycle::m_fLightsOnGroundBrightness[timeId][weatherId];
     m_nLowCloudsRed             = CTimeCycle::m_nLowCloudsRed[timeId][weatherId];
     m_nLowCloudsGreen           = CTimeCycle::m_nLowCloudsGreen[timeId][weatherId];
     m_nLowCloudsBlue            = CTimeCycle::m_nLowCloudsBlue[timeId][weatherId];
@@ -56,107 +56,102 @@ CColourSet::CColourSet(int32 timeId, int32 weatherId) {
     m_nFluffyCloudsBottomGreen  = CTimeCycle::m_nFluffyCloudsBottomGreen[timeId][weatherId];
     m_nFluffyCloudsBottomBlue   = CTimeCycle::m_nFluffyCloudsBottomBlue[timeId][weatherId];
 
-    m_fWaterRed                 = (float)CTimeCycle::m_fWaterRed[timeId][weatherId];
-    m_fWaterGreen               = (float)CTimeCycle::m_fWaterGreen[timeId][weatherId];
-    m_fWaterBlue                = (float)CTimeCycle::m_fWaterBlue[timeId][weatherId];
-    m_fWaterAlpha               = (float)CTimeCycle::m_fWaterAlpha[timeId][weatherId];
+    m_fWaterRed                 = CTimeCycle::m_fWaterRed[timeId][weatherId];
+    m_fWaterGreen               = CTimeCycle::m_fWaterGreen[timeId][weatherId];
+    m_fWaterBlue                = CTimeCycle::m_fWaterBlue[timeId][weatherId];
+    m_fWaterAlpha               = CTimeCycle::m_fWaterAlpha[timeId][weatherId];
 
-    m_fPostFx1Red               = (float)CTimeCycle::m_fPostFx1Red[timeId][weatherId];
-    m_fPostFx1Green             = (float)CTimeCycle::m_fPostFx1Green[timeId][weatherId];
-    m_fPostFx1Blue              = (float)CTimeCycle::m_fPostFx1Blue[timeId][weatherId];
-    m_fPostFx1Alpha             = (float)CTimeCycle::m_fPostFx1Alpha[timeId][weatherId];
+    m_fPostFx1Red               = CTimeCycle::m_fPostFx1Red[timeId][weatherId];
+    m_fPostFx1Green             = CTimeCycle::m_fPostFx1Green[timeId][weatherId];
+    m_fPostFx1Blue              = CTimeCycle::m_fPostFx1Blue[timeId][weatherId];
+    m_fPostFx1Alpha             = CTimeCycle::m_fPostFx1Alpha[timeId][weatherId];
 
-    m_fPostFx2Red               = (float)CTimeCycle::m_fPostFx2Red[timeId][weatherId];
-    m_fPostFx2Green             = (float)CTimeCycle::m_fPostFx2Green[timeId][weatherId];
-    m_fPostFx2Blue              = (float)CTimeCycle::m_fPostFx2Blue[timeId][weatherId];
-    m_fPostFx2Alpha             = (float)CTimeCycle::m_fPostFx2Alpha[timeId][weatherId];
+    m_fPostFx2Red               = CTimeCycle::m_fPostFx2Red[timeId][weatherId];
+    m_fPostFx2Green             = CTimeCycle::m_fPostFx2Green[timeId][weatherId];
+    m_fPostFx2Blue              = CTimeCycle::m_fPostFx2Blue[timeId][weatherId];
+    m_fPostFx2Alpha             = CTimeCycle::m_fPostFx2Alpha[timeId][weatherId];
 
-    m_fCloudAlpha               = (float)CTimeCycle::m_fCloudAlpha[timeId][weatherId];
+    m_fCloudAlpha               = CTimeCycle::m_fCloudAlpha[timeId][weatherId];
     m_nHighLightMinIntensity    = CTimeCycle::m_nHighLightMinIntensity[timeId][weatherId];
     m_nWaterFogAlpha            = CTimeCycle::m_nWaterFogAlpha[timeId][weatherId];
     m_fLodDistMult              = 1.0f;
-    m_fIllumination             = (float)CTimeCycle::m_nDirectionalMult[timeId][weatherId] / 100.0f;
-
-    // Originally not initialized
-    m_fAmbientBeforeBrightnessRed = 0.0f;
-    m_fAmbientBeforeBrightnessGreen = 0.0f;
-    m_fAmbientBeforeBrightnessBlue  = 0.0f;
+    m_fIllumination             = CTimeCycle::m_nDirectionalMult[timeId][weatherId] / 100.0f;
 }
 
 /*!
  * @brief Interpolates colour sets
- * @param a First Color Set
- * @param b Second Color Set
- * @param fa First Factor
- * @param fb Second Factor
- * @param bIgnoreSky
+ * @param A First Color Set
+ * @param B Second Color Set
+ * @param multA First Factor
+ * @param multB Second Factor
+ * @param ignoreSky
  * @addr 0x55F870
  */
-void CColourSet::Interpolate(CColourSet* a, CColourSet* b, float fa, float fb, bool bIgnoreSky) {
-    if (!bIgnoreSky) {
-        m_nSkyTopRed   = (uint16)((float)a->m_nSkyTopRed   * fa + (float)b->m_nSkyTopRed   * fb);
-        m_nSkyTopGreen = (uint16)((float)a->m_nSkyTopGreen * fa + (float)b->m_nSkyTopGreen * fb);
-        m_nSkyTopBlue  = (uint16)((float)a->m_nSkyTopBlue  * fa + (float)b->m_nSkyTopBlue  * fb);
+void CColourSet::Interpolate(CColourSet* A, CColourSet* B, float multA, float multB, bool ignoreSky) {
+    if (!ignoreSky) {
+        m_nSkyTopRed   = (uint16)(A->m_nSkyTopRed   * multA + B->m_nSkyTopRed   * multB);
+        m_nSkyTopGreen = (uint16)(A->m_nSkyTopGreen * multA + B->m_nSkyTopGreen * multB);
+        m_nSkyTopBlue  = (uint16)(A->m_nSkyTopBlue  * multA + B->m_nSkyTopBlue  * multB);
 
-        m_nSkyBottomRed   = (uint16)((float)a->m_nSkyBottomRed   * fa + (float)b->m_nSkyBottomRed   * fb);
-        m_nSkyBottomGreen = (uint16)((float)a->m_nSkyBottomGreen * fa + (float)b->m_nSkyBottomGreen * fb);
-        m_nSkyBottomBlue  = (uint16)((float)a->m_nSkyBottomBlue  * fa + (float)b->m_nSkyBottomBlue  * fb);
+        m_nSkyBottomRed   = (uint16)(A->m_nSkyBottomRed   * multA + B->m_nSkyBottomRed   * multB);
+        m_nSkyBottomGreen = (uint16)(A->m_nSkyBottomGreen * multA + B->m_nSkyBottomGreen * multB);
+        m_nSkyBottomBlue  = (uint16)(A->m_nSkyBottomBlue  * multA + B->m_nSkyBottomBlue  * multB);
 
-        m_nSunCoreRed   = (uint16)((float)a->m_nSunCoreRed   * fa + (float)b->m_nSunCoreRed   * fb);
-        m_nSunCoreGreen = (uint16)((float)a->m_nSunCoreGreen * fa + (float)b->m_nSunCoreGreen * fb);
-        m_nSunCoreBlue  = (uint16)((float)a->m_nSunCoreBlue  * fa + (float)b->m_nSunCoreBlue  * fb);
+        m_nSunCoreRed   = (uint16)(A->m_nSunCoreRed   * multA + B->m_nSunCoreRed   * multB);
+        m_nSunCoreGreen = (uint16)(A->m_nSunCoreGreen * multA + B->m_nSunCoreGreen * multB);
+        m_nSunCoreBlue  = (uint16)(A->m_nSunCoreBlue  * multA + B->m_nSunCoreBlue  * multB);
 
-        m_nSunCoronaRed   = (uint16)((float)a->m_nSunCoronaRed   * fa + (float)b->m_nSunCoronaRed   * fb);
-        m_nSunCoronaGreen = (uint16)((float)a->m_nSunCoronaGreen * fa + (float)b->m_nSunCoronaGreen * fb);
-        m_nSunCoronaBlue  = (uint16)((float)a->m_nSunCoronaBlue  * fa + (float)b->m_nSunCoronaBlue  * fb);
+        m_nSunCoronaRed   = (uint16)(A->m_nSunCoronaRed   * multA + B->m_nSunCoronaRed   * multB);
+        m_nSunCoronaGreen = (uint16)(A->m_nSunCoronaGreen * multA + B->m_nSunCoronaGreen * multB);
+        m_nSunCoronaBlue  = (uint16)(A->m_nSunCoronaBlue  * multA + B->m_nSunCoronaBlue  * multB);
 
-        m_fSunSize = fa * a->m_fSunSize + fb * b->m_fSunSize;
+        m_fSunSize = multA * A->m_fSunSize + multB * B->m_fSunSize;
 
-        m_nLowCloudsRed   = (uint16)((float)a->m_nLowCloudsRed   * fa + (float)b->m_nLowCloudsRed   * fb);
-        m_nLowCloudsGreen = (uint16)((float)a->m_nLowCloudsGreen * fa + (float)b->m_nLowCloudsGreen * fb);
-        m_nLowCloudsBlue  = (uint16)((float)a->m_nLowCloudsBlue  * fa + (float)b->m_nLowCloudsBlue  * fb);
+        m_nLowCloudsRed   = (uint16)(A->m_nLowCloudsRed   * multA + B->m_nLowCloudsRed   * multB);
+        m_nLowCloudsGreen = (uint16)(A->m_nLowCloudsGreen * multA + B->m_nLowCloudsGreen * multB);
+        m_nLowCloudsBlue  = (uint16)(A->m_nLowCloudsBlue  * multA + B->m_nLowCloudsBlue  * multB);
 
-        m_nFluffyCloudsBottomRed   = (uint16)((float)a->m_nFluffyCloudsBottomRed   * fa + (float)b->m_nFluffyCloudsBottomRed   * fb);
-        m_nFluffyCloudsBottomGreen = (uint16)((float)a->m_nFluffyCloudsBottomGreen * fa + (float)b->m_nFluffyCloudsBottomGreen * fb);
-        m_nFluffyCloudsBottomBlue  = (uint16)((float)a->m_nFluffyCloudsBottomBlue  * fa + (float)b->m_nFluffyCloudsBottomBlue  * fb);
+        m_nFluffyCloudsBottomRed   = (uint16)(A->m_nFluffyCloudsBottomRed   * multA + B->m_nFluffyCloudsBottomRed   * multB);
+        m_nFluffyCloudsBottomGreen = (uint16)(A->m_nFluffyCloudsBottomGreen * multA + B->m_nFluffyCloudsBottomGreen * multB);
+        m_nFluffyCloudsBottomBlue  = (uint16)(A->m_nFluffyCloudsBottomBlue  * multA + B->m_nFluffyCloudsBottomBlue  * multB);
     }
-    m_fAmbientRed   = fa * a->m_fAmbientRed   + fb * b->m_fAmbientRed;
-    m_fAmbientGreen = fa * a->m_fAmbientGreen + fb * b->m_fAmbientGreen;
-    m_fAmbientBlue  = fa * a->m_fAmbientBlue  + fb * b->m_fAmbientBlue;
+    m_fAmbientRed   = multA * A->m_fAmbientRed   + multB * B->m_fAmbientRed;
+    m_fAmbientGreen = multA * A->m_fAmbientGreen + multB * B->m_fAmbientGreen;
+    m_fAmbientBlue  = multA * A->m_fAmbientBlue  + multB * B->m_fAmbientBlue;
 
-    m_fAmbientRed_Obj   = fa * a->m_fAmbientRed_Obj   + fb * b->m_fAmbientRed_Obj;
-    m_fAmbientGreen_Obj = fa * a->m_fAmbientGreen_Obj + fb * b->m_fAmbientGreen_Obj;
-    m_fAmbientBlue_Obj  = fa * a->m_fAmbientBlue_Obj  + fb * b->m_fAmbientBlue_Obj;
+    m_fAmbientRed_Obj   = multA * A->m_fAmbientRed_Obj   + multB * B->m_fAmbientRed_Obj;
+    m_fAmbientGreen_Obj = multA * A->m_fAmbientGreen_Obj + multB * B->m_fAmbientGreen_Obj;
+    m_fAmbientBlue_Obj  = multA * A->m_fAmbientBlue_Obj  + multB * B->m_fAmbientBlue_Obj;
 
-    m_fSpriteSize       = fa * a->m_fSpriteSize       + fb * b->m_fSpriteSize;
-    m_fSpriteBrightness = fa * a->m_fSpriteBrightness + fb * b->m_fSpriteBrightness;
+    m_fSpriteSize       = multA * A->m_fSpriteSize       + multB * B->m_fSpriteSize;
+    m_fSpriteBrightness = multA * A->m_fSpriteBrightness + multB * B->m_fSpriteBrightness;
 
-    m_nShadowStrength      = (uint16)((float)(int16)a->m_nShadowStrength      * fa + (float)(int16)b->m_nShadowStrength      * fb);
-    m_nLightShadowStrength = (uint16)((float)(int16)a->m_nLightShadowStrength * fa + (float)(int16)b->m_nLightShadowStrength * fb);
-    m_nPoleShadowStrength  = (uint16)((float)(int16)a->m_nPoleShadowStrength  * fa + (float)(int16)b->m_nPoleShadowStrength  * fb);
+    m_nShadowStrength      = (int16)(A->m_nShadowStrength      * multA + B->m_nShadowStrength      * multB);
+    m_nLightShadowStrength = (int16)(A->m_nLightShadowStrength * multA + B->m_nLightShadowStrength * multB);
+    m_nPoleShadowStrength  = (int16)(A->m_nPoleShadowStrength  * multA + B->m_nPoleShadowStrength  * multB);
 
-    m_fFarClip  = fa * a->m_fFarClip  + fb * b->m_fFarClip;
-    m_fFogStart = fa * a->m_fFogStart + fb * b->m_fFogStart;
+    m_fFarClip  = multA * A->m_fFarClip  + multB * B->m_fFarClip;
+    m_fFogStart = multA * A->m_fFogStart + multB * B->m_fFogStart;
 
-    m_fPostFx1Red   = fa * a->m_fPostFx1Red   + fb * b->m_fPostFx1Red;
-    m_fPostFx1Green = fa * a->m_fPostFx1Green + fb * b->m_fPostFx1Green;
-    m_fPostFx1Blue  = fa * a->m_fPostFx1Blue  + fb * b->m_fPostFx1Blue;
-    m_fPostFx1Alpha = fa * a->m_fPostFx1Alpha + fb * b->m_fPostFx1Alpha;
+    m_fPostFx1Red   = multA * A->m_fPostFx1Red   + multB * B->m_fPostFx1Red;
+    m_fPostFx1Green = multA * A->m_fPostFx1Green + multB * B->m_fPostFx1Green;
+    m_fPostFx1Blue  = multA * A->m_fPostFx1Blue  + multB * B->m_fPostFx1Blue;
+    m_fPostFx1Alpha = multA * A->m_fPostFx1Alpha + multB * B->m_fPostFx1Alpha;
 
-    m_fPostFx2Red   = fa * a->m_fPostFx2Red   + fb * b->m_fPostFx2Red;
-    m_fPostFx2Green = fa * a->m_fPostFx2Green + fb * b->m_fPostFx2Green;
-    m_fPostFx2Blue  = fa * a->m_fPostFx2Blue  + fb * b->m_fPostFx2Blue;
-    m_fPostFx2Alpha = fa * a->m_fPostFx2Alpha + fb * b->m_fPostFx2Alpha;
+    m_fPostFx2Red   = multA * A->m_fPostFx2Red   + multB * B->m_fPostFx2Red;
+    m_fPostFx2Green = multA * A->m_fPostFx2Green + multB * B->m_fPostFx2Green;
+    m_fPostFx2Blue  = multA * A->m_fPostFx2Blue  + multB * B->m_fPostFx2Blue;
+    m_fPostFx2Alpha = multA * A->m_fPostFx2Alpha + multB * B->m_fPostFx2Alpha;
 
-    m_fLightsOnGroundBrightness = fa * a->m_fLightsOnGroundBrightness + fb * b->m_fLightsOnGroundBrightness;
-    m_fCloudAlpha = fa * a->m_fCloudAlpha + fb * b->m_fCloudAlpha;
-    m_nHighLightMinIntensity = (uint16)((float)a->m_nHighLightMinIntensity * fa + (float)b->m_nHighLightMinIntensity * fb);
-    m_nWaterFogAlpha = (uint16)((float)a->m_nWaterFogAlpha * fa + (float)b->m_nWaterFogAlpha * fb);
-    m_fIllumination = fa * a->m_fIllumination + fb * b->m_fIllumination;
-    m_fLodDistMult = fa * a->m_fLodDistMult + fb * b->m_fLodDistMult;
+    m_fLightsOnGroundBrightness = multA * A->m_fLightsOnGroundBrightness + multB * B->m_fLightsOnGroundBrightness;
+    m_fCloudAlpha = multA * A->m_fCloudAlpha + multB * B->m_fCloudAlpha;
+    m_nHighLightMinIntensity = (uint16)(A->m_nHighLightMinIntensity * multA + B->m_nHighLightMinIntensity * multB);
+    m_nWaterFogAlpha = (uint16)(A->m_nWaterFogAlpha * multA + B->m_nWaterFogAlpha * multB);
+    m_fIllumination = multA * A->m_fIllumination + multB * B->m_fIllumination;
+    m_fLodDistMult = multA * A->m_fLodDistMult + multB * B->m_fLodDistMult;
 
-    m_fWaterRed   = fa * a->m_fWaterRed   + fb * b->m_fWaterRed;
-    m_fWaterGreen = fa * a->m_fWaterGreen + fb * b->m_fWaterGreen;
-    m_fWaterBlue  = fa * a->m_fWaterBlue  + fb * b->m_fWaterBlue;
-    m_fWaterAlpha = fa * a->m_fWaterAlpha + fb * b->m_fWaterAlpha;
+    m_fWaterRed   = multA * A->m_fWaterRed   + multB * B->m_fWaterRed;
+    m_fWaterGreen = multA * A->m_fWaterGreen + multB * B->m_fWaterGreen;
+    m_fWaterBlue  = multA * A->m_fWaterBlue  + multB * B->m_fWaterBlue;
+    m_fWaterAlpha = multA * A->m_fWaterAlpha + multB * B->m_fWaterAlpha;
 }

--- a/source/game_sa/Collision/ColourSet.h
+++ b/source/game_sa/Collision/ColourSet.h
@@ -18,9 +18,10 @@ public:
     float  m_fAmbientGreen_Obj;
     float  m_fAmbientBlue_Obj;
 
-    float m_fAmbientBeforeBrightnessRed; // m_fDirectional
-    float m_fAmbientBeforeBrightnessGreen;
-    float m_fAmbientBeforeBrightnessBlue;
+    float  m_fAmbientBeforeBrightnessRed; // m_fDirectional
+    float  m_fAmbientBeforeBrightnessGreen;
+    float  m_fAmbientBeforeBrightnessBlue;
+
 
     uint16 m_nSkyTopRed;
     uint16 m_nSkyTopGreen;
@@ -47,6 +48,7 @@ public:
 
     float  m_fFarClip;
     float  m_fFogStart;
+
     float  m_fLightsOnGroundBrightness;
 
     uint16 m_nLowCloudsRed;
@@ -73,7 +75,7 @@ public:
     float  m_fPostFx2Alpha;
 
     float  m_fCloudAlpha;
-    int32 m_nHighLightMinIntensity;
+    int32  m_nHighLightMinIntensity;
     uint16 m_nWaterFogAlpha;
 
     float  m_fIllumination;
@@ -88,8 +90,10 @@ public:
 
     CColourSet() = default;
     CColourSet(int32 timeId, int32 weatherId);
-    void Interpolate(CColourSet* a, CColourSet* b, float fa, float fb, bool bIgnoreSky);
 
+    void Interpolate(CColourSet* A, CColourSet* B, float multA, float multB, bool ignoreSky);
+
+public: // NOTSA
     // helpers
     [[nodiscard]] CRGBA GetSkyBottom(uint8 alpha = 255) const {
         return {

--- a/source/game_sa/Collision/ColourSet.h
+++ b/source/game_sa/Collision/ColourSet.h
@@ -41,9 +41,10 @@ public:
     float  m_fSunSize;
     float  m_fSpriteSize;
     float  m_fSpriteBrightness;
-    uint16 m_nShadowStrength;
-    uint16 m_nLightShadowStrength;
-    uint16 m_nPoleShadowStrength;
+    int16  m_nShadowStrength;
+    int16  m_nLightShadowStrength;
+    int16  m_nPoleShadowStrength;
+
     float  m_fFarClip;
     float  m_fFogStart;
     float  m_fLightsOnGroundBrightness;
@@ -74,6 +75,7 @@ public:
     float  m_fCloudAlpha;
     int32 m_nHighLightMinIntensity;
     uint16 m_nWaterFogAlpha;
+
     float  m_fIllumination;
     float  m_fLodDistMult;
 

--- a/source/game_sa/Entity/Ped/Ped.cpp
+++ b/source/game_sa/Entity/Ped/Ped.cpp
@@ -2801,7 +2801,7 @@ void CPed::PreRenderAfterTest()
         }
     }
 
-    if (m_bIsVisible && CTimeCycle::m_CurrentColours.m_nShadowStrength != 0) {
+    if (m_bIsVisible && CTimeCycle::GetShadowStrength()) {
         const auto [shadowNeeded, activeTask] = [&]() -> std::pair<bool, CTask*> {
             if (!bInVehicle) {
                 return std::make_pair(false, intel->m_TaskMgr.FindActiveTaskByType(TASK_COMPLEX_ENTER_ANY_CAR_AS_DRIVER));

--- a/source/game_sa/Game.cpp
+++ b/source/game_sa/Game.cpp
@@ -565,7 +565,7 @@ bool CGame::InitialiseCoreDataAfterRW() {
 
     g_surfaceInfos.Init();
     CPedStats::Initialise();
-    CTimeCycle::Initialise();
+    CTimeCycle::Initialise(false);
     CPopCycle::Initialise();
     CVehicleRecording::InitAtStartOfGame();
 
@@ -864,7 +864,7 @@ void CGame::ReInitGameObjectVariables() {
     CRadar::Initialise();
     CCarCtrl::ReInit();
     ThePaths.ReInit();
-    CTimeCycle::Initialise();
+    CTimeCycle::Initialise(false);
     CPopCycle::Initialise();
     CDraw::SetFOV(120.0f);
     CDraw::ms_fLODDistance = 500.0f;

--- a/source/game_sa/PostEffects.cpp
+++ b/source/game_sa/PostEffects.cpp
@@ -1025,7 +1025,7 @@ void CPostEffects::Render() {
             );
         } else {
             Radiosity(
-                CTimeCycle::m_CurrentColours.m_nHighLightMinIntensity,
+                CTimeCycle::GetHighLightMinIntensity(),
                 m_RadiosityFilterPasses,
                 m_RadiosityRenderPasses,
                 m_RadiosityIntensity

--- a/source/game_sa/Shadows.cpp
+++ b/source/game_sa/Shadows.cpp
@@ -1206,7 +1206,7 @@ void CShadows::StoreShadowForPole(CEntity* entity, float offsetX, float offsetY,
         return;
     }
 
-    const auto intensity = 2.f * (mat.GetUp().z - 0.5f) * (float)(CTimeCycle::m_CurrentColours.m_nPoleShadowStrength);
+    const auto intensity = 2.f * (mat.GetUp().z - 0.5f) * CTimeCycle::m_CurrentColours.m_nPoleShadowStrength;
 
     const auto front     = CVector2D{ CTimeCycle::GetVectorToSun() } * (-poleHeight / 2.f);
     const auto right     = CVector2D{ CTimeCycle::GetShadowSide() } * poleWidth;

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -74,7 +74,7 @@ void CTimeCycle::Initialise() {
             }
 
             // TODO: Fix in original TIMECYC.dat line 320 (255 ... -> 22 22 22 ...)
-            sscanf(line,
+            const auto n = sscanf(line,
                 "%d %d %d " // Static ambience color
                 "%d %d %d " // Dynamic ambience color
                 "%d %d %d " // Direct light color - NOP
@@ -120,6 +120,9 @@ void CTimeCycle::Initialise() {
                 &postFx2A, &postFx2R, &postFx2G, &postFx2B,
                 &cloudAlpha, &highLightMinIntensity, &waterFogAlpha, &dirMult
             );
+            if (n != 52 && n != 51) {
+                NOTSA_LOG_WARN("Bad timecyc line: '{}'", line); // TODO: fix
+            }
 
             m_nAmbientRed[h][w]   = ambR;
             m_nAmbientGreen[h][w] = ambG;

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -10,7 +10,7 @@ void CTimeCycle::InjectHooks() {
     RH_ScopedClass(CTimeCycle);
     RH_ScopedCategoryGlobal();
 
-    RH_ScopedInstall(Initialise, 0x5BBAC0, { .reversed = false });
+    RH_ScopedInstall(Initialise, 0x5BBAC0);
     RH_ScopedInstall(InitForRestart, 0x5601F0);
     RH_ScopedInstall(Shutdown, 0x5601E0);
     RH_ScopedInstall(Update, 0x561760);
@@ -34,14 +34,12 @@ void CTimeCycle::InjectHooks() {
 
 // 0x5BBAC0
 void CTimeCycle::Initialise() {
-    return plugin::Call<0x5BBAC0>(); // looks differ
-
     CFileMgr::SetDir("DATA");
     auto file = CFileMgr::OpenFile("TIMECYC.DAT", "rb");
     CFileMgr::SetDir("");
 
     if (!file) { // NOTSA
-        NOTSA_LOG_DEBUG("[CTimeCycle] Failed to open TIMECYC.DAT");
+        NOTSA_LOG_WARN("[CTimeCycle] Failed to open TIMECYC.DAT");
         CFileMgr::CloseFile(file);
         return;
     }
@@ -59,8 +57,8 @@ void CTimeCycle::Initialise() {
     int32 lowCloudR, lowCloudG, lowCloudB;
     int32 bottomCloudR, bottomCloudG, bottomCloudB;
     float waterR, waterG, waterB, waterA;
-    float postFx1a, postFx1R, postFx1G, postFx1B;
-    float postFx2a, postFx2R, postFx2G, postFx2B;
+    float postFx1A, postFx1R, postFx1G, postFx1B;
+    float postFx2A, postFx2R, postFx2G, postFx2B;
     float cloudAlpha;
     int32 highLightMinIntensity;
     int32 waterFogAlpha;
@@ -75,26 +73,53 @@ void CTimeCycle::Initialise() {
                 }
             }
 
-            VERIFY(sscanf_s(line,
-                "%d %d %d  %d %d %d  %d %d %d  %d %d %d  %d %d %d" "%d %d %d  %d %d %d"
-                "%f %f %f %d %d %d %f %f %f"
-                "%d %d %d  %d %d %d  %f %f %f  %f %f %f  %f %f %f" "%f %f %f"
-                "%f %d %d %f",
-                &ambR,       &ambG,       &ambB,
-                &ambObjR,    &ambObjG,    &ambObjB,
-                &dirR,       &dirG,       &dirB,
-                &skyTopR,    &skyTopG,    &skyTopB,
-                &skyBotR,    &skyBotG,    &skyBotB,
-                &sunCoreR,   &sunCoreG,   &sunCoreB,
+            // TODO: Fix in original TIMECYC.dat line 320 (255 ... -> 22 22 22 ...)
+            sscanf(line,
+                "%d %d %d " // Static ambience color
+                "%d %d %d " // Dynamic ambience color
+                "%d %d %d " // Direct light color - NOP
+                "%d %d %d " // Sky top color
+                "%d %d %d " // Sky bottom color
+                "%d %d %d " // Sun core color
+                "%d %d %d " // Sun corona color
+                "%f "       // Sun core size
+                "%f "       // Sun corona size
+                "%f "       // Sprite brightness
+                "%d "       // Pole shading value
+                "%d "       // Light shading value
+                "%d "       // Pole shading value
+                "%f "       // Far clipping offset
+                "%f "       // Fog start offset
+                "%f "       // Light on ground
+                "%d %d %d " // Lower clouds color
+                "%d %d %d " // Upper clouds bottom color
+                "%f %f %f " // Water color
+                "%f "       // Water alpha level
+                "%f "       // Color correction 1 alpha
+                "%f %f %f " // Color correction 1
+                "%f "       // Color correction 2 alpha
+                "%f %f %f " // Color correction 2
+                "%f "       // Lower clouds alpha level
+                "%d "       // Highlight min intensity
+                "%d "       // Water fog alpha
+                "%f",       // Directional multiplier
+                &ambR, &ambG, &ambB,
+                &ambObjR, &ambObjG, &ambObjB,
+                &dirR, &dirG, &dirB,
+                &skyTopR, &skyTopG, &skyTopB,
+                &skyBotR, &skyBotG, &skyBotB,
+                &sunCoreR, &sunCoreG, &sunCoreB,
                 &sunCoronaR, &sunCoronaG, &sunCoronaB,
-                &sunSize, &spriteSize, &spriteBrightness, &shadowStrength, &lightShadowStrength, &poleShadowStrength, &farClip, &fogStart, &lightOnGround,
+                &sunSize, &spriteSize, &spriteBrightness,
+                &shadowStrength, &lightShadowStrength, &poleShadowStrength,
+                &farClip, &fogStart, &lightOnGround,
                 &lowCloudR, &lowCloudG, &lowCloudB,
                 &bottomCloudR, &bottomCloudG, &bottomCloudB,
                 &waterR, &waterG, &waterB, &waterA,
-                &postFx1a, &postFx1R, &postFx1G, &postFx1B,
-                &postFx2a, &postFx2R, &postFx2G, &postFx2B,
+                &postFx1A, &postFx1R, &postFx1G, &postFx1B,
+                &postFx2A, &postFx2R, &postFx2G, &postFx2B,
                 &cloudAlpha, &highLightMinIntensity, &waterFogAlpha, &dirMult
-            ) == 52);
+            );
 
             m_nAmbientRed[h][w]   = ambR;
             m_nAmbientGreen[h][w] = ambG;
@@ -103,6 +128,8 @@ void CTimeCycle::Initialise() {
             m_nAmbientRed_Obj[h][w]   = ambObjR;
             m_nAmbientGreen_Obj[h][w] = ambObjG;
             m_nAmbientBlue_Obj[h][w]  = ambObjB;
+
+            // code dir RGB?
 
             m_nSkyTopRed[h][w]   = skyTopR;
             m_nSkyTopGreen[h][w] = skyTopG;
@@ -120,14 +147,16 @@ void CTimeCycle::Initialise() {
             m_nSunCoronaGreen[h][w] = sunCoronaG;
             m_nSunCoronaBlue[h][w]  = sunCoronaB;
 
-            m_fSunSize[h][w]    = uint8(sunSize * 10.0f + 0.5f);
-            m_fSpriteSize[h][w] = uint8(spriteSize * 10.0f + 0.5f);
-            m_fSpriteBrightness[h][w]    = uint8(spriteBrightness * 10.0f + 0.5f);
+            m_fSunSize[h][w] = int8(sunSize * 10.0f + 0.5f);
+            m_fSpriteSize[h][w] = int8(spriteSize * 10.0f + 0.5f);
+            m_fSpriteBrightness[h][w] = int8(spriteBrightness * 10.0f + 0.5f);
+
             m_nShadowStrength[h][w]      = shadowStrength;
             m_nLightShadowStrength[h][w] = lightShadowStrength;
             m_nPoleShadowStrength[h][w]  = poleShadowStrength;
-            m_fFarClip[h][w]  = (uint16)farClip;
-            m_fFogStart[h][w] = (uint16)fogStart;
+
+            m_fFarClip[h][w]  = (int16)farClip;
+            m_fFogStart[h][w] = (int16)fogStart;
             m_fLightsOnGroundBrightness[h][w] = uint8(lightOnGround * 10.0f + 0.5f);
 
             m_nLowCloudsRed[h][w]   = lowCloudR;
@@ -151,13 +180,13 @@ void CTimeCycle::Initialise() {
             m_fPostFx2Green[h][w] = (uint8)postFx2G;
             m_fPostFx2Blue[h][w]  = (uint8)postFx2B;
 
-            m_fPostFx1Alpha[h][w] = (uint8)sq(postFx1a);
-            m_fPostFx2Alpha[h][w] = (uint8)sq(postFx2a);
+            m_fPostFx1Alpha[h][w] = uint8(postFx1A * 2.f);
+            m_fPostFx2Alpha[h][w] = uint8(postFx2A * 2.f);
 
             m_fCloudAlpha[h][w]            = (uint8)cloudAlpha;
             m_nHighLightMinIntensity[h][w] = (uint8)highLightMinIntensity;
             m_nWaterFogAlpha[h][w]         = (uint8)waterFogAlpha;
-            m_nDirectionalMult[h][w]       = uint8(dirMult * 100.0f);
+            m_nDirectionalMult[h][w]       = uint8((uint8)dirMult * 100.0f);
         }
     }
 
@@ -248,7 +277,7 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
     const auto hours = std::min(23.999f, CClock::GetHoursToday());
 
     // 0x560528 - Find sample index for current hour
-    int32 currSampleIdx{};
+    int32 currSampleIdx = 0;
     while (hours >= (float)(TimeSamples[currSampleIdx + 1])) {
         currSampleIdx++;
     }
@@ -329,7 +358,7 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
     }
 
     if (m_FogReduction) {
-        set->m_fFarClip = set->m_fFarClip > float(m_FogReduction) * 10.15625f ? set->m_fFarClip : float(m_FogReduction) * 10.15625f;
+        set->m_fFarClip = std::max(set->m_fFarClip, (float)m_FogReduction * 10.15625f); // 10.15625f = 1/64 * 10 + 10 ?
     }
 
     // 0x560A59
@@ -373,12 +402,12 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
             set->m_fAmbientGreen_Obj = lerp<float>(set->m_fAmbientGreen_Obj, m_nAmbientGreen_Obj[boxHour][boxWeather], boxf);
             set->m_fAmbientBlue_Obj  = lerp<float>(set->m_fAmbientBlue_Obj, m_nAmbientBlue_Obj[boxHour][boxWeather], boxf);
         }
-        if (m_fFarClip[boxHour][boxWeather] != 255) { // 0x560D08
-            if ((float)m_fFarClip[boxHour][boxWeather] < set->m_fFarClip) {
+        if (m_fFarClip[boxHour][boxWeather] != -1) { // 0x560D08
+            if (m_fFarClip[boxHour][boxWeather] < set->m_fFarClip) {
                 set->m_fFarClip = set->m_fFarClip * invboxf + (float)m_fFarClip[boxHour][boxWeather] * boxf;
             }
         }
-        if (m_fFogStart[boxHour][boxWeather] != 255) { // 0x560D3E
+        if (m_fFogStart[boxHour][boxWeather] != -1) { // 0x560D3E
             set->m_fFogStart = lerp(set->m_fFogStart, (float)m_fFogStart[boxHour][boxWeather], boxf);
         }
         if (m_fPostFx1Red[boxHour][boxWeather] != 255) { // 0x560D63
@@ -396,24 +425,19 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
     }
 
     if (lodBoxA) {
-        set->m_fLodDistMult *= (1.0f - lodBoxA_T) + (float)lodBoxA->LodDistMult / 32.0f * lodBoxA_T;
+        float newLodMult = (float)lodBoxA->LodDistMult / 32.0f; // 0.03125f = 1/32
+        set->m_fLodDistMult  = lerp(set->m_fLodDistMult, newLodMult, lodBoxA_T);
     }
 
-    if (farBoxA && (float)farBoxA->FarClip < set->m_fFarClip) {
-        set->m_fFarClip = set->m_fFarClip * (1.0f - farBoxA_T) + (float)farBoxA->FarClip * farBoxA_T;
+    if (farBoxA) {
+        set->m_fFarClip = lerp(set->m_fFarClip, std::min(set->m_fFarClip, (float)farBoxA->FarClip), farBoxA_T);
     }
-    if (farBoxB && (float)farBoxB->FarClip < set->m_fFarClip) {
-        set->m_fFarClip = set->m_fFarClip * (1.0f - farBoxB_T) + (float)farBoxB->FarClip * farBoxB_T;
+    if (farBoxB) {
+        set->m_fFarClip = lerp(set->m_fFarClip, std::min(set->m_fFarClip, (float)farBoxB->FarClip), farBoxB_T);
     }
 
     float inc = CTimer::GetTimeStep() / 120.0f;
-    if (m_bExtraColourOn) {
-        m_ExtraColourInter += inc;
-        m_ExtraColourInter = std::min(m_ExtraColourInter, 1.0f);
-    } else {
-        m_ExtraColourInter -= inc;
-        m_ExtraColourInter = std::max(m_ExtraColourInter, 0.0f);
-    }
+    m_ExtraColourInter = std::clamp(m_ExtraColourInter + (m_bExtraColourOn ? inc : -inc), 0.0f, 1.0f);
 
     if (m_ExtraColourInter > 0.0f) {
         CColourSet extra(m_ExtraColour, m_ExtraColourWeatherType);
@@ -445,45 +469,46 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
     // 0x5612AA
     CShadows::CalcPedShadowValues(
         m_VectorToSun[m_CurrentStoredValue],
-        m_fShadowFrontX[m_CurrentStoredValue], m_fShadowFrontY[m_CurrentStoredValue],
-        m_fShadowSideX[m_CurrentStoredValue],  m_fShadowSideY[m_CurrentStoredValue],
-        m_fShadowDisplacementX[m_CurrentStoredValue], m_fShadowDisplacementY[m_CurrentStoredValue]
+        m_fShadowFrontX[m_CurrentStoredValue],
+        m_fShadowFrontY[m_CurrentStoredValue],
+        m_fShadowSideX[m_CurrentStoredValue],
+        m_fShadowSideY[m_CurrentStoredValue],
+        m_fShadowDisplacementX[m_CurrentStoredValue],
+        m_fShadowDisplacementY[m_CurrentStoredValue]
     );
 
-    if (   TheCamera.m_mCameraMatrix.GetForward().z < -0.9f
-        || !CWeather::bScriptsForceRain && (CCullZones::PlayerNoRain() || CCullZones::CamNoRain() || CCutsceneMgr::ms_running)
-    ) {
+    if (TheCamera.m_mCameraMatrix.GetForward().z < -0.9f || !CWeather::bScriptsForceRain
+        && (CCullZones::PlayerNoRain() || CCullZones::CamNoRain() || CCutsceneMgr::ms_running)) {
         m_FogReduction = std::min(m_FogReduction + 1, 64);
     } else {
         m_FogReduction = std::max(m_FogReduction - 1, 0);
     }
 
     if (camPos.z > 200.0f) {
-        if (camPos.z <= 500.0f)
-        {
-            set->m_fFarClip = set->m_fFarClip * (1.0f - (camPos.z - 200.0f) / 300.0f) + 1000.0f * (camPos.z - 200.0f) / 300.0f;
-        }
-        else if (set->m_fFarClip >= 1000.0f)
-        {
-            set->m_fFarClip = 1000.0f;
+        if (set->m_fFarClip > 1000.0f) {
+            if (camPos.z <= 500.0f) {
+                float t_alt = (camPos.z - 200.0f) / 300.0f;
+                set->m_fFarClip = lerp(set->m_fFarClip, 1000.0f, t_alt);
+            } else {
+                set->m_fFarClip = 1000.0f;
+            }
         }
     }
 
-    float horizon = (float)GreyValuesDuringDay[currSampleIdx] * invTimeT + (float)GreyValuesDuringDay[nextSampleIdx] * timeT;
-    m_BelowHorizonGrey.red   = uint8((float)m_CurrentColours.m_nSkyBottomRed   * CWeather::UnderWaterness + horizon * (1.0f - CWeather::UnderWaterness));
-    m_BelowHorizonGrey.green = uint8((float)m_CurrentColours.m_nSkyBottomGreen * CWeather::UnderWaterness + horizon * (1.0f - CWeather::UnderWaterness));
-    m_BelowHorizonGrey.blue  = uint8((float)m_CurrentColours.m_nSkyBottomBlue  * CWeather::UnderWaterness + horizon * (1.0f - CWeather::UnderWaterness));
+    float horizon = lerp((float)GreyValuesDuringDay[currSampleIdx], (float)GreyValuesDuringDay[nextSampleIdx], timeT);
+    m_BelowHorizonGrey.red   = (uint8)lerp(horizon, (float)m_CurrentColours.m_nSkyBottomRed, CWeather::UnderWaterness);
+    m_BelowHorizonGrey.green = (uint8)lerp(horizon, (float)m_CurrentColours.m_nSkyBottomGreen, CWeather::UnderWaterness);
+    m_BelowHorizonGrey.blue  = (uint8)lerp(horizon, (float)m_CurrentColours.m_nSkyBottomBlue, CWeather::UnderWaterness);
 
     set->m_fAmbientBeforeBrightnessRed   = set->m_fAmbientRed;
     set->m_fAmbientBeforeBrightnessGreen = set->m_fAmbientGreen;
     set->m_fAmbientBeforeBrightnessBlue  = set->m_fAmbientBlue;
 
+    // 0x561468
     const auto brightness = (float)FrontEndMenuManager.m_PrefsBrightness;
     if (brightness >= 256.0f) {
         f = (brightness - 256.0f) / 128.0f + 1.0f;
-        float max = set->m_fAmbientRed;
-        max = std::max(max, set->m_fAmbientGreen);
-        max = std::max(max, set->m_fAmbientBlue);
+        float max = std::max({ set->m_fAmbientRed, set->m_fAmbientGreen, set->m_fAmbientBlue });
         max = max * f - max;
         set->m_fAmbientRed   += max;
         set->m_fAmbientGreen += max;
@@ -498,17 +523,16 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
     if (f > 1.0f) {
         float r, g, b;
         f = (f - 1.0f) * 0.06f;
-        float max = set->m_fAmbientRed;
-        max = std::max(max, set->m_fAmbientGreen);
-        max = std::max(max, set->m_fAmbientBlue);
+        float max = std::max({ set->m_fAmbientRed, set->m_fAmbientGreen, set->m_fAmbientBlue });
         r = set->m_fAmbientRed;
         g = set->m_fAmbientGreen;
         b = set->m_fAmbientBlue;
         if (max == 0.0f) {
+            max = 0.001f;
             set->m_fAmbientRed   = 0.001f;
             set->m_fAmbientGreen = 0.001f;
             set->m_fAmbientBlue  = 0.001f;
-        }
+         }
         if (f > max) {
             f /= max;
             set->m_fAmbientRed   *= f;

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -33,7 +33,7 @@ void CTimeCycle::InjectHooks() {
 }
 
 // 0x5BBAC0
-void CTimeCycle::Initialise() {
+void CTimeCycle::Initialise(bool padFile) {
     CFileMgr::SetDir("DATA");
     auto file = CFileMgr::OpenFile("TIMECYC.DAT", "rb");
     CFileMgr::SetDir("");
@@ -120,7 +120,7 @@ void CTimeCycle::Initialise() {
                 &postFx2A, &postFx2R, &postFx2G, &postFx2B,
                 &cloudAlpha, &highLightMinIntensity, &waterFogAlpha, &dirMult
             );
-            if (n != 52 && n != 51) {
+            if (n < 51) {
                 NOTSA_LOG_WARN("Bad timecyc line: '{}'", line);
             }
 
@@ -150,8 +150,8 @@ void CTimeCycle::Initialise() {
             m_nSunCoronaGreen[h][w] = sunCoronaG;
             m_nSunCoronaBlue[h][w]  = sunCoronaB;
 
-            m_fSunSize[h][w] = int8(sunSize * 10.0f + 0.5f);
-            m_fSpriteSize[h][w] = int8(spriteSize * 10.0f + 0.5f);
+            m_fSunSize[h][w]          = int8(sunSize * 10.0f + 0.5f);
+            m_fSpriteSize[h][w]       = int8(spriteSize * 10.0f + 0.5f);
             m_fSpriteBrightness[h][w] = int8(spriteBrightness * 10.0f + 0.5f);
 
             m_nShadowStrength[h][w]      = shadowStrength;
@@ -674,3 +674,15 @@ void CTimeCycle::SetConstantParametersForPostFX() {
         m_CurrentColours.m_nSkyBottomBlue = 128;
     }
 }
+
+float CTimeCycle::GetAmbientRed()   { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientRed; }   // 0x560330
+float CTimeCycle::GetAmbientGreen() { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientGreen; } // 0x560340
+float CTimeCycle::GetAmbientBlue()  { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBlue; }  // 0x560350
+
+float CTimeCycle::GetAmbientRed_Obj()   { return m_CurrentColours.m_fAmbientRed_Obj; }   // 0x560360
+float CTimeCycle::GetAmbientGreen_Obj() { return m_CurrentColours.m_fAmbientGreen_Obj; } // 0x560370
+float CTimeCycle::GetAmbientBlue_Obj()  { return m_CurrentColours.m_fAmbientBlue_Obj; }  // 0x560380
+
+float CTimeCycle::GetAmbientRed_BeforeBrightness()   { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessRed; }   // 0x560390
+float CTimeCycle::GetAmbientGreen_BeforeBrightness() { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessGreen; } // 0x5603A0
+float CTimeCycle::GetAmbientBlue_BeforeBrightness()  { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessBlue; }  // 0x5603B0

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -73,7 +73,6 @@ void CTimeCycle::Initialise(bool padFile) {
                 }
             }
 
-            // TODO: Fix in original TIMECYC.dat line 320 (255 ... -> 22 22 22 ...)
             const auto n = sscanf(line,
                 "%d %d %d " // Static ambience color
                 "%d %d %d " // Dynamic ambience color
@@ -121,6 +120,10 @@ void CTimeCycle::Initialise(bool padFile) {
                 &cloudAlpha, &highLightMinIntensity, &waterFogAlpha, &dirMult
             );
             if (n < 51) {
+                // TODO:
+                // R* made a mistake in line 320:
+                // instead of the first 3 RGB values, only 255 is specified,
+                // which causes the entire line to shift and be read incorrectly
                 NOTSA_LOG_WARN("Bad timecyc line: '{}'", line);
             }
 

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -532,7 +532,7 @@ void CTimeCycle::CalcColoursForPoint(CVector point, CColourSet* set) {
             set->m_fAmbientRed   = 0.001f;
             set->m_fAmbientGreen = 0.001f;
             set->m_fAmbientBlue  = 0.001f;
-         }
+        }
         if (f > max) {
             f /= max;
             set->m_fAmbientRed   *= f;

--- a/source/game_sa/TimeCycle.cpp
+++ b/source/game_sa/TimeCycle.cpp
@@ -121,7 +121,7 @@ void CTimeCycle::Initialise() {
                 &cloudAlpha, &highLightMinIntensity, &waterFogAlpha, &dirMult
             );
             if (n != 52 && n != 51) {
-                NOTSA_LOG_WARN("Bad timecyc line: '{}'", line); // TODO: fix
+                NOTSA_LOG_WARN("Bad timecyc line: '{}'", line);
             }
 
             m_nAmbientRed[h][w]   = ambR;

--- a/source/game_sa/TimeCycle.h
+++ b/source/game_sa/TimeCycle.h
@@ -142,7 +142,6 @@ public:
     static float FindFarClipForCoors(CVector cameraPos);
     static void Shutdown();
 
-
     static float GetAmbientRed();
     static float GetAmbientGreen();
     static float GetAmbientBlue();
@@ -213,22 +212,18 @@ public:
     static float GetCloudAlpha() { return m_CurrentColours.m_fCloudAlpha; }
     static int32 GetHighLightMinIntensity() { return m_CurrentColours.m_nHighLightMinIntensity; }
 
-
     static float GetLODMultiplier() { return m_CurrentColours.m_fLodDistMult; }
 
     static void SetFogRed(uint16 value)   { SetSkyBottomRed(value); }
     static void SetFogGreen(uint16 value) { SetSkyBottomGreen(value); }
     static void SetFogBlue(uint16 value)  { SetSkyBottomBlue(value); }
 
-
     static void StartExtraColour(int32 colour, bool bNoExtraColorInterior);
     static void StopExtraColour(bool bNoExtraColorInterior);
-
 
     static void AddOne(CBox& box, int16 farClip, int32 extraColor, float strength, float falloff, float lodDistMult);
     static void FindTimeCycleBox(CVector pos, CTimeCycleBox** out, float* currentBox, bool isLOD, bool isFarClip, CTimeCycleBox* alreadyFoundBox);
     static void InitForRestart();
-
 
     static void SetConstantParametersForPostFX();
 

--- a/source/game_sa/TimeCycle.h
+++ b/source/game_sa/TimeCycle.h
@@ -19,20 +19,29 @@ VALIDATE_SIZE(CTimeCycleBox, 0x28);
 
 static inline float& gfLaRiotsLightMult = *(float*)0x8CD060; // 1.0f
 
+enum eTimeType {
+    TIME_MIDNIGHT,
+    TIME_5AM,
+    TIME_6AM,
+    TIME_7AM,
+    TIME_MIDDAY,
+    TIME_7PM,
+    TIME_8PM,
+    TIME_10PM,
+
+    NUM_HOURS
+};
+
 class CTimeCycle {
 public:
-    static constexpr auto NUM_HOURS = 8;
-
-
     static inline CVector& m_vecDirnLightToSun = *(CVector*)0xB7CB14;
     static inline RwRGBA& m_BelowHorizonGrey = *(RwRGBA*)0xB7CB10;
     static inline CVector (&m_VectorToSun)[16] = *(CVector(*)[16])0xB7CA50;
 
     static inline CTimeCycleBox (&m_aBoxes)[20] = *(CTimeCycleBox(*)[20])0xB7C550;
-    static inline uint32& m_NumBoxes = *(uint32*)0xB7C480;
-
-    static inline uint32& m_bExtraColourOn = *(uint32*)0xB7C484;
     static inline CColourSet& m_CurrentColours = *(CColourSet*)0xB7C4A0;
+    static inline uint32& m_bExtraColourOn = *(uint32*)0xB7C484;
+    static inline uint32& m_NumBoxes = *(uint32*)0xB7C480;
 
     template<typename T>
     using Colors = notsa::mdarray<T, NUM_HOURS, NUM_WEATHERS>;
@@ -53,26 +62,26 @@ public:
     static inline auto& m_nSkyBottomGreen = StaticRef<Colors<uint8>>(0xB7BC98);
     static inline auto& m_nSkyBottomBlue = StaticRef<Colors<uint8>>(0xB7BBE0);
 
-    static inline auto& m_fSunSize = StaticRef<Colors<uint8>>(0xB7B6D8);
+    static inline auto& m_nSunCoreRed = StaticRef<Colors<uint8>>(0xB7BB28);
+    static inline auto& m_nSunCoreGreen = StaticRef<Colors<uint8>>(0xB7BA70);
+    static inline auto& m_nSunCoreBlue = StaticRef<Colors<uint8>>(0xB7B9B8);
 
     static inline auto& m_nSunCoronaRed = StaticRef<Colors<uint8>>(0xB7B900);
     static inline auto& m_nSunCoronaGreen = StaticRef<Colors<uint8>>(0xB7B848);
     static inline auto& m_nSunCoronaBlue = StaticRef<Colors<uint8>>(0xB7B790);
 
-    static inline auto& m_nSunCoreRed = StaticRef<Colors<uint8>>(0xB7BB28);
-    static inline auto& m_nSunCoreGreen = StaticRef<Colors<uint8>>(0xB7BA70);
-    static inline auto& m_nSunCoreBlue = StaticRef<Colors<uint8>>(0xB7B9B8);
+    static inline auto& m_fSunSize = StaticRef<Colors<int8>>(0xB7B6D8);
 
-    static inline auto& m_fFarClip = StaticRef<Colors<uint16>>(0xB7B1D0);
-    static inline auto& m_fFogStart = StaticRef<Colors<uint16>>(0xB7B060);
-    static inline auto& m_fLightsOnGroundBrightness = StaticRef<Colors<uint8>>(0xB7AFA8);
+    static inline auto& m_fSpriteSize = StaticRef<Colors<int8>>(0xB7B620);
+    static inline auto& m_fSpriteBrightness = StaticRef<Colors<int8>>(0xB7B568);
 
     static inline auto& m_nShadowStrength = StaticRef<Colors<uint8>>(0xB7B4B0);
     static inline auto& m_nLightShadowStrength = StaticRef<Colors<uint8>>(0xB7B3F8);
     static inline auto& m_nPoleShadowStrength = StaticRef<Colors<uint8>>(0xB7B340);
 
-    static inline auto& m_fSpriteSize = StaticRef<Colors<uint8>>(0xB7B620);
-    static inline auto& m_fSpriteBrightness = StaticRef<Colors<uint8>>(0xB7B568);
+    static inline auto& m_fFarClip = StaticRef<Colors<int16>>(0xB7B1D0);
+    static inline auto& m_fFogStart = StaticRef<Colors<int16>>(0xB7B060);
+    static inline auto& m_fLightsOnGroundBrightness = StaticRef<Colors<uint8>>(0xB7AFA8);
 
     static inline auto& m_nLowCloudsRed = StaticRef<Colors<uint8>>(0xB7AEF0);
     static inline auto& m_nLowCloudsGreen = StaticRef<Colors<uint8>>(0xB7AE38);

--- a/source/game_sa/TimeCycle.h
+++ b/source/game_sa/TimeCycle.h
@@ -34,15 +34,6 @@ enum eTimeType {
 
 class CTimeCycle {
 public:
-    static inline CVector& m_vecDirnLightToSun = *(CVector*)0xB7CB14;
-    static inline RwRGBA& m_BelowHorizonGrey = *(RwRGBA*)0xB7CB10;
-    static inline CVector (&m_VectorToSun)[16] = *(CVector(*)[16])0xB7CA50;
-
-    static inline CTimeCycleBox (&m_aBoxes)[20] = *(CTimeCycleBox(*)[20])0xB7C550;
-    static inline CColourSet& m_CurrentColours = *(CColourSet*)0xB7C4A0;
-    static inline uint32& m_bExtraColourOn = *(uint32*)0xB7C484;
-    static inline uint32& m_NumBoxes = *(uint32*)0xB7C480;
-
     template<typename T>
     using Colors = notsa::mdarray<T, NUM_HOURS, NUM_WEATHERS>;
 
@@ -111,66 +102,140 @@ public:
     static inline auto& m_nWaterFogAlpha = StaticRef<Colors<uint8>>(0xB7A090);
     static inline auto& m_nDirectionalMult = StaticRef<Colors<uint8>>(0xB79FD8);
 
-    static inline int32& m_CurrentStoredValue = *(int32*)0xB79FD0;
+    static inline CColourSet& m_CurrentColours = *(CColourSet*)0xB7C4A0;
 
-    static inline float (&m_fShadowFrontX)[16] = *(float (*)[16])0xB79F90;
-    static inline float (&m_fShadowFrontY)[16] = *(float (*)[16])0xB79F50;
+    static inline CTimeCycleBox (&m_aBoxes)[20] = *(CTimeCycleBox(*)[20])0xB7C550;
+    static inline uint32& m_NumBoxes = *(uint32*)0xB7C480;
 
-    static inline float (&m_fShadowSideX)[16] = *(float (*)[16])0xB79F10;
-    static inline float (&m_fShadowSideY)[16] = *(float (*)[16])0xB79ED0;
+    static inline uint32& m_CurrentStoredValue = *(uint32*)0xB79FD0;
+    static inline CVector (&m_VectorToSun)[16] = *(CVector(*)[16])0xB7CA50;
 
-    static inline float (&m_fShadowDisplacementX)[16] = *(float (*)[16])0xB79E90;
-    static inline float (&m_fShadowDisplacementY)[16] = *(float (*)[16])0xB79E50;
+    // TODO: CVector2D?
+    static inline float (&m_fShadowFrontX)[16] = *(float(*)[16])0xB79F90;
+    static inline float (&m_fShadowFrontY)[16] = *(float(*)[16])0xB79F50;
+    static inline float (&m_fShadowSideX)[16] = *(float(*)[16])0xB79F10;
+    static inline float (&m_fShadowSideY)[16] = *(float(*)[16])0xB79ED0;
+    static inline float (&m_fShadowDisplacementX)[16] = *(float(*)[16])0xB79E90;
+    static inline float (&m_fShadowDisplacementY)[16] = *(float(*)[16])0xB79E50;
 
     static inline int32& m_FogReduction = *(int32*)0xB79E48;
 
     static inline int32& m_ExtraColour = *(int32*)0xB79E44;
     static inline int32& m_ExtraColourWeatherType = *(int32*)0xB79E40;
+    static inline uint32& m_bExtraColourOn = *(uint32*)0xB7C484;
     static inline float& m_ExtraColourInter = *(float*)0xB79E3C;
+
+    static inline RwRGBA& m_BelowHorizonGrey = *(RwRGBA*)0xB7CB10;
 
     static inline float& m_BrightnessAddedToAmbientRed = *(float*)0xB79E38;
     static inline float& m_BrightnessAddedToAmbientGreen = *(float*)0xB79E34;
     static inline float& m_BrightnessAddedToAmbientBlue = *(float*)0xB79E30;
 
+    static inline CVector& m_vecDirnLightToSun = *(CVector*)0xB7CB14;
+
 public:
     static void InjectHooks();
 
-    static void Initialise();
-    static void InitForRestart();
+    static void Initialise(bool padFile);
+    static void Update();
+    static void CalcColoursForPoint(CVector point, CColourSet* set);
+    static float FindFarClipForCoors(CVector cameraPos);
     static void Shutdown();
 
-    static void Update();
+
+    static float GetAmbientRed();
+    static float GetAmbientGreen();
+    static float GetAmbientBlue();
+
+    static float GetAmbientRed_Obj();
+    static float GetAmbientGreen_Obj();
+    static float GetAmbientBlue_Obj();
+
+    static float GetAmbientRed_BeforeBrightness();
+    static float GetAmbientGreen_BeforeBrightness();
+    static float GetAmbientBlue_BeforeBrightness();
+
+    static uint16 GetSkyTopRed() { return m_CurrentColours.m_nSkyTopRed; };
+    static uint16 GetSkyTopGreen() { return m_CurrentColours.m_nSkyTopGreen; };
+    static uint16 GetSkyTopBlue() { return m_CurrentColours.m_nSkyTopBlue; };
+
+    static uint16 GetSkyBottomRed()   { return m_CurrentColours.m_nSkyBottomRed; };
+    static uint16 GetSkyBottomGreen() { return m_CurrentColours.m_nSkyBottomGreen; };
+    static uint16 GetSkyBottomBlue()  { return m_CurrentColours.m_nSkyBottomBlue; }
+
+    static uint16 GetFogRed()   { return m_CurrentColours.m_nSkyBottomRed; }
+    static uint16 GetFogGreen() { return m_CurrentColours.m_nSkyBottomGreen; }
+    static uint16 GetFogBlue()  { return m_CurrentColours.m_nSkyBottomBlue; }
+
+    static uint16 GetSunCoreRed()   { return m_CurrentColours.m_nSunCoreRed; };
+    static uint16 GetSunCoreGreen() { return m_CurrentColours.m_nSunCoreGreen; };
+    static uint16 GetSunCoreBlue()  { return m_CurrentColours.m_nSunCoreBlue; }
+
+    static uint16 GetSunCoronaRed()   { return m_CurrentColours.m_nSunCoronaRed; }
+    static uint16 GetSunCoronaGreen() { return m_CurrentColours.m_nSunCoronaGreen; }
+    static uint16 GetSunCoronaBlue()  { return m_CurrentColours.m_nSunCoronaBlue; }
+
+    static float GetSunSize() { return m_CurrentColours.m_fSunSize; }
+    static float GetSpriteSize() { return m_CurrentColours.m_fSpriteSize; }
+    static float GetSpriteBrightness() { return m_CurrentColours.m_fSpriteBrightness; }
+
+    static int16 GetShadowStrength() { return m_CurrentColours.m_nShadowStrength; }
+    static int16 GetLightShadowStrength() { return m_CurrentColours.m_nLightShadowStrength; }
+    static int16 GetPoleShadowStrength() { return m_CurrentColours.m_nPoleShadowStrength; }
+
+    static float GetFarClip() { return m_CurrentColours.m_fFarClip; }
+    static float GetFogStart() { return m_CurrentColours.m_fFogStart; }
+    static float GetLightsOnGroundBrightness() { return m_CurrentColours.m_fLightsOnGroundBrightness; }
+
+    static uint16 GetLowCloudsRed()   { return m_CurrentColours.m_nLowCloudsRed; }
+    static uint16 GetLowCloudsGreen() { return m_CurrentColours.m_nLowCloudsGreen; }
+    static uint16 GetLowCloudsBlue()  { return m_CurrentColours.m_nLowCloudsBlue; }
+
+    static uint16 GetFluffyCloudsBottomRed()   { return m_CurrentColours.m_nFluffyCloudsBottomRed; }
+    static uint16 GetFluffyCloudsBottomGreen() { return m_CurrentColours.m_nFluffyCloudsBottomGreen; }
+    static uint16 GetFluffyCloudsBottomBlue()  { return m_CurrentColours.m_nFluffyCloudsBottomBlue; }
+
+    static float GetWaterRed()   { return m_CurrentColours.m_fWaterRed; }
+    static float GetWaterGreen() { return m_CurrentColours.m_fWaterGreen; }
+    static float GetWaterBlue()  { return m_CurrentColours.m_fWaterBlue; }
+    static float GetWaterAlpha() { return m_CurrentColours.m_fWaterAlpha; }
+
+    static float GetPostFx1Red()  { return m_CurrentColours.m_fPostFx1Red; }
+    static float GetPostFx1Green() { return m_CurrentColours.m_fPostFx1Green; }
+    static float GetPostFx1Blue()  { return m_CurrentColours.m_fPostFx1Blue; }
+    static float GetPostFx1Alpha() { return m_CurrentColours.m_fPostFx1Alpha; }
+
+    static float GetPostFx2Red()   { return m_CurrentColours.m_fPostFx2Red; }
+    static float GetPostFx2Green() { return m_CurrentColours.m_fPostFx2Green; }
+    static float GetPostFx2Blue()  { return m_CurrentColours.m_fPostFx2Blue; }
+    static float GetPostFx2Alpha() { return m_CurrentColours.m_fPostFx2Alpha; }
+
+    static float GetCloudAlpha() { return m_CurrentColours.m_fCloudAlpha; }
+    static int32 GetHighLightMinIntensity() { return m_CurrentColours.m_nHighLightMinIntensity; }
+
+
+    static float GetLODMultiplier() { return m_CurrentColours.m_fLodDistMult; }
+
+    static void SetFogRed(uint16 value) { m_CurrentColours.m_nSkyBottomRed = value; }
+    static void SetFogGreen(uint16 value) { m_CurrentColours.m_nSkyBottomGreen = value; }
+    static void SetFogBlue(uint16 value) { m_CurrentColours.m_nSkyBottomBlue = value; }
+    
 
     static void StartExtraColour(int32 colour, bool bNoExtraColorInterior);
     static void StopExtraColour(bool bNoExtraColorInterior);
 
+
     static void AddOne(CBox& box, int16 farClip, int32 extraColor, float strength, float falloff, float lodDistMult);
-    static void CalcColoursForPoint(CVector point, CColourSet* set);
-    static float FindFarClipForCoors(CVector cameraPos);
-    static void FindTimeCycleBox(
-        CVector         pos,
-        CTimeCycleBox** out,
-        float*          currentBox,
-        bool            isLOD,
-        bool            isFarClip,
-        CTimeCycleBox*  alreadyFoundBox
-    );
+    static void FindTimeCycleBox(CVector pos, CTimeCycleBox** out, float* currentBox, bool isLOD, bool isFarClip, CTimeCycleBox* alreadyFoundBox);
+    static void InitForRestart();
+
+
     static void SetConstantParametersForPostFX();
 
-    static float GetAmbientRed()                    { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientRed; }       // 0x560330
-    static float GetAmbientGreen()                  { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientGreen; }     // 0x560340
-    static float GetAmbientBlue()                   { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBlue; }      // 0x560350
-    static float GetAmbientRed_BeforeBrightness()   { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessRed; }   // 0x560390
-    static float GetAmbientGreen_BeforeBrightness() { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessGreen; } // 0x5603A0
-    static float GetAmbientBlue_BeforeBrightness()  { return gfLaRiotsLightMult * m_CurrentColours.m_fAmbientBeforeBrightnessBlue; }  // 0x5603B0
-    static float GetAmbientRed_Obj()                { return m_CurrentColours.m_fAmbientRed_Obj; }                        // 0x560360
-    static float GetAmbientGreen_Obj()              { return m_CurrentColours.m_fAmbientGreen_Obj; }                      // 0x560370
-    static float GetAmbientBlue_Obj()               { return m_CurrentColours.m_fAmbientBlue_Obj; }                       // 0x560380
-
+public: // NOTSA
     static auto GetVectorToSun() { return m_VectorToSun[m_CurrentStoredValue]; }
     static auto GetShadowSide() { return CVector2D{ m_fShadowSideX[m_CurrentStoredValue], m_fShadowSideY[m_CurrentStoredValue] }; }
 
-public: // NOTSA
     static CRGBA GetCurrentSkyBottomColor()         { return m_CurrentColours.GetSkyBottom(); }
 
     static auto GetPostFxColors() { return std::make_pair(m_CurrentColours.GetPostFx1(), m_CurrentColours.GetPostFx2()); }
@@ -187,3 +252,4 @@ public: // NOTSA
         );
     }
 };
+// VALIDATE_SIZE(CTimeCycle, 0x919); Maybe?

--- a/source/game_sa/TimeCycle.h
+++ b/source/game_sa/TimeCycle.h
@@ -24,7 +24,7 @@ enum eTimeType {
     TIME_5AM,
     TIME_6AM,
     TIME_7AM,
-    TIME_MIDDAY,
+    TIME_MIDDAY, // TIME_NOON
     TIME_7PM,
     TIME_8PM,
     TIME_10PM,

--- a/source/game_sa/TimeCycle.h
+++ b/source/game_sa/TimeCycle.h
@@ -155,17 +155,17 @@ public:
     static float GetAmbientGreen_BeforeBrightness();
     static float GetAmbientBlue_BeforeBrightness();
 
-    static uint16 GetSkyTopRed() { return m_CurrentColours.m_nSkyTopRed; };
+    static uint16 GetSkyTopRed()   { return m_CurrentColours.m_nSkyTopRed; };
     static uint16 GetSkyTopGreen() { return m_CurrentColours.m_nSkyTopGreen; };
-    static uint16 GetSkyTopBlue() { return m_CurrentColours.m_nSkyTopBlue; };
+    static uint16 GetSkyTopBlue()  { return m_CurrentColours.m_nSkyTopBlue; };
 
     static uint16 GetSkyBottomRed()   { return m_CurrentColours.m_nSkyBottomRed; };
     static uint16 GetSkyBottomGreen() { return m_CurrentColours.m_nSkyBottomGreen; };
     static uint16 GetSkyBottomBlue()  { return m_CurrentColours.m_nSkyBottomBlue; }
 
-    static uint16 GetFogRed()   { return m_CurrentColours.m_nSkyBottomRed; }
-    static uint16 GetFogGreen() { return m_CurrentColours.m_nSkyBottomGreen; }
-    static uint16 GetFogBlue()  { return m_CurrentColours.m_nSkyBottomBlue; }
+    static uint16 GetFogRed()   { return GetSkyBottomRed(); }
+    static uint16 GetFogGreen() { return GetSkyBottomGreen(); }
+    static uint16 GetFogBlue()  { return GetSkyBottomBlue(); }
 
     static uint16 GetSunCoreRed()   { return m_CurrentColours.m_nSunCoreRed; };
     static uint16 GetSunCoreGreen() { return m_CurrentColours.m_nSunCoreGreen; };
@@ -200,7 +200,7 @@ public:
     static float GetWaterBlue()  { return m_CurrentColours.m_fWaterBlue; }
     static float GetWaterAlpha() { return m_CurrentColours.m_fWaterAlpha; }
 
-    static float GetPostFx1Red()  { return m_CurrentColours.m_fPostFx1Red; }
+    static float GetPostFx1Red()   { return m_CurrentColours.m_fPostFx1Red; }
     static float GetPostFx1Green() { return m_CurrentColours.m_fPostFx1Green; }
     static float GetPostFx1Blue()  { return m_CurrentColours.m_fPostFx1Blue; }
     static float GetPostFx1Alpha() { return m_CurrentColours.m_fPostFx1Alpha; }
@@ -216,10 +216,10 @@ public:
 
     static float GetLODMultiplier() { return m_CurrentColours.m_fLodDistMult; }
 
-    static void SetFogRed(uint16 value) { m_CurrentColours.m_nSkyBottomRed = value; }
-    static void SetFogGreen(uint16 value) { m_CurrentColours.m_nSkyBottomGreen = value; }
-    static void SetFogBlue(uint16 value) { m_CurrentColours.m_nSkyBottomBlue = value; }
-    
+    static void SetFogRed(uint16 value)   { SetSkyBottomRed(value); }
+    static void SetFogGreen(uint16 value) { SetSkyBottomGreen(value); }
+    static void SetFogBlue(uint16 value)  { SetSkyBottomBlue(value); }
+
 
     static void StartExtraColour(int32 colour, bool bNoExtraColorInterior);
     static void StopExtraColour(bool bNoExtraColorInterior);
@@ -233,6 +233,10 @@ public:
     static void SetConstantParametersForPostFX();
 
 public: // NOTSA
+    static void SetSkyBottomRed(uint16 value)   { m_CurrentColours.m_nSkyBottomRed = value; }
+    static void SetSkyBottomGreen(uint16 value) { m_CurrentColours.m_nSkyBottomGreen = value; }
+    static void SetSkyBottomBlue(uint16 value)  { m_CurrentColours.m_nSkyBottomBlue = value; }
+
     static auto GetVectorToSun() { return m_VectorToSun[m_CurrentStoredValue]; }
     static auto GetShadowSide() { return CVector2D{ m_fShadowSideX[m_CurrentStoredValue], m_fShadowSideY[m_CurrentStoredValue] }; }
 

--- a/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
+++ b/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
@@ -59,7 +59,7 @@ void TimeCycleDebugModule::RenderWindow() {
         ImGui::NewLine();
     }
 
-    ImGui::SliderInt("Selected Hour", &m_TimeId, 0, CTimeCycle::NUM_HOURS); // todo: Calc this from the current time
+    ImGui::SliderInt("Selected Hour", &m_TimeId, 0, eTimeType::NUM_HOURS); // todo: Calc this from the current time
     if (ImGui::Combo("Current Weather", &m_OldWeatherTypeId, WEATHER_NAMES, std::size(WEATHER_NAMES))) {
         CWeather::OldWeatherType = static_cast<eWeatherType>(m_OldWeatherTypeId);
     }
@@ -75,13 +75,13 @@ void TimeCycleDebugModule::RenderWindow() {
     }
 
     ImGui::NewLine();
-    if (ImGui::ColorEdit3("Post Fx 1", (float*)&m_PostFx1)) {
+    if (ImGui::ColorEdit3("Current Post Fx 1", (float*)&m_PostFx1)) {
         CTimeCycle::m_CurrentColours.m_fPostFx1Red   = m_PostFx1.r * 255.0f;
         CTimeCycle::m_CurrentColours.m_fPostFx1Green = m_PostFx1.g * 255.0f;
         CTimeCycle::m_CurrentColours.m_fPostFx1Blue  = m_PostFx1.b * 255.0f;
     }
 
-    if (ImGui::ColorEdit3("Post Fx 2", (float*)&m_PostFx2)) {
+    if (ImGui::ColorEdit3("Current Post Fx 2", (float*)&m_PostFx2)) {
         CTimeCycle::m_CurrentColours.m_fPostFx2Red   = m_PostFx2.r * 255.0f;
         CTimeCycle::m_CurrentColours.m_fPostFx2Green = m_PostFx2.g * 255.0f;
         CTimeCycle::m_CurrentColours.m_fPostFx2Blue  = m_PostFx2.b * 255.0f;
@@ -171,11 +171,11 @@ void TimeCycleDebugModule::RenderWindow() {
     }
 
     if (ImGui::SliderInt("Far Clip", &m_FarClip, INT16_MIN, INT16_MAX)) {
-        CTimeCycle::m_fFarClip[m_TimeId][m_WeatherId] = static_cast<uint16>(m_FarClip);
+        CTimeCycle::m_fFarClip[m_TimeId][m_WeatherId] = static_cast<int16>(m_FarClip);
     }
 
     if (ImGui::SliderInt("Fog Start", &m_FogStart, INT16_MIN, INT16_MAX)) {
-        CTimeCycle::m_fFogStart[m_TimeId][m_WeatherId] = static_cast<uint16>(m_FogStart);
+        CTimeCycle::m_fFogStart[m_TimeId][m_WeatherId] = static_cast<int16>(m_FogStart);
     }
 
     ImGui::NewLine();

--- a/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
+++ b/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
@@ -50,7 +50,7 @@ void TimeCycleDebugModule::RenderWindow() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Reset")) {
-        CTimeCycle::Initialise();
+        CTimeCycle::Initialise(false);
     }
     ImGui::Checkbox("Extra Colour On", reinterpret_cast<bool*>(&CTimeCycle::m_bExtraColourOn));
     ImGui::Checkbox("Show boxes", &m_ShowBoxes);
@@ -235,7 +235,7 @@ void TimeCycleDebugModule::RenderWindow() {
     }
 
     ImGui::NewLine();
-    ImGui::SliderInt("Current Stored Value", &CTimeCycle::m_CurrentStoredValue, 0, 16);
+    ImGui::SliderInt("Current Stored Value", (int32*)&CTimeCycle::m_CurrentStoredValue, 0, 16);
     ImGui::SliderFloat("Shadow Front X", &CTimeCycle::m_fShadowFrontX[0], 0.0f, 1.0f);
     ImGui::SliderFloat("Shadow Front Y", &CTimeCycle::m_fShadowFrontY[0], 0.0f, 1.0f);
     ImGui::SliderFloat("Shadow Side X", &CTimeCycle::m_fShadowSideX[0], 0.0f, 1.0f);

--- a/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
+++ b/source/toolsmenu/DebugModules/TimeCycleDebugModule.cpp
@@ -235,7 +235,10 @@ void TimeCycleDebugModule::RenderWindow() {
     }
 
     ImGui::NewLine();
-    ImGui::SliderInt("Current Stored Value", (int32*)&CTimeCycle::m_CurrentStoredValue, 0, 16);
+    if (ImGui::SliderInt("Current Stored Value", &m_CurrentStoredValue, 0, 16)) {
+        CTimeCycle::m_CurrentStoredValue = m_CurrentStoredValue;
+    }
+
     ImGui::SliderFloat("Shadow Front X", &CTimeCycle::m_fShadowFrontX[0], 0.0f, 1.0f);
     ImGui::SliderFloat("Shadow Front Y", &CTimeCycle::m_fShadowFrontY[0], 0.0f, 1.0f);
     ImGui::SliderFloat("Shadow Side X", &CTimeCycle::m_fShadowSideX[0], 0.0f, 1.0f);

--- a/source/toolsmenu/DebugModules/TimeCycleDebugModule.h
+++ b/source/toolsmenu/DebugModules/TimeCycleDebugModule.h
@@ -55,6 +55,7 @@ private:
      int32  m_HighLightMinIntensity{};
      int32  m_WaterFogAlpha{};
      int32  m_DirectionalMult{};
+     int32  m_CurrentStoredValue{};
      Color3 m_BrightnessAddedToAmbient{};
      int32  m_TimeId{};
      int32  m_WeatherId{};


### PR DESCRIPTION
1. Remove conversions where not required.
2. Reverse `CTimeCycle::Initialise` and slightly refactor `CTimeCycle::CalcColoursForPoint`
3. Implementation of `eTimeType`
4. Sort variables in `CTimeCycle` in descending order by address
5. Set negative values for Float values (why it was necessary to remove the negative sign is a question).

<img width="1920" height="1080" alt="gta_sa_6gc4Ltvsrf" src="https://github.com/user-attachments/assets/cdc1bc5a-1f51-4bda-99bd-d23f3118d49e" />

6. Fix `PostFx` in Debug

<img width="1021" height="155" alt="gta_sa_rzw6TkW1ek" src="https://github.com/user-attachments/assets/5ed90e1d-a675-4c4a-aa12-0fd966d8ba04" />
