### PR TITLE
refactor(DamageManager): `ApplyDamage` by incorporating `GetComponentGroup` and removing `tComponentGroup` enum entirely

### DIFF
--- a/contrib/rename-all.py
+++ b/contrib/rename-all.py
@@ -1,0 +1,44 @@
+#
+# Should be ran from the `/source` directory
+# replace the values below you want to rename
+#
+
+import asyncio
+from asyncio.subprocess import create_subprocess_exec
+
+async def process_one_rename(old: str, new: str):
+    process = await create_subprocess_exec(
+        "python",
+        "../contrib/unscoped-enum-to-scoped-rename.py",
+        "tComponent",
+        old,
+        new,
+    )
+    await process.wait()
+
+async def main():
+    for old, new in (
+        ("COMPONENT_NA", "ENGINE"),
+        ("COMPONENT_WHEEL_LF", "WHEEL_FRONT_LEFT"),
+        ("COMPONENT_WHEEL_RF", "WHEEL_FRONT_RIGHT"),
+        ("COMPONENT_WHEEL_LR", "WHEEL_REAR_LEFT"),
+        ("COMPONENT_WHEEL_RR", "WHEEL_REAR_RIGHT"),
+        ("COMPONENT_BONNET", "DOOR_BONNET"),
+        ("COMPONENT_BOOT", "DOOR_BOOT"),
+        ("COMPONENT_DOOR_LF", "DOOR_FRONT_LEFT"),
+        ("COMPONENT_DOOR_RF", "DOOR_FRONT_RIGHT"),
+        ("COMPONENT_DOOR_LR", "DOOR_REAR_LEFT"),
+        ("COMPONENT_DOOR_RR", "DOOR_REAR_RIGHT"),
+        ("COMPONENT_WING_LF", "PANEL_FRONT_LEFT"),
+        ("COMPONENT_WING_RF", "PANEL_FRONT_RIGHT"),
+        ("COMPONENT_WING_LR", "PANEL_REAR_LEFT"),
+        ("COMPONENT_WING_RR", "PANEL_REAR_RIGHT"),
+        ("COMPONENT_WINDSCREEN", "PANEL_WINDSCREEN"),
+        ("COMPONENT_BUMP_FRONT", "PANEL_FRONT_BUMPER"),
+        ("COMPONENT_BUMP_REAR", "PANEL_REAR_BUMPER"),
+    ):
+        print(f"Renaming {old} to {new}...")
+        await process_one_rename(old, new)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/contrib/unscoped-enum-to-scoped-rename.py
+++ b/contrib/unscoped-enum-to-scoped-rename.py
@@ -1,0 +1,33 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+parser = ArgumentParser(
+    description="Convert unscoped enums to scoped enums in C++ code. Should be ran from the `/source` directrory!"
+)
+parser.add_argument("enum_name", help="The name of the enum to convert.")
+parser.add_argument("enum_old_member", help="The old member name to replace.")
+parser.add_argument(
+    "enum_new_member", help="The new member name to use in the scoped enum."
+)
+args = parser.parse_args()
+
+
+def main():
+    for pattern in ["*.h", "*.cpp"]:
+        for path in Path(".").rglob(pattern):
+            try:
+                with path.open("r+", encoding="utf-8") as f:
+                    content = f.read()
+                    f.seek(0)
+                    f.truncate(0)
+                    new = f"{args.enum_name}::{args.enum_new_member}"
+                    f.write(
+                        content
+                            .replace(f"{args.enum_name}::{args.enum_old_member}", new)
+                            .replace(args.enum_old_member, new)
+                    )
+            except Exception as e:
+                print(f"Error processing {path}: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/source/game_sa/Audio/entities/AEVehicleAudioEntity.h
+++ b/source/game_sa/Audio/entities/AEVehicleAudioEntity.h
@@ -45,7 +45,7 @@ protected: // Config:
     // Config struct - Obviously this is notsa, but it's necessary for the debug module
     static inline struct Config {
         float      FreqUnderwaterFactor = 0.7f;              // 0x8CBC48
-        tComponent HeliAudioComponent   = COMPONENT_WING_RR; //!< 0x8CBD4C - Where audio is placed for helis
+        tComponent HeliAudioComponent   = tComponent::PANEL_REAR_RIGHT; //!< 0x8CBD4C - Where audio is placed for helis
 
         float IdRollOffFactor               = 2.f; // 0x8CBC2C
         float RevRollOffFactor              = 2.f; // 0x8CBC30

--- a/source/game_sa/Audio/entities/AEVehicleAudioEntity.h
+++ b/source/game_sa/Audio/entities/AEVehicleAudioEntity.h
@@ -14,7 +14,8 @@
 #include "eRadioID.h"
 #include "eVehicleType.h"
 #include "eAudioEvents.h"
-#include <DamageManager.h> // tComponent
+
+#include <Entity/Vehicle/Enums/HeliNodes.h>
 
 #include <Audio/Enums/eSoundBank.h>
 #include <Audio/Enums/eSoundBankSlot.h>
@@ -45,7 +46,7 @@ protected: // Config:
     // Config struct - Obviously this is notsa, but it's necessary for the debug module
     static inline struct Config {
         float      FreqUnderwaterFactor = 0.7f;              // 0x8CBC48
-        tComponent HeliAudioComponent   = tComponent::PANEL_REAR_RIGHT; //!< 0x8CBD4C - Where audio is placed for helis
+        eHeliNodes HeliAudioComponent   = HELI_STATIC_ROTOR2; //!< 0x8CBD4C - Where audio is placed for helis
 
         float IdRollOffFactor               = 2.f; // 0x8CBC2C
         float RevRollOffFactor              = 2.f; // 0x8CBC30

--- a/source/game_sa/DamageManager.cpp
+++ b/source/game_sa/DamageManager.cpp
@@ -86,7 +86,7 @@ bool CDamageManager::ApplyDamage(CAutomobile* vehicle, tComponent compId, float 
 
     static constexpr float afPanelDamageMultByGroup[] = { 2.5f, 1.25f, 3.2f, 1.4f, 2.5f, 2.8f, 0.5f, 1.2f, 0.87f, 0.2f };
     fIntensity *= afPanelDamageMultByGroup[(size_t)group];
-    if (compId == tComponent::COMPONENT_WINDSCREEN)
+    if (compId == tComponent::PANEL_WINDSCREEN)
         fIntensity *= 0.6f;
 
     if (fIntensity <= 150.0f)
@@ -251,13 +251,13 @@ eCarNodes CDamageManager::GetCarNodeIndexFromPanel(ePanels panel) {
 eDoorStatus CDamageManager::GetDoorStatus_Component(tComponent doorComp) const {
     /* Enums don't seem to match up... */
     switch (doorComp) {
-    case tComponent::COMPONENT_DOOR_RF:
+    case tComponent::DOOR_FRONT_RIGHT:
         return GetDoorStatus(eDoors::DOOR_RIGHT_FRONT);
-    case tComponent::COMPONENT_DOOR_LR:
+    case tComponent::DOOR_REAR_LEFT:
         return GetDoorStatus(eDoors::DOOR_RIGHT_REAR);
-    case tComponent::COMPONENT_DOOR_RR:
+    case tComponent::DOOR_REAR_RIGHT:
         return GetDoorStatus(eDoors::DOOR_LEFT_FRONT);
-    case tComponent::COMPONENT_WING_LF:
+    case tComponent::PANEL_FRONT_LEFT:
         return GetDoorStatus(eDoors::DOOR_LEFT_REAR);
     default:
         return eDoorStatus::DAMSTATE_NOTPRESENT;
@@ -267,16 +267,16 @@ eDoorStatus CDamageManager::GetDoorStatus_Component(tComponent doorComp) const {
 // 0x6C21E0
 void CDamageManager::SetDoorStatus_Component(tComponent doorComp, eDoorStatus status) {
     switch (doorComp) {
-    case tComponent::COMPONENT_DOOR_RF:
+    case tComponent::DOOR_FRONT_RIGHT:
         SetDoorStatus(eDoors::DOOR_RIGHT_FRONT, status);
         break;
-    case tComponent::COMPONENT_DOOR_LR:
+    case tComponent::DOOR_REAR_LEFT:
         SetDoorStatus(eDoors::DOOR_RIGHT_REAR, status);
         break;
-    case tComponent::COMPONENT_DOOR_RR:
+    case tComponent::DOOR_REAR_RIGHT:
         SetDoorStatus(eDoors::DOOR_LEFT_FRONT, status);
         break;
-    case tComponent::COMPONENT_WING_LF:
+    case tComponent::PANEL_FRONT_LEFT:
         SetDoorStatus(eDoors::DOOR_LEFT_REAR, status);
         break;
     }

--- a/source/game_sa/DamageManager.cpp
+++ b/source/game_sa/DamageManager.cpp
@@ -30,7 +30,6 @@ void CDamageManager::InjectHooks() {
     RH_ScopedInstall(GetLightStatus, 0x6C2130); 
     RH_ScopedInstall(SetLightStatus, 0x6C2100); 
     RH_ScopedInstall(ResetDamageStatus, 0x6C20E0); 
-    RH_ScopedInstall(GetComponentGroup, 0x6C2040); 
     RH_ScopedInstall(GetCarNodeIndexFromDoor, 0x6C26F0);
     RH_ScopedNamedInstall(GetWheelStatus_Hooked, "GetWheelStatus", 0x6C21B0);
 }
@@ -76,47 +75,85 @@ void CDamageManager::FuckCarCompletely(bool bDontDetachWheel) {
 }
 
 // 0x6C24B0
-bool CDamageManager::ApplyDamage(CAutomobile* vehicle, tComponent compId, float fIntensity, float fColDmgMult) {
-    if (!vehicle->autoFlags.bCanBeVisiblyDamaged)
+// NOTE: This function has been refactored so we can get rid of `GetComponentGroup` (useless function)
+bool CDamageManager::ApplyDamage(CAutomobile* vehicle, tComponent component, float intensity, float fColDmgMult) {
+    if (!vehicle->autoFlags.bCanBeVisiblyDamaged) {
         return false;
-
-    tComponentGroup group{};
-    uint8 relCompIdx{};
-    GetComponentGroup(compId, group, relCompIdx);
-
-    static constexpr float afPanelDamageMultByGroup[] = { 2.5f, 1.25f, 3.2f, 1.4f, 2.5f, 2.8f, 0.5f, 1.2f, 0.87f, 0.2f };
-    fIntensity *= afPanelDamageMultByGroup[(size_t)group];
-    if (compId == tComponent::PANEL_WINDSCREEN)
-        fIntensity *= 0.6f;
-
-    if (fIntensity <= 150.0f)
-        return false;
-
-    switch (group) {
-    case tComponentGroup::COMPGROUP_PANEL: {
-        if (ProgressPanelDamage((ePanels)relCompIdx))
-            vehicle->SetBumperDamage((ePanels)relCompIdx, false);
-        return true;
     }
-    case tComponentGroup::COMPGROUP_WHEEL: {
-        ProgressWheelDamage((eCarWheel)relCompIdx);
+
+    const auto CheckIntensity = [=](float intensityFactor = 1.f) {
+        return intensity * intensityFactor > 150.0f;
+    };
+
+    const auto ApplyPanelDamage = [&](ePanels panel, std::optional<eLights> lightOfPanel = std::nullopt, float intensityFactor = 1.f) {
+        if (!CheckIntensity(intensityFactor)) {
+            return false;
+        }
+        if (lightOfPanel) {
+            SetLightStatus(*lightOfPanel, eLightsState::VEHICLE_LIGHT_SMASHED);
+        }
+        if (ProgressPanelDamage(panel)) {
+            switch (panel) {
+            case ePanels::WINDSCREEN_PANEL:
+            case ePanels::FRONT_BUMPER:
+            case ePanels::REAR_BUMPER:      vehicle->SetBumperDamage(panel, false); break;
+
+            case ePanels::FRONT_LEFT_PANEL:
+            case ePanels::FRONT_RIGHT_PANEL:
+            case ePanels::REAR_LEFT_PANEL:
+            case ePanels::REAR_RIGHT_PANEL:  vehicle->SetPanelDamage(panel, false); break;
+
+            default: NOTSA_UNREACHABLE();
+            }
+        }
         return true;
-    }
-    case tComponentGroup::COMPGROUP_DOOR:
-    case tComponentGroup::COMPGROUP_BONNET:
-    case tComponentGroup::COMPGROUP_BOOT: {
-        if (ProgressDoorDamage((eDoors)relCompIdx, vehicle))
-            vehicle->SetDoorDamage((eDoors)relCompIdx, false);
+    };
+
+    const auto ApplyWheelDamage = [&](eCarWheel wheel, float intensityFactor) {
+        if (!CheckIntensity(intensityFactor)) {
+            return false;
+        }
+        ProgressWheelDamage(wheel);
         return true;
-    }
-    case tComponentGroup::COMPGROUP_LIGHT: {
-        SetLightStatus((eLights)relCompIdx, eLightsState::VEHICLE_LIGHT_SMASHED);
-        if (ProgressPanelDamage((ePanels)relCompIdx))
-            vehicle->SetPanelDamage((ePanels)relCompIdx, false);
+    };
+
+    const auto ApplyDoorDamage = [&](eDoors door, float intensityFactor) {
+        if (!CheckIntensity(intensityFactor)) {
+            return false;
+        }
+        if (ProgressDoorDamage(door, vehicle)) {
+            vehicle->SetDoorDamage(door, false);
+        }
         return true;
-    }
-    default:
-        return true;
+    };
+
+    /* Based on code from `0x6C2040` and `0x6C2514` */
+    /* Intensity values from array at `0x8D32A0` */
+    switch (component) {
+    case tComponent::WHEEL_FRONT_LEFT:  return ApplyWheelDamage(CAR_WHEEL_FRONT_LEFT, 1.25f);
+    case tComponent::WHEEL_FRONT_RIGHT: return ApplyWheelDamage(CAR_WHEEL_FRONT_RIGHT, 1.25f);
+    case tComponent::WHEEL_REAR_LEFT:   return ApplyWheelDamage(CAR_WHEEL_REAR_LEFT, 1.25f);
+    case tComponent::WHEEL_REAR_RIGHT:  return ApplyWheelDamage(CAR_WHEEL_REAR_RIGHT, 1.25f);
+
+    case tComponent::DOOR_BONNET:      return ApplyDoorDamage(eDoors::DOOR_BONNET, 1.40f);
+    case tComponent::DOOR_BOOT:        return ApplyDoorDamage(eDoors::DOOR_BOOT, 2.50f);
+    case tComponent::DOOR_FRONT_LEFT:  return ApplyDoorDamage(eDoors::DOOR_LEFT_FRONT, 3.20f);
+    case tComponent::DOOR_FRONT_RIGHT: return ApplyDoorDamage(eDoors::DOOR_RIGHT_FRONT, 3.20f);
+    case tComponent::DOOR_REAR_LEFT:   return ApplyDoorDamage(eDoors::DOOR_LEFT_REAR, 3.20f);
+    case tComponent::DOOR_REAR_RIGHT:  return ApplyDoorDamage(eDoors::DOOR_RIGHT_REAR, 3.20f);
+
+    case tComponent::PANEL_FRONT_LEFT:  return ApplyPanelDamage(ePanels::FRONT_LEFT_PANEL, eLights::LIGHT_FRONT_LEFT, 2.80f);
+    case tComponent::PANEL_FRONT_RIGHT: return ApplyPanelDamage(ePanels::FRONT_RIGHT_PANEL, eLights::LIGHT_FRONT_RIGHT, 2.80f);
+    case tComponent::PANEL_REAR_LEFT:   return ApplyPanelDamage(ePanels::REAR_LEFT_PANEL, eLights::LIGHT_REAR_RIGHT, 2.80f);
+    case tComponent::PANEL_REAR_RIGHT:  return ApplyPanelDamage(ePanels::REAR_RIGHT_PANEL, eLights::LIGHT_REAR_LEFT, 2.80f);
+
+    case tComponent::PANEL_WINDSCREEN:   return ApplyPanelDamage(ePanels::WINDSCREEN_PANEL, std::nullopt, 2.50f * 0.6f); /* Apply 0.6f factor on top (see 0x6C24F4) */
+    case tComponent::PANEL_FRONT_BUMPER: return ApplyPanelDamage(ePanels::FRONT_BUMPER, std::nullopt, 2.50f);
+    case tComponent::PANEL_REAR_BUMPER:  return ApplyPanelDamage(ePanels::REAR_BUMPER, std::nullopt, 2.50f);
+
+    case tComponent::ENGINE: return CheckIntensity(0.50f);
+
+    default: NOTSA_UNREACHABLE();
     }
 }
 
@@ -341,60 +378,6 @@ void CDamageManager::ResetDamageStatus() {
 
     for (size_t i = 0; i < ePanels::MAX_PANELS; i++)
         SetPanelStatus((ePanels)i, ePanelDamageState::DAMSTATE_OK);
-}
-
-// 0x6C2040
-bool CDamageManager::GetComponentGroup(tComponent nComp, tComponentGroup& outCompGroup, uint8& outComponentRelativeIdx) {
-    outComponentRelativeIdx = (uint8)-2;
-    switch (nComp) {
-    case tComponent::COMPONENT_WHEEL_LF:
-    case tComponent::COMPONENT_WHEEL_RF:
-    case tComponent::COMPONENT_WHEEL_LR:
-    case tComponent::COMPONENT_WHEEL_RR: {
-        outCompGroup = tComponentGroup::COMPGROUP_WHEEL;
-        outComponentRelativeIdx = (uint8)nComp - 1;
-        return true;
-    }
-    case tComponent::COMPONENT_BONNET: {
-        outCompGroup = tComponentGroup::COMPGROUP_BONNET;
-        outComponentRelativeIdx = (uint8)eDoors::DOOR_BONNET;
-        return true;
-    }
-    case tComponent::COMPONENT_BOOT: {
-        outCompGroup = tComponentGroup::COMPGROUP_BOOT;
-        outComponentRelativeIdx = (uint8)eDoors::DOOR_BOOT;
-        return true;
-    }
-    case tComponent::COMPONENT_DOOR_LF:
-    case tComponent::COMPONENT_DOOR_RF:
-    case tComponent::COMPONENT_DOOR_LR:
-    case tComponent::COMPONENT_DOOR_RR: {
-        outCompGroup = tComponentGroup::COMPGROUP_DOOR;
-        outComponentRelativeIdx = (uint8)nComp - (uint8)tComponent::COMPONENT_BONNET;
-        return true;
-    }
-    case tComponent::COMPONENT_WING_LF:
-    case tComponent::COMPONENT_WING_RF:
-    case tComponent::COMPONENT_WING_LR:
-    case tComponent::COMPONENT_WING_RR: 
-    case tComponent::COMPONENT_WINDSCREEN: {
-        outCompGroup = tComponentGroup::COMPGROUP_LIGHT;
-        outComponentRelativeIdx = (uint8)nComp - (uint8)tComponent::COMPONENT_WING_LF;
-        return true;
-    }
-    case tComponent::COMPONENT_BUMP_FRONT:
-    case tComponent::COMPONENT_BUMP_REAR: {
-        outCompGroup = tComponentGroup::COMPGROUP_PANEL;
-        outComponentRelativeIdx = (uint8)nComp - (uint8)tComponent::COMPONENT_WING_LF;
-        return true;
-    }
-    case tComponent::COMPONENT_NA: {
-        outCompGroup = tComponentGroup::COMPGROUP_NA;
-        outComponentRelativeIdx = 0;
-        return true;
-    }
-    }
-    return false;
 }
 
 // NOTSA

--- a/source/game_sa/DamageManager.h
+++ b/source/game_sa/DamageManager.h
@@ -33,30 +33,30 @@ enum ePanelDamageState : uint8 {
 };
 
 // original name
-enum tComponent : uint8 {
-    COMPONENT_NA         = 0,
-    COMPONENT_WHEEL_LF   = 1,
-    COMPONENT_WHEEL_RF   = 2,
-    COMPONENT_WHEEL_LR   = 3,
-    COMPONENT_WHEEL_RR   = 4,
-    COMPONENT_BONNET     = 5,
-    COMPONENT_BOOT       = 6,
-    COMPONENT_DOOR_LF    = 7,
-    COMPONENT_DOOR_RF    = 8,
-    COMPONENT_DOOR_LR    = 9,
-    COMPONENT_DOOR_RR    = 10,
+enum class tComponent : uint8 {
+    ENGINE             = 0, // NA
 
-    // ----- CT_PANEL_
-    COMPONENT_WING_LF    = 11,
-    COMPONENT_WING_RF    = 12,
-    COMPONENT_WING_LR    = 13,
-    COMPONENT_WING_RR    = 14,
-    COMPONENT_WINDSCREEN = 15,
-    COMPONENT_BUMP_FRONT = 16,
-    COMPONENT_BUMP_REAR  = 17,
-    // -----
+    WHEEL_FRONT_LEFT   = 1, // WHEEL_LF
+    WHEEL_FRONT_RIGHT  = 2, // WHEEL_RF
+    WHEEL_REAR_LEFT    = 3, // WHEEL_LR
+    WHEEL_REAR_RIGHT   = 4, // WHEEL_RR
 
-    MAX_COMPONENTS = COMPONENT_BUMP_REAR /* cause it starts at 1, not 0 */
+    DOOR_BONNET        = 5,  // BONNET
+    DOOR_BOOT          = 6,  // BOOT
+    DOOR_FRONT_LEFT    = 7,  // DOOR_LF
+    DOOR_FRONT_RIGHT   = 8,  // DOOR_RF
+    DOOR_REAR_LEFT     = 9,  // DOOR_LR
+    DOOR_REAR_RIGHT    = 10, // DOOR_RR
+
+    PANEL_FRONT_LEFT   = 11, // WING_LF
+    PANEL_FRONT_RIGHT  = 12, // WING_RF
+    PANEL_REAR_LEFT    = 13, // WING_LR
+    PANEL_REAR_RIGHT   = 14, // WING_RR
+    PANEL_WINDSCREEN   = 15, // WINDSCREEN
+    PANEL_FRONT_BUMPER = 16, // BUMP_FRONT
+    PANEL_REAR_BUMPER  = 17, // BUMP_REAR
+
+    MAX_COMPONENTS
 };
 
 // original name

--- a/source/game_sa/DamageManager.h
+++ b/source/game_sa/DamageManager.h
@@ -33,21 +33,26 @@ enum ePanelDamageState : uint8 {
 };
 
 // original name
-enum class tComponent : uint8 {
+enum class tComponent {
     ENGINE             = 0, // NA
 
+    WHEEL_BEGIN,
     WHEEL_FRONT_LEFT   = 1, // WHEEL_LF
     WHEEL_FRONT_RIGHT  = 2, // WHEEL_RF
     WHEEL_REAR_LEFT    = 3, // WHEEL_LR
     WHEEL_REAR_RIGHT   = 4, // WHEEL_RR
+    WHEEL_END,
 
+    DOOR_BEGIN,
     DOOR_BONNET        = 5,  // BONNET
     DOOR_BOOT          = 6,  // BOOT
     DOOR_FRONT_LEFT    = 7,  // DOOR_LF
     DOOR_FRONT_RIGHT   = 8,  // DOOR_RF
     DOOR_REAR_LEFT     = 9,  // DOOR_LR
     DOOR_REAR_RIGHT    = 10, // DOOR_RR
+    DOOR_END,
 
+    PANEL_BEGIN,
     PANEL_FRONT_LEFT   = 11, // WING_LF
     PANEL_FRONT_RIGHT  = 12, // WING_RF
     PANEL_REAR_LEFT    = 13, // WING_LR
@@ -55,21 +60,9 @@ enum class tComponent : uint8 {
     PANEL_WINDSCREEN   = 15, // WINDSCREEN
     PANEL_FRONT_BUMPER = 16, // BUMP_FRONT
     PANEL_REAR_BUMPER  = 17, // BUMP_REAR
+    PANEL_END,
 
     MAX_COMPONENTS
-};
-
-// original name
-enum tComponentGroup : uint8 {
-    COMPGROUP_PANEL  = 0,
-    COMPGROUP_WHEEL  = 1,
-    COMPGROUP_DOOR   = 2,
-    COMPGROUP_BONNET = 3,
-    COMPGROUP_BOOT   = 4,
-    COMPGROUP_LIGHT  = 5,
-    COMPGROUP_NA     = 6,
-
-    MAX_COMGROUPS
 };
 
 enum eCarWheelStatus : uint8  {
@@ -85,6 +78,7 @@ enum ePanels : uint8 {
     FRONT_RIGHT_PANEL,
     REAR_LEFT_PANEL,
     REAR_RIGHT_PANEL,
+
     WINDSCREEN_PANEL,
     FRONT_BUMPER,
     REAR_BUMPER,
@@ -160,7 +154,7 @@ public:
     void ResetDamageStatus();
     void ResetDamageStatusAndWheelDamage();
     void FuckCarCompletely(bool bDetachWheel);
-    bool ApplyDamage(CAutomobile* vehicle, tComponent compId, float fIntensity, float fColDmgMult);
+    bool ApplyDamage(CAutomobile* vehicle, tComponent component, float intensity, float fColDmgMult);
 
     // Set next level of damage to aero-plane component
     bool ProgressAeroplaneDamage(uint8 nFrameId);
@@ -196,7 +190,6 @@ public:
     // returns -1 if no node for this panel
     static eCarNodes GetCarNodeIndexFromPanel(ePanels panel);
     static eCarNodes GetCarNodeIndexFromDoor(eDoors door);
-    static bool GetComponentGroup(tComponent nComp, tComponentGroup& outCompGroup, uint8& outComponentRelativeIdx);
 
     // NOTSA
     void SetAllWheelsState(eCarWheelStatus state);

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -4195,9 +4195,9 @@ void CAutomobile::SetBusDoorTimer(uint32 timerEndDelta, bool setAsStartedInPast)
 void CAutomobile::ProcessAutoBusDoors() {
     if (m_nBusDoorTimerEnd <= CTimer::GetTimeInMS()) {
         if (m_nBusDoorTimerStart) {
-            static constexpr struct { eDoors door; tComponent comp; uint32 flagMask; } doors[]{
-                { eDoors::DOOR_LEFT_FRONT,  tComponent::DOOR_REAR_RIGHT, 1 }, // TODO: `tComponent::DOOR_REAR_RIGHT` doesn't match up with `DOOR_LEFT_FRONT`
-                { eDoors::DOOR_RIGHT_FRONT, tComponent::DOOR_FRONT_RIGHT, 4 }
+            static constexpr struct { eDoors door; eCarNodes comp; uint32 flagMask; } doors[]{
+                { eDoors::DOOR_LEFT_FRONT,  CAR_DOOR_LF, 1 }, 
+                { eDoors::DOOR_RIGHT_FRONT, CAR_DOOR_RF, 4 }
             };
 
             for (auto&& [door, comp, flagMask] : doors) {
@@ -4212,7 +4212,7 @@ void CAutomobile::ProcessAutoBusDoors() {
     } else if (m_nBusDoorTimerEnd && CTimer::GetTimeInMS() > m_nBusDoorTimerEnd - 500) {
         if (!IsDoorMissing(eDoors::DOOR_LEFT_FRONT) && (m_nGettingInFlags & 1)) {
             const auto OpenThisDoor = [this](float ratio) {
-                OpenDoor(nullptr, tComponent::DOOR_REAR_RIGHT, DOOR_LEFT_FRONT, ratio, true); // TODO: `tComponent::DOOR_REAR_RIGHT` doesn't match up with `DOOR_LEFT_FRONT`
+                OpenDoor(nullptr, CAR_DOOR_LF, DOOR_LEFT_FRONT, ratio, true);
             };
 
             if (IsDoorClosed(eDoors::DOOR_LEFT_FRONT)) {
@@ -4227,7 +4227,7 @@ void CAutomobile::ProcessAutoBusDoors() {
             if (IsDoorClosed(eDoors::DOOR_RIGHT_FRONT)) {
                 m_nBusDoorTimerEnd = CTimer::GetTimeInMS();
             }
-            OpenDoor(nullptr, tComponent::DOOR_FRONT_RIGHT, DOOR_RIGHT_FRONT, 0.f, true);
+            OpenDoor(nullptr, CAR_DOOR_RF, DOOR_RIGHT_FRONT, 0.f, true);
         }
     }
 }
@@ -4499,21 +4499,21 @@ void CAutomobile::PopBootUsingPhysics() {
 void CAutomobile::CloseAllDoors() {
     const auto& mi = *GetVehicleModelInfo();
 
-    const auto CloseDoor = [this](tComponent comp, eDoors door) {
+    const auto CloseDoor = [this](eCarNodes node, eDoors door) {
         if (!IsDoorMissing(door)) {
-            OpenDoor(nullptr, comp, door, 0.f, true);
+            OpenDoor(nullptr, node, door, 0.f, true);
         }
     };
 
     assert(mi.m_nNumDoors > 0);
-    CloseDoor(tComponent::DOOR_REAR_RIGHT, eDoors::DOOR_LEFT_FRONT); // TODO: Again, enums dont seem to match up..
+    CloseDoor(CAR_DOOR_LF, eDoors::DOOR_LEFT_FRONT);
     if (mi.m_nNumDoors > 1) {
-        CloseDoor(tComponent::DOOR_FRONT_RIGHT, eDoors::DOOR_RIGHT_FRONT);
+        CloseDoor(CAR_DOOR_RF, eDoors::DOOR_RIGHT_FRONT);
         if (mi.m_nNumDoors > 2) {
             assert(mi.m_nNumDoors == 4); // Pirulax: May assert, I'm not sure. Let me know if it did.
 
-            CloseDoor(tComponent::PANEL_FRONT_LEFT, eDoors::DOOR_LEFT_REAR); // TODO: Enums dont match at all..
-            CloseDoor(tComponent::DOOR_REAR_LEFT, eDoors::DOOR_RIGHT_REAR);
+            CloseDoor(CAR_DOOR_LR, eDoors::DOOR_LEFT_REAR);
+            CloseDoor(CAR_DOOR_RR, eDoors::DOOR_RIGHT_REAR);
         }
     }
 }

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -2999,13 +2999,13 @@ void CAutomobile::VehicleDamage(float damageIntensity, eVehicleCollisionComponen
 
             switch (collisionComponent) {
             case eVehicleCollisionComponent::BONNET:
-                ApplyDamageToComponent(tComponent::COMPONENT_BONNET);
+                ApplyDamageToComponent(tComponent::DOOR_BONNET);
                 break;
             case eVehicleCollisionComponent::BOOT:
-                ApplyDamageToComponent(tComponent::COMPONENT_BOOT);
+                ApplyDamageToComponent(tComponent::DOOR_BOOT);
                 break;
             case eVehicleCollisionComponent::BUMP_FRONT: {
-                ApplyDamageToComponent(tComponent::COMPONENT_BUMP_FRONT);
+                ApplyDamageToComponent(tComponent::PANEL_FRONT_BUMPER);
 
                 const auto localDir       = GetCollisionPointLocalDirection();
                 const auto colDirDotRight = DotProduct(*vecCollisionDirection, m_matrix->GetRight());
@@ -3014,69 +3014,69 @@ void CAutomobile::VehicleDamage(float damageIntensity, eVehicleCollisionComponen
                 if (   localDir > 0.7f // [0, 45] deg
                     || localDir > 0.5f && colDirDotRight < -0.5f && m_fMass * 0.35f < calcDmgIntensity
                 ) {
-                    ApplyDamageToComponent(tComponent::COMPONENT_WING_RF);
+                    ApplyDamageToComponent(tComponent::PANEL_FRONT_RIGHT);
                 } else if (
                        localDir > -0.7f // [90, 135] deg
                     || localDir > -0.5f && colDirDotRight > 0.5f && m_fMass * 0.35f < calcDmgIntensity
                 ) {
-                    ApplyDamageToComponent(tComponent::COMPONENT_WING_LF);
+                    ApplyDamageToComponent(tComponent::PANEL_FRONT_LEFT);
                 }
 
                 // Possibly apply bonnet damage if front bumper is not `ok`
                 if (   m_damageManager.GetPanelStatus(ePanels::FRONT_BUMPER) != DAMSTATE_OK && m_fMass * 0.2f < calcDmgIntensity
                     || weapon < WEAPON_LAST_WEAPON && (CGeneral::GetRandomNumber() % 3 == 0) // If it was a weapon, apply damage by randomly
                 ) {
-                    ApplyDamageToComponent(tComponent::COMPONENT_BONNET);
+                    ApplyDamageToComponent(tComponent::DOOR_BONNET);
                 }
 
                 // Possibly apply windscreen damage if front bumper is `damaged`
                 if (m_damageManager.GetPanelStatus(ePanels::FRONT_BUMPER) >= DAMSTATE_DAMAGED && m_fMass * 0.2f < calcDmgIntensity) {
-                    ApplyDamageToComponent(tComponent::COMPONENT_WINDSCREEN);
+                    ApplyDamageToComponent(tComponent::PANEL_WINDSCREEN);
                 }
                 break;
             }
             case eVehicleCollisionComponent::BUMP_REAR: {
-                ApplyDamageToComponent(tComponent::COMPONENT_BUMP_REAR);
+                ApplyDamageToComponent(tComponent::PANEL_REAR_BUMPER);
 
                 const auto localDir = GetCollisionPointLocalDirection();
 
                 // If this is a van possibly apply damage to the rear doors
                 if (vehicleFlags.bIsVan && m_fMass * 0.35f < calcDmgIntensity) {
                     if (localDir > 0.1f) { // [-90, -85] deg
-                        ApplyDamageToComponent(tComponent::COMPONENT_DOOR_RR);
+                        ApplyDamageToComponent(tComponent::DOOR_REAR_RIGHT);
                     } else if (localDir < -0.1f) { // [-95, -90]
-                        ApplyDamageToComponent(tComponent::COMPONENT_DOOR_LR);
+                        ApplyDamageToComponent(tComponent::DOOR_REAR_LEFT);
                     }
                 }
 
                 // Possibly apply damage to boot if not already damaged
                 if (m_damageManager.GetPanelStatus(ePanels::REAR_BUMPER) < DAMSTATE_DAMAGED) {
-                    ApplyDamageToComponent(tComponent::COMPONENT_BOOT);
+                    ApplyDamageToComponent(tComponent::DOOR_BOOT);
                 }
 
 
                 break;
             }
             case eVehicleCollisionComponent::DOOR_LF:
-                ApplyDamageToComponent(tComponent::COMPONENT_DOOR_LF);
+                ApplyDamageToComponent(tComponent::DOOR_FRONT_LEFT);
                 break;
             case eVehicleCollisionComponent::DOOR_RF:
-                ApplyDamageToComponent(tComponent::COMPONENT_DOOR_RF);
+                ApplyDamageToComponent(tComponent::DOOR_FRONT_RIGHT);
                 break;
             case eVehicleCollisionComponent::DOOR_LR:
-                ApplyDamageToComponent(tComponent::COMPONENT_DOOR_LR);
+                ApplyDamageToComponent(tComponent::DOOR_REAR_LEFT);
                 break;
             case eVehicleCollisionComponent::DOOR_RR:
-                ApplyDamageToComponent(tComponent::COMPONENT_DOOR_RR);
+                ApplyDamageToComponent(tComponent::DOOR_REAR_RIGHT);
                 break;
             case eVehicleCollisionComponent::WING_LF:
-                ApplyDamageToComponent(tComponent::COMPONENT_WING_LF);
+                ApplyDamageToComponent(tComponent::PANEL_FRONT_LEFT);
                 break;
             case eVehicleCollisionComponent::WING_RF:
-                ApplyDamageToComponent(tComponent::COMPONENT_WING_RF);
+                ApplyDamageToComponent(tComponent::PANEL_FRONT_RIGHT);
                 break;
             case eVehicleCollisionComponent::WINDSCREEN:
-                ApplyDamageToComponent(tComponent::COMPONENT_WINDSCREEN);
+                ApplyDamageToComponent(tComponent::PANEL_WINDSCREEN);
                 break;
             case eVehicleCollisionComponent::DEFAULT:
             case eVehicleCollisionComponent::WING_LR:
@@ -4196,8 +4196,8 @@ void CAutomobile::ProcessAutoBusDoors() {
     if (m_nBusDoorTimerEnd <= CTimer::GetTimeInMS()) {
         if (m_nBusDoorTimerStart) {
             static constexpr struct { eDoors door; tComponent comp; uint32 flagMask; } doors[]{
-                { eDoors::DOOR_LEFT_FRONT,  tComponent::COMPONENT_DOOR_RR, 1 }, // TODO: `COMPONENT_DOOR_RR` doesn't match up with `DOOR_LEFT_FRONT`
-                { eDoors::DOOR_RIGHT_FRONT, tComponent::COMPONENT_DOOR_RF, 4 }
+                { eDoors::DOOR_LEFT_FRONT,  tComponent::DOOR_REAR_RIGHT, 1 }, // TODO: `tComponent::DOOR_REAR_RIGHT` doesn't match up with `DOOR_LEFT_FRONT`
+                { eDoors::DOOR_RIGHT_FRONT, tComponent::DOOR_FRONT_RIGHT, 4 }
             };
 
             for (auto&& [door, comp, flagMask] : doors) {
@@ -4212,7 +4212,7 @@ void CAutomobile::ProcessAutoBusDoors() {
     } else if (m_nBusDoorTimerEnd && CTimer::GetTimeInMS() > m_nBusDoorTimerEnd - 500) {
         if (!IsDoorMissing(eDoors::DOOR_LEFT_FRONT) && (m_nGettingInFlags & 1)) {
             const auto OpenThisDoor = [this](float ratio) {
-                OpenDoor(nullptr, COMPONENT_DOOR_RR, DOOR_LEFT_FRONT, ratio, true); // TODO: `COMPONENT_DOOR_RR` doesn't match up with `DOOR_LEFT_FRONT`
+                OpenDoor(nullptr, tComponent::DOOR_REAR_RIGHT, DOOR_LEFT_FRONT, ratio, true); // TODO: `tComponent::DOOR_REAR_RIGHT` doesn't match up with `DOOR_LEFT_FRONT`
             };
 
             if (IsDoorClosed(eDoors::DOOR_LEFT_FRONT)) {
@@ -4227,7 +4227,7 @@ void CAutomobile::ProcessAutoBusDoors() {
             if (IsDoorClosed(eDoors::DOOR_RIGHT_FRONT)) {
                 m_nBusDoorTimerEnd = CTimer::GetTimeInMS();
             }
-            OpenDoor(nullptr, COMPONENT_DOOR_RF, DOOR_RIGHT_FRONT, 0.f, true);
+            OpenDoor(nullptr, tComponent::DOOR_FRONT_RIGHT, DOOR_RIGHT_FRONT, 0.f, true);
         }
     }
 }
@@ -4506,14 +4506,14 @@ void CAutomobile::CloseAllDoors() {
     };
 
     assert(mi.m_nNumDoors > 0);
-    CloseDoor(tComponent::COMPONENT_DOOR_RR, eDoors::DOOR_LEFT_FRONT); // TODO: Again, enums dont seem to match up..
+    CloseDoor(tComponent::DOOR_REAR_RIGHT, eDoors::DOOR_LEFT_FRONT); // TODO: Again, enums dont seem to match up..
     if (mi.m_nNumDoors > 1) {
-        CloseDoor(tComponent::COMPONENT_DOOR_RF, eDoors::DOOR_RIGHT_FRONT);
+        CloseDoor(tComponent::DOOR_FRONT_RIGHT, eDoors::DOOR_RIGHT_FRONT);
         if (mi.m_nNumDoors > 2) {
             assert(mi.m_nNumDoors == 4); // Pirulax: May assert, I'm not sure. Let me know if it did.
 
-            CloseDoor(tComponent::COMPONENT_WING_LF, eDoors::DOOR_LEFT_REAR); // TODO: Enums dont match at all..
-            CloseDoor(tComponent::COMPONENT_DOOR_LR, eDoors::DOOR_RIGHT_REAR);
+            CloseDoor(tComponent::PANEL_FRONT_LEFT, eDoors::DOOR_LEFT_REAR); // TODO: Enums dont match at all..
+            CloseDoor(tComponent::DOOR_REAR_LEFT, eDoors::DOOR_RIGHT_REAR);
         }
     }
 }

--- a/source/game_sa/Entity/Vehicle/Enums/HeliNodes.h
+++ b/source/game_sa/Entity/Vehicle/Enums/HeliNodes.h
@@ -1,0 +1,28 @@
+#pragma once
+
+enum eHeliNodes {
+    HELI_NODE_NONE     = 0,
+    HELI_CHASSIS       = 1,
+    HELI_WHEEL_RF      = 2,
+    HELI_WHEEL_RM      = 3,
+    HELI_WHEEL_RB      = 4,
+    HELI_WHEEL_LF      = 5,
+    HELI_WHEEL_LM      = 6,
+    HELI_WHEEL_LB      = 7,
+    HELI_DOOR_RF       = 8,
+    HELI_DOOR_RR       = 9,
+    HELI_DOOR_LF       = 10,
+    HELI_DOOR_LR       = 11,
+    HELI_STATIC_ROTOR  = 12,
+    HELI_MOVING_ROTOR  = 13,
+    HELI_STATIC_ROTOR2 = 14,
+    HELI_MOVING_ROTOR2 = 15,
+    HELI_RUDDER        = 16,
+    HELI_ELEVATORS     = 17,
+    HELI_MISC_A        = 18,
+    HELI_MISC_B        = 19,
+    HELI_MISC_C        = 20,
+    HELI_MISC_D        = 21,
+
+    HELI_NUM_NODES
+};

--- a/source/game_sa/Entity/Vehicle/Heli.h
+++ b/source/game_sa/Entity/Vehicle/Heli.h
@@ -7,33 +7,7 @@
 #pragma once
 
 #include "Automobile.h"
-
-enum eHeliNodes {
-    HELI_NODE_NONE     = 0,
-    HELI_CHASSIS       = 1,
-    HELI_WHEEL_RF      = 2,
-    HELI_WHEEL_RM      = 3,
-    HELI_WHEEL_RB      = 4,
-    HELI_WHEEL_LF      = 5,
-    HELI_WHEEL_LM      = 6,
-    HELI_WHEEL_LB      = 7,
-    HELI_DOOR_RF       = 8,
-    HELI_DOOR_RR       = 9,
-    HELI_DOOR_LF       = 10,
-    HELI_DOOR_LR       = 11,
-    HELI_STATIC_ROTOR  = 12,
-    HELI_MOVING_ROTOR  = 13,
-    HELI_STATIC_ROTOR2 = 14,
-    HELI_MOVING_ROTOR2 = 15,
-    HELI_RUDDER        = 16,
-    HELI_ELEVATORS     = 17,
-    HELI_MISC_A        = 18,
-    HELI_MISC_B        = 19,
-    HELI_MISC_C        = 20,
-    HELI_MISC_D        = 21,
-
-    HELI_NUM_NODES
-};
+#include "Enums/HeliNodes.h"
 
 struct tHeliLight {
     CVector m_vecOrigin;

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -693,10 +693,10 @@ void CVehicle::ProcessOpenDoor(CPed* ped, uint32 doorComponentId_, uint32 animGr
     auto doorComponentId = (int32)doorComponentId_; // silence warns, todo: OpenDoor receives int32, why?
     eDoors iCheckedDoor = [&] {
         switch (doorComponentId) {
-        case COMPONENT_DOOR_RF: return DOOR_RIGHT_FRONT;
-        case COMPONENT_DOOR_LR: return DOOR_RIGHT_REAR;
-        case COMPONENT_DOOR_RR: return DOOR_LEFT_FRONT;
-        case COMPONENT_WING_LF: return DOOR_LEFT_REAR;
+        case tComponent::DOOR_FRONT_RIGHT: return DOOR_RIGHT_FRONT;
+        case tComponent::DOOR_REAR_LEFT: return DOOR_RIGHT_REAR;
+        case tComponent::DOOR_REAR_RIGHT: return DOOR_LEFT_FRONT;
+        case tComponent::PANEL_FRONT_LEFT: return DOOR_LEFT_REAR;
         default:
             assert(false); // Shouldn't get here
             return static_cast<eDoors>(fTime);

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -691,15 +691,13 @@ void CVehicle::RemoveLighting(bool bRemove) {
 // 0x6D56C0
 void CVehicle::ProcessOpenDoor(CPed* ped, uint32 doorComponentId_, uint32 animGroup, uint32 animId, float fTime) {
     auto doorComponentId = (int32)doorComponentId_; // silence warns, todo: OpenDoor receives int32, why?
-    eDoors iCheckedDoor = [&] {
+    eDoors iCheckedDoor    = [&] {
         switch (doorComponentId) {
-        case tComponent::DOOR_FRONT_RIGHT: return DOOR_RIGHT_FRONT;
-        case tComponent::DOOR_REAR_LEFT: return DOOR_RIGHT_REAR;
-        case tComponent::DOOR_REAR_RIGHT: return DOOR_LEFT_FRONT;
-        case tComponent::PANEL_FRONT_LEFT: return DOOR_LEFT_REAR;
-        default:
-            assert(false); // Shouldn't get here
-            return static_cast<eDoors>(fTime);
+        case CAR_DOOR_RF: return DOOR_RIGHT_FRONT;
+        case CAR_DOOR_RR: return DOOR_RIGHT_REAR;
+        case CAR_DOOR_LF: return DOOR_LEFT_FRONT;
+        case CAR_DOOR_LR: return DOOR_LEFT_REAR;
+        default:          NOTSA_UNREACHABLE();
         }
     }();
 

--- a/source/game_sa/Enums/eCarNodes.h
+++ b/source/game_sa/Enums/eCarNodes.h
@@ -2,17 +2,21 @@
 
 enum eCarNodes {
     CAR_NODE_NONE  = 0,
+
     CAR_CHASSIS    = 1,
+
     CAR_WHEEL_RF   = 2,
     CAR_WHEEL_RM   = 3,
     CAR_WHEEL_RB   = 4,
     CAR_WHEEL_LF   = 5,
     CAR_WHEEL_LM   = 6,
     CAR_WHEEL_LB   = 7,
+
     CAR_DOOR_RF    = 8,  // Right Front
     CAR_DOOR_RR    = 9,  // Right Rear
     CAR_DOOR_LF    = 10, // Left Front
     CAR_DOOR_LR    = 11, // Left Rear
+
     CAR_BUMP_FRONT = 12,
     CAR_BUMP_REAR  = 13,
     CAR_WING_RF    = 14,
@@ -21,6 +25,7 @@ enum eCarNodes {
     CAR_BOOT       = 17,
     CAR_WINDSCREEN = 18,
     CAR_EXHAUST    = 19,
+    
     CAR_MISC_A     = 20,
     CAR_MISC_B     = 21,
     CAR_MISC_C     = 22,


### PR DESCRIPTION
Fixes #1252 - Should test though, I'm not sure :D 

I've refactored the code to completely get rid of `GetComponentGroup` and `tComponentGroup`, as they were only used by this function in a very convoluted way... New implementation is more flexible and easier to understand.