### PR TITLE
fix(Ped): Use eBoneTagU32 in `GetTransformedBonePosition`

### DIFF
--- a/source/game_sa/Entity/Ped/Ped.cpp
+++ b/source/game_sa/Entity/Ped/Ped.cpp
@@ -2098,7 +2098,7 @@ void CPed::GetBonePosition(CVector* outVec, eBoneTag bone, bool updateSkinBones)
 * @param [in,out] inOutPos The position to be transformed in-place.
 * @param          updateSkinBones If `UpdateRpHAnim` should be called
 */
-void CPed::GetTransformedBonePosition(RwV3d& inOutPos, eBoneTag bone, bool updateSkinBones) { // todo: fix this too!!!
+void CPed::GetTransformedBonePosition(RwV3d& inOutPos, eBoneTagU32 bone, bool updateSkinBones) { // todo: fix this too!!!
     // Pretty much the same as GetBonePosition..
     if (updateSkinBones) {
         if (!bCalledPreRender) {

--- a/source/game_sa/Entity/Ped/Ped.h
+++ b/source/game_sa/Entity/Ped/Ped.h
@@ -428,7 +428,7 @@ public:
     bool IsAlive() const;
     void UpdateStatEnteringVehicle();
     void UpdateStatLeavingVehicle();
-    void GetTransformedBonePosition(RwV3d& inOutPos, eBoneTag boneId, bool updateSkinBones = false);
+    void GetTransformedBonePosition(RwV3d& inOutPos, eBoneTagU32 boneId, bool updateSkinBones = false);
     void ReleaseCoverPoint();
     CTaskSimpleHoldEntity* GetHoldingTask();
     CEntity* GetEntityThatThisPedIsHolding();

--- a/source/game_sa/Enums/eBoneTag.h
+++ b/source/game_sa/Enums/eBoneTag.h
@@ -56,3 +56,4 @@ enum eBoneTag : int16 {
 
 using eBoneTag16 = notsa::WEnumS16<eBoneTag>;
 using eBoneTag32 = notsa::WEnumS32<eBoneTag>;
+using eBoneTagu32 = notsa::WEnumU32<eBoneTag>;

--- a/source/game_sa/Enums/eBoneTag.h
+++ b/source/game_sa/Enums/eBoneTag.h
@@ -56,4 +56,4 @@ enum eBoneTag : int16 {
 
 using eBoneTag16 = notsa::WEnumS16<eBoneTag>;
 using eBoneTag32 = notsa::WEnumS32<eBoneTag>;
-using eBoneTagu32 = notsa::WEnumU32<eBoneTag>;
+using eBoneTagU32 = notsa::WEnumU32<eBoneTag>;


### PR DESCRIPTION
Fix: #1344 

Implement eBoneTagU32 in enum `eBoneTag`