### PR TITLE
Fix: Warnings and improvements in CLang/GCC

### DIFF
--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -31,7 +31,7 @@
 char(&CFileLoader::ms_line)[512] = *reinterpret_cast<char(*)[512]>(0xB71848);
 uint32& gAtomicModelId = *reinterpret_cast<uint32*>(0xB71840);
 
-void LinkLods(int32 a1);
+void LinkLods(int32 numRelatedIPLs);
 
 void CFileLoader::InjectHooks() {
     RH_ScopedClass(CFileLoader);

--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -204,16 +204,25 @@ RpClump* CFileLoader::LoadAtomicFile2Return(const char* filename) {
     return clump;
 }
 
-// NOTSA
+// NOTSA - Finds the first character that is NOT whitespace or null
 char* CFileLoader::FindFirstNonNullOrWS(char* it) {
-    // Have to cast to uint8, because signed ASCII is retarded
-    for (; *it && (uint8)*it <= (uint8)' '; it++) {}
+    while (*it) {
+        if (const auto& c = static_cast<uint8_t>(*it); c > ' ') {
+            break;
+        }
+        ++it;
+    }
     return it;
 }
 
 // NOTSA
 char* CFileLoader::FindFirstNullOrWS(char* it) {
-    for (; *it && *it > ' '; it++) {}
+    while (*it) {
+        if (const auto& c = static_cast<uint8_t>(*it); c <= ' ') {
+            break;
+        }
+        ++it;
+    }
     return it;
 }
 

--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -206,10 +206,7 @@ RpClump* CFileLoader::LoadAtomicFile2Return(const char* filename) {
 
 // NOTSA - Finds the first character that is NOT whitespace or null
 char* CFileLoader::FindFirstNonNullOrWS(char* it) {
-    while (*it) {
-        if (const auto& c = static_cast<uint8_t>(*it); c > ' ') {
-            break;
-        }
+    while (*it && static_cast<uint8_t>(*it) <= ' ') {
         ++it;
     }
     return it;
@@ -217,10 +214,7 @@ char* CFileLoader::FindFirstNonNullOrWS(char* it) {
 
 // NOTSA
 char* CFileLoader::FindFirstNullOrWS(char* it) {
-    while (*it) {
-        if (const auto& c = static_cast<uint8_t>(*it); c <= ' ') {
-            break;
-        }
+    while (*it && static_cast<uint8_t>(*it) > ' ') {
         ++it;
     }
     return it;

--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -2140,7 +2140,7 @@ void CFileLoader::LoadScene(const char* filename) {
 
         } else {
             const auto FindSectionID = [&] {
-                static const struct { std::string_view name; SectionID id; } mapping[]{
+                constexpr struct { std::string_view name; SectionID id; } mapping[]{
                     { "path", SectionID::PATH },
                     { "inst", SectionID::INST },
                     { "mult", SectionID::MULT },
@@ -2288,7 +2288,7 @@ void CFileLoader::LoadObjectTypes(const char* filename) {
             // Find out next section
 
             const auto FindSectionID = [&] {
-                static const struct { std::string_view name; SectionID id; } mapping[]{
+                constexpr struct { std::string_view name; SectionID id; } mapping[]{
                     { "objs", SectionID::OBJS },
                     { "tobj", SectionID::TOBJ },
                     { "weap", SectionID::WEAP },

--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -207,13 +207,13 @@ RpClump* CFileLoader::LoadAtomicFile2Return(const char* filename) {
 // NOTSA
 char* CFileLoader::FindFirstNonNullOrWS(char* it) {
     // Have to cast to uint8, because signed ASCII is retarded
-    for (; *it && (uint8)*it <= (uint8)' '; it++);
+    for (; *it && (uint8)*it <= (uint8)' '; it++) {}
     return it;
 }
 
 // NOTSA
 char* CFileLoader::FindFirstNullOrWS(char* it) {
-    for (; *it && *it > ' '; it++);
+    for (; *it && *it > ' '; it++) {}
     return it;
 }
 


### PR DESCRIPTION
Fixs warnings in clang-tidy:
- Function 'LinkLods' has a definition with different parameter names'
- Possibly erroneous empty statement

Improvements:
- Use `constexpr struct` in place of `static const struct` in struct mapping