### PR TITLE
Add separate getters for accessing `RpClump`, `RpAtomic` or `RwObject` instead of accessing member fields directly

### DIFF
--- a/source/game_sa/BreakObject_c.cpp
+++ b/source/game_sa/BreakObject_c.cpp
@@ -31,12 +31,12 @@ bool BreakObject_c::Init(CObject* object, const CVector* velocity, float fVeloci
     if (!object->GetRwObject() || RwObjectGetType(object->GetRwObject()) != rpATOMIC)
         return false;
 
-    auto* info = BREAKABLEPLG(RpAtomicGetGeometry(object->m_pRwAtomic), m_pBreakableInfo);
+    auto* info = BREAKABLEPLG(RpAtomicGetGeometry(object->GetRpAtomic()), m_pBreakableInfo);
     if (!info)
         return false;
 
     SetBreakInfo(info, bJustFaces);
-    auto ltm = RwFrameGetLTM(RpAtomicGetFrame(object->m_pRwAtomic));
+    auto ltm = RwFrameGetLTM(RpAtomicGetFrame(object->GetRpAtomic()));
     SetGroupData(ltm, velocity, fVelocityRand);
 
     m_JustFaces = bJustFaces;

--- a/source/game_sa/BulletInfo.cpp
+++ b/source/game_sa/BulletInfo.cpp
@@ -110,9 +110,9 @@ void CBulletInfo::Update() {
                     g_fx.AddBlood(colPoint.m_vecPoint, colPoint.m_vecNormal, 8, hitPed->m_fContactSurfaceBrightness);
                     // std::cout << "Create blood\n";
                     if (hitPed->m_nPedState == PEDSTATE_DEAD) {
-                        const auto anim = RpAnimBlendClumpGetFirstAssociation(hitPed->m_pRwClump, ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
+                        const auto anim = RpAnimBlendClumpGetFirstAssociation(hitPed->GetRpClump(), ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
 
-                        if (auto assoc = CAnimManager::BlendAnimation(hitPed->m_pRwClump, ANIM_GROUP_DEFAULT, anim, 8.0f)) {
+                        if (auto assoc = CAnimManager::BlendAnimation(hitPed->GetRpClump(), ANIM_GROUP_DEFAULT, anim, 8.0f)) {
                             assoc->SetCurrentTime(0.0f);
                             assoc->SetFlag(ANIMATION_IS_FINISH_AUTO_REMOVE, false);
                             // std::cout << "Blood anim\n";

--- a/source/game_sa/Cam.cpp
+++ b/source/game_sa/Cam.cpp
@@ -396,7 +396,7 @@ void CCam::Process_1rstPersonPedOnPC(const CVector& target, float orientation, f
         return;
     }
 
-    const auto hier = GetAnimHierarchyFromSkinClump(m_pCamTargetEntity->m_pRwClump);
+    const auto hier = GetAnimHierarchyFromSkinClump(m_pCamTargetEntity->GetRpClump());
     const auto aIdx = RpHAnimIDGetIndex(hier, ConvertPedNode2BoneTag(2)); // todo: enum
     auto&      aMat = RpHAnimHierarchyGetMatrixArray(hier)[aIdx];
     auto*      targetPed = m_pCamTargetEntity->AsPed();

--- a/source/game_sa/CarEnterExit.cpp
+++ b/source/game_sa/CarEnterExit.cpp
@@ -69,7 +69,7 @@ void CCarEnterExit::AddInCarAnim(const CVehicle* vehicle, CPed* ped, bool bAsDri
             return { ANIM_GROUP_DEFAULT, ANIM_ID_CAR_SITP };
         }
     }();
-    CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 1000.f);
+    CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 1000.f);
     ped->StopNonPartialAnims();
 }
 
@@ -609,8 +609,8 @@ void CCarEnterExit::MakeUndraggedPassengerPedsLeaveCar(const CVehicle* targetVeh
 void CCarEnterExit::QuitEnteringCar(CPed* ped, CVehicle* vehicle, int32 doorId, bool bCarWasBeingJacked) {
     RemoveGetInAnims(ped);
     ped->RestartNonPartialAnims();
-    if (!RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE)) {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
+    if (!RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE)) {
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
     }
 
     if (bCarWasBeingJacked) {
@@ -651,16 +651,16 @@ void CCarEnterExit::QuitEnteringCar(CPed* ped, CVehicle* vehicle, int32 doorId, 
 
 // 0x64F680
 void CCarEnterExit::RemoveCarSitAnim(const CPed* ped) {
-    for (auto anim = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_SECONDARY_TASK_ANIM); anim; anim = RpAnimBlendGetNextAssociation(anim, ANIMATION_SECONDARY_TASK_ANIM)) {
+    for (auto anim = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_SECONDARY_TASK_ANIM); anim; anim = RpAnimBlendGetNextAssociation(anim, ANIMATION_SECONDARY_TASK_ANIM)) {
         anim->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE);
         anim->m_BlendDelta = -1000.f;
     }
-    CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0);
+    CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0);
 }
 
 // 0x64F6E0
 void CCarEnterExit::RemoveGetInAnims(const CPed* ped) {
-    for (auto anim = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_PARTIAL); anim; anim = RpAnimBlendGetNextAssociation(anim, ANIMATION_IS_PARTIAL)) {
+    for (auto anim = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_PARTIAL); anim; anim = RpAnimBlendGetNextAssociation(anim, ANIMATION_IS_PARTIAL)) {
         anim->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE);
         anim->m_BlendDelta = -1000.f;
     }

--- a/source/game_sa/CarGenerator.cpp
+++ b/source/game_sa/CarGenerator.cpp
@@ -331,7 +331,7 @@ void CCarGenerator::DoInternalProcessing()
         m_nPrimaryColor = vehicle->m_nPrimaryColor;
         m_nSecondaryColor = vehicle->m_nSecondaryColor;
     }
-    CVisibilityPlugins::SetClumpAlpha(vehicle->m_pRwClump, 0);
+    CVisibilityPlugins::SetClumpAlpha(vehicle->GetRpClump(), 0);
     m_nVehicleHandle = GetVehiclePool()->GetRef(vehicle);
 
     // Originally, R* did a signed comparison between unsigned m_nGenerateCount and signed 32bit constant -1.

--- a/source/game_sa/Clothes.cpp
+++ b/source/game_sa/Clothes.cpp
@@ -192,7 +192,7 @@ void CClothes::RebuildPlayerIfNeeded(CPlayerPed* player) {
 
 // 0x5A82C0
 void CClothes::RebuildPlayer(CPlayerPed* player, bool bIgnoreFatAndMuscle) {
-    auto assoc = RpAnimBlendClumpExtractAssociations(player->m_pRwClump);
+    auto assoc = RpAnimBlendClumpExtractAssociations(player->GetRpClump());
     auto task = player->GetIntelligence()->GetTaskManager().GetTaskSecondary(TASK_SECONDARY_IK);
     if (task)
         task->MakeAbortable(player, ABORT_PRIORITY_IMMEDIATE, nullptr);
@@ -206,7 +206,7 @@ void CClothes::RebuildPlayer(CPlayerPed* player, bool bIgnoreFatAndMuscle) {
 
     ConstructPedModel(player->GetModelIndex(), *player->GetPlayerData()->m_pPedClothesDesc, &PlayerClothes, 0);
     player->Dress();
-    RpAnimBlendClumpGiveAssociations(player->m_pRwClump, assoc);
+    RpAnimBlendClumpGiveAssociations(player->GetRpClump(), assoc);
     PlayerClothes = *player->GetPlayerData()->m_pPedClothesDesc;
 }
 

--- a/source/game_sa/Clothes.cpp
+++ b/source/game_sa/Clothes.cpp
@@ -147,7 +147,7 @@ void CClothes::ConstructPedModel(uint32 modelId, CPedClothesDesc& newClothes, co
 
     auto modelInfo = CModelInfo::GetModelInfo(modelId)->AsPedModelInfoPtr();
     auto txd = CTxdStore::ms_pTxdPool->GetAt(modelInfo->m_nTxdIndex);
-    auto skinnedClump = CClothesBuilder::CreateSkinnedClump(modelInfo->m_pRwClump, txd->m_pRwDictionary, newClothes, oldClothes, bCutscenePlayer);
+    auto skinnedClump = CClothesBuilder::CreateSkinnedClump(modelInfo->GetRpClump(), txd->m_pRwDictionary, newClothes, oldClothes, bCutscenePlayer);
     if (skinnedClump) {
         RequestMotionGroupAnims();
         modelInfo->AddTexDictionaryRef();

--- a/source/game_sa/ClothesBuilder.cpp
+++ b/source/game_sa/ClothesBuilder.cpp
@@ -281,8 +281,8 @@ void CClothesBuilder::ConstructGeometryArray(RpGeometry** out, uint32* modelName
             CStreaming::LoadRequestedModels();
         }
 
-        *out = BlendGeometry(mi->m_pRwClump, "normal", "fat", "ripped", normal, fatness, strength);
-        StoreBoneArray(mi->m_pRwClump, i);
+        *out = BlendGeometry(mi->GetRpClump(), "normal", "fat", "ripped", normal, fatness, strength);
+        StoreBoneArray(mi->GetRpClump(), i);
         CStreaming::RemoveModel(modelIdx);
     }
 }

--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -2372,7 +2372,7 @@ float GetNearestDistanceOfPedSphereToCameraNearClip(CPed* ped) {
     const auto mi = ped->GetPedModelInfo();
 
     // Calculate hit colmodel
-    mi->AnimatePedColModelSkinnedWorld(ped->m_pRwClump);
+    mi->AnimatePedColModelSkinnedWorld(ped->GetRpClump());
     const auto hitCM = mi->m_pHitColModel;
     assert(hitCM->GetData()->m_nNumSpheres == 12); // In theory it should have 12 spheres
 

--- a/source/game_sa/CutsceneMgr.cpp
+++ b/source/game_sa/CutsceneMgr.cpp
@@ -111,9 +111,9 @@ CCutsceneObject* CCutsceneMgr::CreateCutsceneObject(eModelID modelId) {
 
     // Create col model for it (If cutscene object)
     if (IsModelIDForCutScene(modelId)) {
-        const auto mi = CModelInfo::GetModelInfo(modelId);
+        const auto mi = static_cast<CClumpModelInfo*>(CModelInfo::GetModelInfo(modelId));
         mi->SetColModel(&CTempColModels::ms_colModelCutObj[modelId - MODEL_CUTOBJ01]);
-        UpdateCutsceneObjectBoundingBox(mi->m_pRwClump, modelId);
+        UpdateCutsceneObjectBoundingBox(mi->GetRpClump(), modelId);
     }
 
     // Actually create the object now

--- a/source/game_sa/CutsceneMgr.cpp
+++ b/source/game_sa/CutsceneMgr.cpp
@@ -44,19 +44,19 @@ void CCutsceneMgr::AppendToNextCutscene(const char* objectName, const char* anim
 // 0x5B0450
 void CCutsceneMgr::AttachObjectToBone(CCutsceneObject* attachment, CCutsceneObject* object, int32 boneId) {
     attachment->m_pAttachmentObject = object;
-    attachment->m_nAttachBone       = RpHAnimIDGetIndex(GetAnimHierarchyFromSkinClump(object->m_pRwClump), boneId);
+    attachment->m_nAttachBone       = RpHAnimIDGetIndex(GetAnimHierarchyFromSkinClump(object->GetRpClump()), boneId);
 }
 
 // 0x5B0480
 void CCutsceneMgr::AttachObjectToFrame(CCutsceneObject* attachment, CEntity* object, const char* frameName) {
     attachment->m_pAttachmentObject = nullptr;
-    attachment->m_pAttachToFrame    = RpAnimBlendClumpFindFrame(object->m_pRwClump, frameName)->Frame;
+    attachment->m_pAttachToFrame    = RpAnimBlendClumpFindFrame(object->GetRpClump(), frameName)->Frame;
 }
 
 // 0x5B04B0
 void CCutsceneMgr::AttachObjectToParent(CCutsceneObject* attachment, CEntity* object) {
     attachment->m_pAttachmentObject = nullptr;
-    attachment->m_pAttachToFrame    = RpClumpGetFrame(object->m_pRwClump);
+    attachment->m_pAttachToFrame    = RpClumpGetFrame(object->GetRpClump());
 }
 
 // 0x4D5E20
@@ -387,14 +387,14 @@ void CCutsceneMgr::LoadCutsceneData_loading() {
 
             // If it's a skinned object, we use bone indencies
             const auto csobj = ms_pCutsceneObjects[objIdx];
-            if (const auto atomic = GetFirstAtomic(csobj->m_pRwClump); atomic && RpSkinGeometryGetSkin(RpAtomicGetGeometry(atomic))) {
+            if (const auto atomic = GetFirstAtomic(csobj->GetRpClump()); atomic && RpSkinGeometryGetSkin(RpAtomicGetGeometry(atomic))) {
                 const auto nodeIdx = notsa::ston<uint32>({ csfx.m_szObjectPart }); // Obj Part is just an node index in this case
-                const auto hier = GetAnimHierarchyFromSkinClump(csobj->m_pRwClump);
+                const auto hier = GetAnimHierarchyFromSkinClump(csobj->GetRpClump());
                 return &RpHAnimHierarchyGetMatrixArray(hier)[RpHAnimIDGetIndex(hier, nodeIdx)];
             }
 
             // If not skinned, it's the name of a frame
-            if (const auto frame = CClumpModelInfo::GetFrameFromName(csobj->m_pRwClump, csfx.m_szObjectPart)) {
+            if (const auto frame = CClumpModelInfo::GetFrameFromName(csobj->GetRpClump(), csfx.m_szObjectPart)) {
                 return RwFrameGetMatrix(frame);
             } else {
                 NOTSA_LOG_DEBUG("Part(\"{}\") of object not found", csfx.m_szObjectPart);
@@ -892,7 +892,7 @@ void CCutsceneMgr::SetCutsceneAnim(const char* animName, CObject* object) {
     cpyOfTheAnim->SetFlag(ANIMATION_CAN_EXTRACT_VELOCITY, true);
     cpyOfTheAnim->Start(0.f);
 
-    const auto blendData = RpAnimBlendClumpGetData(object->m_pRwClump);
+    const auto blendData = RpAnimBlendClumpGetData(object->GetRpClump());
     blendData->m_AnimList.Prepend(&cpyOfTheAnim->m_Link);
 
     if (cpyOfTheAnim->m_BlendHier->m_bKeepCompressed) {
@@ -923,7 +923,7 @@ void CCutsceneMgr::SetupCutsceneToStart() {
             csobj->SetPosn(pos);
         };
 
-        if (const auto anim = RpAnimBlendClumpGetFirstAssociation(csobj->m_pRwClump)) {
+        if (const auto anim = RpAnimBlendClumpGetFirstAssociation(csobj->GetRpClump())) {
             if (csobj->m_pAttachToFrame) {
                 anim->SetFlag(ANIMATION_CAN_EXTRACT_VELOCITY, false);
                 anim->SetFlag(ANIMATION_IS_PLAYING, true);
@@ -1062,7 +1062,7 @@ void CCutsceneMgr::Update_overlay() {
         // Update cutscene specific model bounding boxes
         for (const auto csobj : ms_pCutsceneObjects | rngv::take(ms_numCutsceneObjs)) {
             if (IsModelIDForCutScene(csobj->GetModelId())) {
-                UpdateCutsceneObjectBoundingBox(csobj->m_pRwClump, csobj->GetModelId());
+                UpdateCutsceneObjectBoundingBox(csobj->GetRpClump(), csobj->GetModelId());
             }
         }
 

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -419,9 +419,9 @@ void CEntity::PreRender() {
     if (!mi->HasBeenPreRendered()) {
         mi->SetHasBeenPreRendered(true);
 
-        if (ami && ami->m_pRwObject) {
-            if (RpMatFXAtomicQueryEffects(ami->m_pRwAtomic) && RpAtomicGetGeometry(ami->m_pRwAtomic)) {
-                RpGeometryForAllMaterials(RpAtomicGetGeometry(ami->m_pRwAtomic), MaterialUpdateUVAnimCB, nullptr);
+        if (ami && ami->GetRwObject()) {
+            if (RpMatFXAtomicQueryEffects(ami->GetRpAtomic()) && RpAtomicGetGeometry(ami->GetRpAtomic())) {
+                RpGeometryForAllMaterials(RpAtomicGetGeometry(ami->GetRpAtomic()), MaterialUpdateUVAnimCB, nullptr);
             }
         }
 
@@ -429,9 +429,9 @@ void CEntity::PreRender() {
 
         // PC Only
         if (ami) {
-            CCustomBuildingDNPipeline::PreRenderUpdate(ami->m_pRwAtomic, false);
+            CCustomBuildingDNPipeline::PreRenderUpdate(ami->GetRpAtomic(), false);
         } else if (mi->GetModelType() == MODEL_INFO_CLUMP) {
-            CCustomBuildingDNPipeline::PreRenderUpdate(mi->m_pRwClump, false);
+            CCustomBuildingDNPipeline::PreRenderUpdate(static_cast<CClumpModelInfo*>(mi)->GetRpClump(), false);
         }
         // PC Only
     }

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -294,7 +294,7 @@ void CEntity::CreateRwObject() {
         if (CTagManager::IsTag(this)) {
             CTagManager::ResetAlpha(this);
         }
-        CCustomBuildingDNPipeline::PreRenderUpdate(m_pRwAtomic, true);
+        CCustomBuildingDNPipeline::PreRenderUpdate(GetRpAtomic(), true);
         break;
     case rpCLUMP:
         if (mi->bIsRoad) {
@@ -311,8 +311,8 @@ void CEntity::CreateRwObject() {
 
             // Synchronize LOD animation timing
             if (GetLod() && GetLod()->GetRwObject() && RwObjectGetType(GetLod()->GetRwObject()) == rpCLUMP) {
-                if (auto* pLodAssoc = RpAnimBlendClumpGetFirstAssociation(GetLod()->m_pRwClump)) {
-                    if (auto* pAssoc = RpAnimBlendClumpGetFirstAssociation(m_pRwClump)) {
+                if (auto* pLodAssoc = RpAnimBlendClumpGetFirstAssociation(GetLod()->GetRpClump())) {
+                    if (auto* pAssoc = RpAnimBlendClumpGetFirstAssociation(GetRpClump())) {
                         pAssoc->SetCurrentTime(pLodAssoc->m_CurrentTime);
                     }
                 }
@@ -327,7 +327,7 @@ void CEntity::CreateRwObject() {
     CreateEffects();
 
     // Determine lighting requirement
-    auto* usedAtomic = RwObjectGetType(GetRwObject()) == rpATOMIC ? m_pRwAtomic : GetFirstAtomic(m_pRwClump);
+    auto* usedAtomic = RwObjectGetType(GetRwObject()) == rpATOMIC ? GetRpAtomic() : GetFirstAtomic(GetRpClump());
 
     if (!CCustomBuildingRenderer::IsCBPCPipelineAttached(usedAtomic)) {
         m_bLightObject = true;
@@ -344,18 +344,18 @@ void CEntity::DeleteRwObject() {
 
     switch (RwObjectGetType(GetRwObject())) {
     case rpATOMIC:
-        if (auto* frame = RpAtomicGetFrame(m_pRwAtomic)) {
-            RpAtomicDestroy(m_pRwAtomic);
+        if (auto* frame = RpAtomicGetFrame(GetRpAtomic())) {
+            RpAtomicDestroy(GetRpAtomic());
             RwFrameDestroy(frame);
         }
         break;
     case rpCLUMP:
 #ifdef SA_SKINNED_PEDS
-        if (IsClumpSkinned(m_pRwClump)) {
-            RpClumpForAllAtomics(m_pRwClump, AtomicRemoveAnimFromSkinCB, nullptr);
+        if (IsClumpSkinned(GetRpClump())) {
+            RpClumpForAllAtomics(GetRpClump(), AtomicRemoveAnimFromSkinCB, nullptr);
         }
 #endif
-        RpClumpDestroy(m_pRwClump);
+        RpClumpDestroy(GetRpClump());
         break;
     }
 
@@ -419,7 +419,7 @@ void CEntity::PreRender() {
     if (!mi->HasBeenPreRendered()) {
         mi->SetHasBeenPreRendered(true);
 
-        if (ami && ami->GetRwObject()) {
+        if (ami && ami->GetRpAtomic()) {
             if (RpMatFXAtomicQueryEffects(ami->GetRpAtomic()) && RpAtomicGetGeometry(ami->GetRpAtomic())) {
                 RpGeometryForAllMaterials(RpAtomicGetGeometry(ami->GetRpAtomic()), MaterialUpdateUVAnimCB, nullptr);
             }
@@ -641,7 +641,7 @@ void CEntity::Render() {
     }
 
     if (RwObjectGetType(GetRwObject()) == rpATOMIC && CTagManager::IsTag(this)) {
-        CTagManager::RenderTagForPC(m_pRwAtomic);
+        CTagManager::RenderTagForPC(GetRpAtomic());
         return;
     }
 
@@ -656,9 +656,9 @@ void CEntity::Render() {
     m_bImBeingRendered = true;
 
     if (RwObjectGetType(GetRwObject()) == rpATOMIC) {
-        RpAtomicRender(m_pRwAtomic);
+        RpAtomicRender(GetRpAtomic());
     } else {
-        RpClumpRender(m_pRwClump);
+        RpClumpRender(GetRpClump());
     }
 
     CStreaming::RenderEntity(m_pStreamingLink);
@@ -709,9 +709,9 @@ void CEntity::UpdateRwFrame() {
 // Updates the bone matrices for a skinned (animated) clump
 // 0x532B20
 void CEntity::UpdateRpHAnim() {
-    if (const auto atomic = GetFirstAtomic(m_pRwClump)) {
+    if (const auto atomic = GetFirstAtomic(GetRpClump())) {
         if (RpSkinGeometryGetSkin(RpAtomicGetGeometry(atomic)) && !m_bDontUpdateHierarchy) {
-            RpHAnimHierarchyUpdateMatrices(GetAnimHierarchyFromSkinClump(m_pRwClump));
+            RpHAnimHierarchyUpdateMatrices(GetAnimHierarchyFromSkinClump(GetRpClump()));
         }
     }
 }
@@ -909,10 +909,10 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
 
     switch (RwObjectGetType(GetRwObject())) {
     case rpATOMIC:
-        RpGeometryForAllMaterials(RpAtomicGetGeometry(m_pRwAtomic), SetCompAlphaCB, (void*)alpha);
+        RpGeometryForAllMaterials(RpAtomicGetGeometry(GetRpAtomic()), SetCompAlphaCB, (void*)alpha);
         break;
     case rpCLUMP:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicAlpha, (void*)alpha);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicAlpha, (void*)alpha);
         break;
     }
 }
@@ -1565,7 +1565,7 @@ void CEntity::UpdateAnim() {
         return;
     }
 
-    if (!RpAnimBlendClumpGetFirstAssociation(m_pRwClump)) {
+    if (!RpAnimBlendClumpGetFirstAssociation(GetRpClump())) {
         return;
     }
 
@@ -1583,7 +1583,7 @@ void CEntity::UpdateAnim() {
         fStep = CTimer::GetTimeStepInSeconds();
     }
 
-    RpAnimBlendClumpUpdateAnimations(m_pRwClump, fStep, bOnScreen);
+    RpAnimBlendClumpUpdateAnimations(GetRpClump(), fStep, bOnScreen);
 }
 
 // Checks if the entity is currently visible on screen
@@ -2337,6 +2337,19 @@ void CEntity::UpdateRwMatrix() {
         m_matrix->UpdateRwMatrix(parentMatrix);
     } else {
         m_placement.UpdateRwMatrix(parentMatrix);
+    }
+}
+
+// notsa
+RpAtomic* CEntity::GetRpAtomicOrFirstAtomicOfClump() const noexcept {
+    const auto obj = GetRwObject();
+    if (!obj) {
+        return nullptr;
+    }
+    switch (const auto type = RwObjectGetType(obj)) {
+    case rpATOMIC: return GetRpAtomic();                /* If we're an atomic, use that */
+    case rpCLUMP:  return GetFirstAtomic(GetRpClump()); /* Otherwise use the first atomic of the clump */
+    default:       NOTSA_UNREACHABLE_CASE(type);        /* Invalid type */
     }
 }
 

--- a/source/game_sa/Entity/Entity.h
+++ b/source/game_sa/Entity/Entity.h
@@ -6,6 +6,9 @@
 */
 #pragma once
 
+#include <rwplcore.h> // RwObject, etc...
+#include <rpworld.h>  // RpAtomic, RpClump, etc...
+
 #include "Placeable.h"
 #include "Reference.h"
 #include "Rect.h"
@@ -35,6 +38,8 @@ class CDummy;
 class CPhysical;
 class CBaseModelInfo;
 
+struct RwObject;
+
 class NOTSA_EXPORT_VTABLE CEntity : public CPlaceable {
 public:
     struct CEntityInfo {
@@ -42,11 +47,10 @@ public:
         eEntityStatus m_nStatus : 5; // Mask: & 0xF8 = 248 (Remember: In the original code unless this was left shifted the value it's compared to has to be left shifted by 3!)
     };
 
-    union {
-        struct RwObject* m_pRwObject;
-        struct RpClump*  m_pRwClump;
-        struct RpAtomic* m_pRwAtomic;
-    };
+private:
+    RwObject* m_pRwObject; // Use `GetRwObject`/`GetRpClump`/`GetRpAtomic` to access
+
+public:
 
     union {
         struct {
@@ -187,7 +191,6 @@ public:
     virtual void SetModelIndexNoCreate(uint32 index);
     uint32 GetModelIndex() const { return m_nModelIndex; }
     auto GetModelId() const { return (eModelID)m_nModelIndex; } // NOTSA
-    RwObject* GetRwObject() const { return m_pRwObject; }
     virtual void CreateRwObject();
     void AttachToRwObject(RwObject* object, bool updateMatrix);
     void DetachFromRwObject();
@@ -294,6 +297,11 @@ public:
     RwMatrix* GetModellingMatrix();
 
     // NOTSA section
+
+    RwObject* GetRwObject() const noexcept { return m_pRwObject; }
+    RpClump*  GetRpClump()  const noexcept { assert(!m_pRwObject || RwObjectGetType(m_pRwObject) == rpCLUMP); return reinterpret_cast<RpClump*>(m_pRwObject); }
+    RpAtomic* GetRpAtomic() const noexcept { assert(!m_pRwObject || RwObjectGetType(m_pRwObject) == rpATOMIC); return reinterpret_cast<RpAtomic*>(m_pRwObject); }
+    RpAtomic* GetRpAtomicOrFirstAtomicOfClump() const noexcept;
 
     // Always returns a non-null value. In case there's no LOD object `this` is returned
     CEntity* FindLastLOD() noexcept;

--- a/source/game_sa/Entity/Object/CutsceneObject.cpp
+++ b/source/game_sa/Entity/Object/CutsceneObject.cpp
@@ -39,11 +39,11 @@ CCutsceneObject::CCutsceneObject() : CObject() {
 void CCutsceneObject::SetModelIndex(unsigned index) {
     CEntity::SetModelIndex(index);
     if (RwObjectGetType(GetRwObject()) == rpCLUMP) {
-        RpAnimBlendClumpInit(m_pRwClump);
-        auto* animData = RpAnimBlendClumpGetData(m_pRwClump);
+        RpAnimBlendClumpInit(GetRpClump());
+        auto* animData = RpAnimBlendClumpGetData(GetRpClump());
         animData->m_PedPosition = &m_vecMoveSpeed;
         animData->m_FrameDatas->HasZVelocity = true;
-        CCutsceneObject::SetupCarPipeAtomicsForClump(index, m_pRwClump);
+        CCutsceneObject::SetupCarPipeAtomicsForClump(index, GetRpClump());
     }
     GetModelInfo()->m_nAlpha = 0xFF;
 }
@@ -58,7 +58,7 @@ void CCutsceneObject::ProcessControl() {
     CPhysical::ProcessControl(); // exactly CPhysical
     if (m_pAttachToFrame) {
         if (m_pAttachmentObject) {
-            auto* hierarchy = GetAnimHierarchyFromClump(m_pAttachmentObject->m_pRwClump);
+            auto* hierarchy = GetAnimHierarchyFromClump(m_pAttachmentObject->GetRpClump());
             auto* matArr = RpHAnimHierarchyGetMatrixArray(hierarchy);
             const auto boneMat = CMatrix(&matArr[m_nAttachBone], false);
             *static_cast<CMatrix*>(m_matrix) = boneMat;
@@ -86,7 +86,7 @@ void CCutsceneObject::ProcessControl() {
 void CCutsceneObject::PreRender() {
     if (m_pAttachToFrame) {
         if (m_pAttachmentObject) {
-            auto* hierarchy = GetAnimHierarchyFromClump(m_pAttachmentObject->m_pRwClump);
+            auto* hierarchy = GetAnimHierarchyFromClump(m_pAttachmentObject->GetRpClump());
             auto* matArr = RpHAnimHierarchyGetMatrixArray(hierarchy);
             const auto boneMat = CMatrix(&matArr[m_nAttachBone], false);
             *static_cast<CMatrix*>(m_matrix) = boneMat;
@@ -97,10 +97,10 @@ void CCutsceneObject::PreRender() {
         }
 
         if (RwObjectGetType(GetRwObject()) == rpCLUMP) {
-            const auto* firstAtomic = GetFirstAtomic(m_pRwClump);
+            const auto* firstAtomic = GetFirstAtomic(GetRpClump());
             if (firstAtomic) {
                 if (RpSkinGeometryGetSkin(RpAtomicGetGeometry(firstAtomic))) {
-                    auto* animData = RpAnimBlendClumpGetData(m_pRwClump);
+                    auto* animData = RpAnimBlendClumpGetData(GetRpClump());
                     auto* morphTarget = RpGeometryGetMorphTarget(RpAtomicGetGeometry(firstAtomic), 0);
                     auto* sphere = RpMorphTargetGetBoundingSphere(morphTarget);
                     sphere->center = animData->m_FrameDatas[0].BonePos;
@@ -126,7 +126,7 @@ void CCutsceneObject::PreRender() {
     }
 
     if (m_nModelIndex == MODEL_CSPLAY) {
-        CPed::ShoulderBoneRotation(m_pRwClump);
+        CPed::ShoulderBoneRotation(GetRpClump());
         m_bDontUpdateHierarchy = true;
     }
 

--- a/source/game_sa/Entity/Object/HandObject.cpp
+++ b/source/game_sa/Entity/Object/HandObject.cpp
@@ -12,7 +12,7 @@ void CHandObject::InjectHooks()
 
 CHandObject::CHandObject(int32 handModelIndex, CPed* ped, bool bLeftHand) : CObject()
 {
-    auto* animHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
+    auto* animHierarchy = GetAnimHierarchyFromSkinClump(ped->GetRpClump());
     m_pPed = ped;
     ped->UpdateRpHAnim();
 
@@ -22,7 +22,7 @@ CHandObject::CHandObject(int32 handModelIndex, CPed* ped, bool bLeftHand) : CObj
         m_nBoneIndex = RpHAnimIDGetIndex(animHierarchy, eBoneTag::BONE_R_FORE_ARM);
 
     CEntity::SetModelIndex(handModelIndex);
-    RpAnimBlendClumpInit(m_pRwClump);
+    RpAnimBlendClumpInit(GetRpClump());
 
     auto* pedModelInfo = CModelInfo::GetModelInfo(ped->m_nModelIndex);
     auto* txd = CTxdStore::ms_pTxdPool->GetAt(pedModelInfo->m_nTxdIndex);
@@ -45,7 +45,7 @@ CHandObject::CHandObject(int32 handModelIndex, CPed* ped, bool bLeftHand) : CObj
 // 0x59EC40
 void CHandObject::ProcessControl()
 {
-    auto* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->m_pRwClump);
+    auto* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->GetRpClump());
     auto* matArr = RpHAnimHierarchyGetMatrixArray(animHierarchy);
     const auto boneMat = CMatrix(&matArr[m_nBoneIndex], false);
     *static_cast<CMatrix*>(m_matrix) = boneMat;
@@ -57,7 +57,7 @@ void CHandObject::ProcessControl()
 // 0x59ECD0
 void CHandObject::PreRender()
 {
-    auto* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->m_pRwClump);
+    auto* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->GetRpClump());
     m_pPed->UpdateRpHAnim();
     m_pPed->m_bDontUpdateHierarchy = true;
 
@@ -96,7 +96,7 @@ void CHandObject::PreRender()
 // 0x59EE80
 void CHandObject::Render()
 {
-    auto* firstAtomic = GetFirstAtomic(m_pRwClump);
+    auto* firstAtomic = GetFirstAtomic(GetRpClump());
     RpMaterialSetTexture(RpGeometryGetMaterial(RpAtomicGetGeometry(firstAtomic), 0), m_pTexture);
     CObject::Render();
 }

--- a/source/game_sa/Entity/Object/Object.cpp
+++ b/source/game_sa/Entity/Object/Object.cpp
@@ -107,13 +107,10 @@ CObject::CObject(CDummyObject* dummyObj) : CPhysical() {
     SetAreaCode(dummyObj->GetAreaCode());
     m_bRenderDamaged = dummyObj->m_bRenderDamaged;
 
-    if (GetRwObject()) {
-        auto* atomic = m_pRwAtomic;
-        if (RwObjectGetType(GetRwObject()) != rpATOMIC)
-            atomic = GetFirstAtomic(m_pRwClump);
-
-        if (!CCustomBuildingRenderer::IsCBPCPipelineAttached(atomic))
+    if (auto* const atomic = GetRpAtomicOrFirstAtomicOfClump()) {
+        if (!CCustomBuildingRenderer::IsCBPCPipelineAttached(atomic)) {
             m_bLightObject = true;
+        }
     }
 }
 
@@ -533,9 +530,9 @@ void CObject::PreRender() {
 
     if (GetRwObject() && RwObjectGetType(GetRwObject()) == rpCLUMP && objectFlags.bFadingIn)
     {
-        auto iAlpha = CVisibilityPlugins::GetClumpAlpha(m_pRwClump) - 16;
+        auto iAlpha = CVisibilityPlugins::GetClumpAlpha(GetRpClump()) - 16;
         iAlpha = std::max(0, iAlpha);
-        CVisibilityPlugins::SetClumpAlpha(m_pRwClump, iAlpha);
+        CVisibilityPlugins::SetClumpAlpha(GetRpClump(), iAlpha);
     }
 
     CEntity::PreRender();

--- a/source/game_sa/Entity/Ped/Ped.cpp
+++ b/source/game_sa/Entity/Ped/Ped.cpp
@@ -413,7 +413,7 @@ void CPed::SetMoveAnim() {
                 return ANIM_ID_WALK;
             };
 
-            if (const auto assoc = RpAnimBlendClumpGetAssociation(m_pRwClump, GetAnimId())) {
+            if (const auto assoc = RpAnimBlendClumpGetAssociation(GetRpClump(), GetAnimId())) {
                 DoUpdateMoveAnim(assoc);
             }
 
@@ -427,7 +427,7 @@ void CPed::SetMoveAnim() {
         case PEDMOVE_WALK:
         case PEDMOVE_RUN:
         case PEDMOVE_SPRINT: {
-            for (auto assoc = RpAnimBlendClumpGetFirstAssociation(m_pRwClump, ANIMATION_IS_PARTIAL); assoc; assoc = RpAnimBlendGetNextAssociation(assoc, ANIMATION_IS_PARTIAL)) {
+            for (auto assoc = RpAnimBlendClumpGetFirstAssociation(GetRpClump(), ANIMATION_IS_PARTIAL); assoc; assoc = RpAnimBlendGetNextAssociation(assoc, ANIMATION_IS_PARTIAL)) {
                 if ((assoc->m_Flags & ANIMATION_IS_FINISH_AUTO_REMOVE) == 0 && (assoc->m_Flags & ANIMATION_DONT_ADD_TO_PARTIAL_BLEND) == 0) {
                     assoc->m_BlendDelta = -2.f;
                     assoc->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE, true);
@@ -443,7 +443,7 @@ void CPed::SetMoveAnim() {
 
         // Do BlendAnimation and call `DoUpdateMoveAnim` afterwards
         const auto DoBlendAnim = [&, this](AssocGroupId grp, AnimationId animId, float blendDelta) {
-            if (const auto assoc = CAnimManager::BlendAnimation(m_pRwClump, grp, animId, blendDelta)) {
+            if (const auto assoc = CAnimManager::BlendAnimation(GetRpClump(), grp, animId, blendDelta)) {
                 DoUpdateMoveAnim(assoc);
             }
         };
@@ -619,11 +619,11 @@ void CPed::CreateDeadPedPickupCoors(CVector& pickupPos) {
 * @notsa
 */
 RpHAnimHierarchy& CPed::GetAnimHierarchy() const {
-    return *GetAnimHierarchyFromSkinClump(m_pRwClump);
+    return *GetAnimHierarchyFromSkinClump(GetRpClump());
 }
 
 CAnimBlendClumpData& CPed::GetAnimBlendData() const {
-    return *RpAnimBlendClumpGetData(m_pRwClump);
+    return *RpAnimBlendClumpGetData(GetRpClump());
 }
 
 /*!
@@ -720,7 +720,7 @@ void CPed::SetMoveAnimSpeed(CAnimBlendAssociation* association) {
 * @addr 0x5DED10
 */
 void CPed::StopNonPartialAnims() {
-    RpAnimBlendClumpForEachAssociation(m_pRwClump, [](CAnimBlendAssociation* a) {
+    RpAnimBlendClumpForEachAssociation(GetRpClump(), [](CAnimBlendAssociation* a) {
         if (!(a->m_Flags & ANIMATION_IS_PARTIAL)) {
             a->SetFlag(ANIMATION_IS_PLAYING, false);
         }
@@ -731,7 +731,7 @@ void CPed::StopNonPartialAnims() {
 * @addr 0x5DED50
 */
 void CPed::RestartNonPartialAnims() {
-    RpAnimBlendClumpForEachAssociation(m_pRwClump, [](CAnimBlendAssociation* a) {
+    RpAnimBlendClumpForEachAssociation(GetRpClump(), [](CAnimBlendAssociation* a) {
         if (!(a->m_Flags & ANIMATION_IS_PARTIAL)) {
             a->SetFlag(ANIMATION_IS_PLAYING, true);
         }
@@ -2218,7 +2218,7 @@ void CPed::DoFootLanded(bool leftFoot, uint8 arg1) {
 void CPed::PlayFootSteps() {
     return plugin::CallMethod<0x5E57F0>(this);
     // Below code is kinda working.. kinda. I'm too lazy to fix it, good luck future me!
-    /* auto& anim = *RpAnimBlendClumpGetFirstAssociation(m_pRwClump);
+    /* auto& anim = *RpAnimBlendClumpGetFirstAssociation(GetRpClump());
 
     const auto IsWalkRunSprintAnim = [&] {
         switch (anim.m_nAnimId) {
@@ -2921,14 +2921,14 @@ void CPed::PreRenderAfterTest()
     }
 
     if (GetModelId() == MODEL_PLAYER) {
-        ShoulderBoneRotation(m_pRwClump);
+        ShoulderBoneRotation(GetRpClump());
         m_bDontUpdateHierarchy = true;
     }
     float windMod{};
     const auto rainAffectsPlayer = IsPlayer() && CWindModifiers::FindWindModifier(GetPosition(), &windMod, &windMod) && !CCullZones::PlayerNoRain();
     const auto drivingOpenTopVeh = IsStateDriving() && IsInVehicle() && (m_pVehicle->IsBike() || m_pVehicle->IsAutomobile() && m_pVehicle->IsOpenTopCar());
 
-    const auto GetHierMatrix = [h = GetAnimHierarchyFromSkinClump(m_pRwClump)](AnimationId id) {
+    const auto GetHierMatrix = [h = GetAnimHierarchyFromSkinClump(GetRpClump())](AnimationId id) {
         return &RpHAnimHierarchyGetMatrixArray(h)[RpHAnimIDGetIndex(h, id)];
     };
 
@@ -3014,14 +3014,14 @@ void CPed::PreRenderAfterTest()
     ) {
         if (DistanceBetweenPoints(TheCamera.GetPosition(), GetPosition()) < 25.0f) {
             auto* const pedModelInfo = GetModelInfo()->AsPedModelInfoPtr();
-            pedModelInfo->AnimatePedColModelSkinnedWorld(m_pRwClump);
+            pedModelInfo->AnimatePedColModelSkinnedWorld(GetRpClump());
 
             if (const auto& s = FindPlayerSpeed(); std::abs(s.x) <= 0.05f
                 && std::abs(s.y) <= 0.05f
                 && !IsStateDying()
                 && !notsa::contains({ PEDSTATE_FALL, PEDSTATE_ATTACK, PEDSTATE_FIGHT }, m_nPedState)
                 && IsPedHeadAbovePos(0.3f)
-                && !RpAnimBlendClumpGetAssociation(m_pRwClump, ANIM_ID_IDLE_TIRED)
+                && !RpAnimBlendClumpGetAssociation(GetRpClump(), ANIM_ID_IDLE_TIRED)
             ) {
                 const auto* colData = pedModelInfo->GetColModel()->GetData();
                 for (const auto& sphere : colData->GetSpheres()) {
@@ -3215,7 +3215,7 @@ void CPed::DettachPedFromEntity(){
         break;
 
     default: {
-        CAnimManager::BlendAnimation(m_pRwClump, m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
+        CAnimManager::BlendAnimation(GetRpClump(), m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
         bIsStanding = true;
 
         // Restore old weapon if any
@@ -3531,7 +3531,7 @@ void CPed::RemoveWeaponAnims(int32 likeUnused, float blendDelta) {
 
     bool bFoundNotPartialAnim{};
     for (auto i = 0; i < 34; i++) { // TODO: Magic number `34`
-        if (const auto assoc = RpAnimBlendClumpGetAssociation(m_pRwClump, ANIM_ID_FIRE)) {
+        if (const auto assoc = RpAnimBlendClumpGetAssociation(GetRpClump(), ANIM_ID_FIRE)) {
             assoc->m_Flags |= ANIMATION_IS_BLEND_AUTO_REMOVE;
             if ((assoc->m_Flags & ANIMATION_IS_PARTIAL)) {
                 assoc->m_BlendDelta = blendDelta;
@@ -3542,7 +3542,7 @@ void CPed::RemoveWeaponAnims(int32 likeUnused, float blendDelta) {
     }
 
     if (bFoundNotPartialAnim) {
-        CAnimManager::BlendAnimation(m_pRwClump, m_nAnimGroup, ANIM_ID_IDLE, -blendDelta);
+        CAnimManager::BlendAnimation(GetRpClump(), m_nAnimGroup, ANIM_ID_IDLE, -blendDelta);
     }
 }
 
@@ -3638,7 +3638,7 @@ bool CPed::IsFollowerOfGroup(const CPedGroup& group) const {
 * @returns Bone transformation matrix into object space. To transform to world space ped's matrix must be used as well.
 */
 RwMatrix* CPed::GetBoneMatrix(eBoneTag bone) const {
-    if (const auto h = GetAnimHierarchyFromClump(m_pRwClump)) {
+    if (const auto h = GetAnimHierarchyFromClump(GetRpClump())) {
         return RpHAnimHierarchyGetNodeMatrix(h, bone);
     }
     return nullptr;
@@ -3655,8 +3655,8 @@ void CPed::SetModelIndex(uint32 modelIndex) {
 
     CEntity::SetModelIndex(modelIndex);
 
-    RpAnimBlendClumpInit(m_pRwClump);
-    RpAnimBlendClumpFillFrameArray(m_pRwClump, m_apBones.data());
+    RpAnimBlendClumpInit(GetRpClump());
+    RpAnimBlendClumpFillFrameArray(GetRpClump(), m_apBones.data());
 
     auto* mi = GetModelInfo()->AsPedModelInfoPtr();
 
@@ -3678,18 +3678,18 @@ void CPed::SetModelIndex(uint32 modelIndex) {
     m_nMoneyCount = GetRandomMoneyCount();
 
     m_nAnimGroup = mi->m_nAnimType;
-    CAnimManager::AddAnimation(m_pRwClump, m_nAnimGroup, ANIM_ID_IDLE);
+    CAnimManager::AddAnimation(GetRpClump(), m_nAnimGroup, ANIM_ID_IDLE);
 
     if (!CanUseTorsoWhenLooking()) {
         m_pedIK.bTorsoUsed = true;
     }
 
     // Deal with animation stuff once again
-    RpAnimBlendClumpGetData(m_pRwClump)->m_PedPosition = (CVector*)&m_vecAnimMovingShiftLocal;
+    RpAnimBlendClumpGetData(GetRpClump())->m_PedPosition = (CVector*)&m_vecAnimMovingShiftLocal;
 
     // Create hit col model
     if (!mi->m_pHitColModel) {
-        mi->CreateHitColModelSkinned(m_pRwClump);
+        mi->CreateHitColModelSkinned(GetRpClump());
     }
 
     // And finally update our rph anim
@@ -3877,7 +3877,7 @@ void CPed::RenderBigHead() const {
         return;
     }
 
-    auto hier = GetAnimHierarchyFromSkinClump(m_pRwClump);
+    auto hier = GetAnimHierarchyFromSkinClump(GetRpClump());
     auto* matrices = RpHAnimHierarchyGetMatrixArray(hier);
 
     const float scale = 3.0f;

--- a/source/game_sa/Entity/Ped/PlayerPed.cpp
+++ b/source/game_sa/Entity/Ped/PlayerPed.cpp
@@ -249,9 +249,9 @@ void CPlayerPed::ReApplyMoveAnims() {
         ANIM_ID_WALK_START
     };
     for (const AnimationId& id : anims) {
-        if (CAnimBlendAssociation* anim = RpAnimBlendClumpGetAssociation(m_pRwClump, id)) {
+        if (CAnimBlendAssociation* anim = RpAnimBlendClumpGetAssociation(GetRpClump(), id)) {
             if (anim->GetHashKey() != CAnimManager::GetAnimAssociation(m_nAnimGroup, id)->GetHashKey()) {
-                CAnimBlendAssociation* addedAnim = CAnimManager::AddAnimation(m_pRwClump, m_nAnimGroup, id);
+                CAnimBlendAssociation* addedAnim = CAnimManager::AddAnimation(GetRpClump(), m_nAnimGroup, id);
                 addedAnim->m_BlendDelta = anim->m_BlendDelta;
                 addedAnim->m_BlendAmount = anim->m_BlendAmount;
 
@@ -743,7 +743,7 @@ void CPlayerPed::MakeChangesForNewWeapon(eWeaponType weaponType) {
         GetPlayerData()->m_bFreeAiming = false;
 
 
-    if (auto anim = RpAnimBlendClumpGetAssociation(m_pRwClump, ANIM_ID_FIRE))
+    if (auto anim = RpAnimBlendClumpGetAssociation(GetRpClump(), ANIM_ID_FIRE))
         anim->m_Flags |= ANIMATION_IS_PLAYING & ANIMATION_IS_FINISH_AUTO_REMOVE;
 
     TheCamera.ClearPlayerWeaponMode();

--- a/source/game_sa/Entity/Vehicle/Automobile.cpp
+++ b/source/game_sa/Entity/Vehicle/Automobile.cpp
@@ -2337,7 +2337,7 @@ void CAutomobile::BlowUpCar_Impl(CEntity* dmgr, bool bDontShakeCam, bool bDontSp
     physicalFlags.bRenderScorched = true;
     m_nTimeWhenBlowedUp      = CTimer::GetTimeInMS();
 
-    CVisibilityPlugins::SetClumpForAllAtomicsFlag(m_pRwClump, eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES);
+    CVisibilityPlugins::SetClumpForAllAtomicsFlag(GetRpClump(), eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES);
     m_damageManager.FuckCarCompletely(false);
 
     const auto isRcShit = (bFixBugs || !bIsForCutScene)
@@ -2651,7 +2651,7 @@ void CAutomobile::Fix() {
     vehicleFlags.bIsDamaged = false;
 
     // Hide all DAM state atomics
-    RpClumpForAllAtomics(m_pRwClump, CVehicleModelInfo::HideAllComponentsAtomicCB, (void*)eAtomicComponentFlag::ATOMIC_DAMAGED);
+    RpClumpForAllAtomics(GetRpClump(), CVehicleModelInfo::HideAllComponentsAtomicCB, (void*)eAtomicComponentFlag::ATOMIC_DAMAGED);
 
     // Reset rotation of some nodes
     for (auto i = (size_t)CAR_DOOR_RF; i < (size_t)CAR_NUM_NODES; i++) {
@@ -3435,7 +3435,7 @@ bool CAutomobile::Load() {
 // 0x6A0770
 void CAutomobile::SetupModelNodes() {
     std::ranges::fill(m_aCarNodes, nullptr);
-    CClumpModelInfo::FillFrameArray(m_pRwClump, m_aCarNodes.data());
+    CClumpModelInfo::FillFrameArray(GetRpClump(), m_aCarNodes.data());
 }
 
 // 0x6A07A0

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -555,7 +555,7 @@ void CBike::SetModelIndex(uint32 index) {
 // 0x6B5960
 void CBike::SetupModelNodes() {
     std::ranges::fill(m_aBikeNodes, nullptr);
-    CClumpModelInfo::FillFrameArray(m_pRwClump, m_aBikeNodes.data());
+    CClumpModelInfo::FillFrameArray(GetRpClump(), m_aBikeNodes.data());
 }
 
 // 0x6B7080

--- a/source/game_sa/Entity/Vehicle/Bmx.cpp
+++ b/source/game_sa/Entity/Vehicle/Bmx.cpp
@@ -88,14 +88,14 @@ void CBmx::ProcessControl() {
         return;
     }
 
-    auto animBikeSprint = RpAnimBlendClumpGetAssociation(m_pDriver->m_pRwClump, ANIM_ID_BIKE_SPRINT);
+    auto animBikeSprint = RpAnimBlendClumpGetAssociation(m_pDriver->GetRpClump(), ANIM_ID_BIKE_SPRINT);
     bool isMountainBike = GetModelId() == MODEL_MTBIKE;
 
     if (animBikeSprint && animBikeSprint->GetBlendAmount() > 0.01f) {
         float mult         = isMountainBike ? MTB_SPRINT_LEANMULT : BMX_SPRINT_LEANMULT;
         m_fSprintLeanAngle = std::sin(animBikeSprint->GetCurrentTime() / animBikeSprint->GetHier()->GetTotalTime() * TWO_PI + BMX_SPRINT_LEANSTART) * animBikeSprint->GetBlendAmount() * mult;
     } else {
-        auto animBikePedal = RpAnimBlendClumpGetAssociation(m_pDriver->m_pRwClump, ANIM_ID_BIKE_PEDAL);
+        auto animBikePedal = RpAnimBlendClumpGetAssociation(m_pDriver->GetRpClump(), ANIM_ID_BIKE_PEDAL);
         if (animBikePedal && animBikePedal->GetBlendAmount() > 0.01f) {
             float mult = isMountainBike ? MTB_PEDAL_LEANMULT : BMX_PEDAL_LEANMULT;
             GetRideAnimData()->LeanAngle += std::sin(animBikePedal->GetCurrentTime() / animBikePedal->GetHier()->GetTotalTime() * TWO_PI + BMX_PEDAL_LEANSTART) * animBikePedal->GetBlendAmount() * mult;
@@ -150,7 +150,7 @@ void CBmx::BlowUpCar(CEntity* damager, bool bHideExplosion) {
 // 0x6C0590
 void CBmx::ProcessBunnyHop() {
     auto* anim = m_pDriver
-        ? RpAnimBlendClumpGetAssociation(m_pDriver->m_pRwClump, ANIM_ID_BIKE_BUNNYHOP)
+        ? RpAnimBlendClumpGetAssociation(m_pDriver->GetRpClump(), ANIM_ID_BIKE_BUNNYHOP)
         : nullptr;
 
     if (GetStatus() != STATUS_PLAYER || !m_pDriver || !m_pDriver->IsPlayer()) {
@@ -166,7 +166,7 @@ void CBmx::ProcessBunnyHop() {
 
     if (pad->IsLeftShoulder1Pressed() && !pad->DisablePlayerControls && m_fControlJump == 0.0f) {
         m_fControlJump += CTimer::GetTimeStep();
-        anim = CAnimManager::BlendAnimation(m_pDriver->m_pRwClump, m_RideAnimData.AnimGroup, ANIM_ID_BIKE_BUNNYHOP, 8.0f);
+        anim = CAnimManager::BlendAnimation(m_pDriver->GetRpClump(), m_RideAnimData.AnimGroup, ANIM_ID_BIKE_BUNNYHOP, 8.0f);
         if (anim) {
             anim->SetCurrentTime(0.0f);
             anim->SetFlag(ANIMATION_IS_PLAYING, false);

--- a/source/game_sa/Entity/Vehicle/Boat.cpp
+++ b/source/game_sa/Entity/Vehicle/Boat.cpp
@@ -138,7 +138,7 @@ CBoat::~CBoat() {
 // 0x6F01A0
 void CBoat::SetupModelNodes() {
     rng::fill(m_BoatNodes, nullptr);
-    CClumpModelInfo::FillFrameArray(m_pRwClump, m_BoatNodes.data());
+    CClumpModelInfo::FillFrameArray(GetRpClump(), m_BoatNodes.data());
 }
 
 // debug function
@@ -504,7 +504,7 @@ void CBoat::FillBoatList() {
 void CBoat::SetModelIndex(uint32 index) {
     CVehicle::SetModelIndex(index);
     rng::fill(m_BoatNodes, nullptr);
-    CClumpModelInfo::FillFrameArray(m_pRwClump, m_BoatNodes.data());
+    CClumpModelInfo::FillFrameArray(GetRpClump(), m_BoatNodes.data());
 }
 
 // 0x6F1770
@@ -1018,7 +1018,7 @@ void CBoat::BlowUpCar(CEntity* culprit, bool inACutscene) {
 
     physicalFlags.bRenderScorched = true;
     SetStatus(STATUS_WRECKED);
-    CVisibilityPlugins::SetClumpForAllAtomicsFlag(m_pRwClump, eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES_LOD);
+    CVisibilityPlugins::SetClumpForAllAtomicsFlag(GetRpClump(), eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES_LOD);
     m_vecMoveSpeed.z += 0.13F;
     m_fHealth = 0.0F;
     m_wBombTimer = 0;

--- a/source/game_sa/Entity/Vehicle/Plane.cpp
+++ b/source/game_sa/Entity/Vehicle/Plane.cpp
@@ -184,7 +184,7 @@ void CPlane::BlowUpCar(CEntity* damager, bool bHideExplosion) {
         // m_nType = m_nType & 7 | STATUS_WRECKED;
         physicalFlags.bRenderScorched = true;
         m_nTimeWhenBlowedUp = CTimer::GetTimeInMS();
-        CVisibilityPlugins::SetClumpForAllAtomicsFlag(m_pRwClump, eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES_LOD);
+        CVisibilityPlugins::SetClumpForAllAtomicsFlag(GetRpClump(), eAtomicComponentFlag::ATOMIC_PIPE_NO_EXTRA_PASSES_LOD);
         m_damageManager.FuckCarCompletely(false);
         if (m_nModelIndex != MODEL_RCBARON) {
             CAutomobile::SetBumperDamage(FRONT_BUMPER, false);

--- a/source/game_sa/Entity/Vehicle/QuadBike.cpp
+++ b/source/game_sa/Entity/Vehicle/QuadBike.cpp
@@ -57,7 +57,7 @@ void CQuadBike::Fix() {
         m_damageManager.SetDoorStatus(static_cast<eDoors>(i), eDoorStatus::DAMSTATE_NOTPRESENT);
     }
     vehicleFlags.bIsDamaged = false;
-    RpClumpForAllAtomics(m_pRwClump, CVehicleModelInfo::HideAllComponentsAtomicCB, (void*)2); // TODO Use RpAtomicVisibility::VISIBILITY_DAM instead of `2` here
+    RpClumpForAllAtomics(GetRpClump(), CVehicleModelInfo::HideAllComponentsAtomicCB, (void*)2); // TODO Use RpAtomicVisibility::VISIBILITY_DAM instead of `2` here
     for (auto i = 0; i < 4; i++) {
         m_damageManager.SetWheelStatus((eCarWheel)i, eCarWheelStatus::WHEEL_STATUS_OK);
     }

--- a/source/game_sa/Entity/Vehicle/Train.cpp
+++ b/source/game_sa/Entity/Vehicle/Train.cpp
@@ -136,7 +136,7 @@ CTrain::CTrain(int32 modelIndex, eVehicleCreatedBy createdBy) : CVehicle(created
 
 void CTrain::SetupModelNodes() {
     std::ranges::fill(m_aTrainNodes, nullptr);
-    CClumpModelInfo::FillFrameArray(m_pRwClump, m_aTrainNodes.data());
+    CClumpModelInfo::FillFrameArray(GetRpClump(), m_aTrainNodes.data());
 }
 
 // 0x6F7440

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -2447,7 +2447,7 @@ void CVehicle::RemoveReplacementUpgrade(int32 frameId) {
 
     CopyObjectsCB_TargetClump = m_pRwClump;
     RwFrameForAllObjects(
-        CClumpModelInfo::GetFrameFromId(GetModelInfo()->m_pRwClump, frameId),
+        CClumpModelInfo::GetFrameFromId(GetModelInfo()->GetRpClump(), frameId),
         CopyObjectsCB,
         frameOfUpgrade
     );

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -899,9 +899,9 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
     if (m_bOffscreen || !driver->IsPlayer())
         return;
 
-    auto* radioTuneAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_CAR_TUNE_RADIO);
+    auto* radioTuneAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_CAR_TUNE_RADIO);
     if (blend) {
-        radioTuneAnim = CAnimManager::BlendAnimation(driver->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CAR_TUNE_RADIO, 4.0F);
+        radioTuneAnim = CAnimManager::BlendAnimation(driver->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CAR_TUNE_RADIO, 4.0F);
     }
 
     if (radioTuneAnim)
@@ -929,14 +929,14 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
     }
 
     // 0x6DF620
-    auto* idleAnim      = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, usedAnims->idle);
-    auto* lookLeftAnim  = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, usedAnims->left);
-    auto* lookRightAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, usedAnims->right);
-    auto* lookBackAnim  = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, usedAnims->back);
+    auto* idleAnim      = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), usedAnims->idle);
+    auto* lookLeftAnim  = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), usedAnims->left);
+    auto* lookRightAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), usedAnims->right);
+    auto* lookBackAnim  = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), usedAnims->back);
 
     if (!idleAnim) {
-        if (RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_CAR_SIT)) {
-            CAnimManager::BlendAnimation(driver->m_pRwClump, ANIM_GROUP_DEFAULT, usedAnims->idle, 4.0F);
+        if (RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_CAR_SIT)) {
+            CAnimManager::BlendAnimation(driver->GetRpClump(), ANIM_GROUP_DEFAULT, usedAnims->idle, 4.0F);
         }
         return;
     }
@@ -952,10 +952,10 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
     }
 
     // 0x6DF6DA
-    auto* driveByAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_DRIVEBY_L);
-    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_DRIVEBY_R);
-    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_DRIVEBYL_L);
-    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->m_pRwClump, ANIM_ID_DRIVEBYL_R);
+    auto* driveByAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_DRIVEBY_L);
+    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_DRIVEBY_R);
+    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_DRIVEBYL_L);
+    if (!driveByAnim) driveByAnim = RpAnimBlendClumpGetAssociation(driver->GetRpClump(), ANIM_ID_DRIVEBYL_R);
 
     if (!vehicleFlags.bLowVehicle
         && m_GasPedal < 0.0F
@@ -967,7 +967,7 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
             || CCamera::GetActiveCamera().m_nDirectionWasLooking != eLookingDirection::LOOKING_DIRECTION_BEHIND)
             && (!lookBackAnim || lookBackAnim->m_BlendAmount < 1.0F && lookBackAnim->m_BlendDelta <= 0.0F)
         ) {
-            CAnimManager::BlendAnimation(driver->m_pRwClump, ANIM_GROUP_DEFAULT, usedAnims->back, 4.0F);
+            CAnimManager::BlendAnimation(driver->GetRpClump(), ANIM_GROUP_DEFAULT, usedAnims->back, 4.0F);
         }
         return;
     }
@@ -991,7 +991,7 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
             lookRightAnim->m_BlendAmount = fUsedAngle;
             lookRightAnim->m_BlendDelta  = 0.0F;
         } else {
-            CAnimManager::BlendAnimation(driver->m_pRwClump, ANIM_GROUP_DEFAULT, usedAnims->right, 4.0F);
+            CAnimManager::BlendAnimation(driver->GetRpClump(), ANIM_GROUP_DEFAULT, usedAnims->right, 4.0F);
         }
     } else {
         if (lookRightAnim) {
@@ -1002,7 +1002,7 @@ void CVehicle::ProcessDrivingAnims(CPed* driver, bool blend) {
             lookLeftAnim->m_BlendAmount = fUsedAngle;
             lookLeftAnim->m_BlendDelta = 0.0F;
         } else {
-            CAnimManager::BlendAnimation(driver->m_pRwClump, ANIM_GROUP_DEFAULT, usedAnims->left, 4.0F);
+            CAnimManager::BlendAnimation(driver->GetRpClump(), ANIM_GROUP_DEFAULT, usedAnims->left, 4.0F);
         }
     }
 
@@ -1975,7 +1975,7 @@ CVector CVehicle::GetDummyPosition(eVehicleDummy dummy, bool bWorldSpace) {
 // 0x6D2980
 void CVehicle::UpdateClumpAlpha() {
     const auto GetAlphaToSet = [this] {
-        const auto curr = CVisibilityPlugins::GetClumpAlpha(m_pRwClump);
+        const auto curr = CVisibilityPlugins::GetClumpAlpha(GetRpClump());
         if (vehicleFlags.bFadeOut) {
             return std::max(0, curr - 8);
         } else if (curr < 255) {
@@ -1983,7 +1983,7 @@ void CVehicle::UpdateClumpAlpha() {
         }
         return 255;
     };
-    CVisibilityPlugins::SetClumpAlpha(m_pRwClump, GetAlphaToSet());
+    CVisibilityPlugins::SetClumpAlpha(GetRpClump(), GetAlphaToSet());
 }
 
 // 0x6D29E0
@@ -2023,8 +2023,8 @@ void CVehicle::AddDamagedVehicleParticles() {
     }
 
     RwMatrix* matrix = nullptr;
-    if (m_pRwAtomic) {
-        matrix = RwFrameGetMatrix(RpAtomicGetFrame(m_pRwAtomic));
+    if (GetRpAtomic()) {
+        matrix = RwFrameGetMatrix(RpAtomicGetFrame(GetRpAtomic()));
     }
 
     if (!m_pOverheatParticle && matrix) {
@@ -2140,7 +2140,7 @@ void CVehicle::ClearGettingOutFlags(uint8 doorId) {
 
 // 0x6D3080
 void CVehicle::SetWindowOpenFlag(uint8 doorId) {
-    auto frameFromId = CClumpModelInfo::GetFrameFromId(m_pRwClump, doorId);
+    auto frameFromId = CClumpModelInfo::GetFrameFromId(GetRpClump(), doorId);
     if (frameFromId) {
         RwFrameForAllObjects(frameFromId, CVehicleModelInfo::SetAtomicFlagCB, (void*)eAtomicComponentFlag::ATOMIC_DONT_RENDER_ALPHA);
     }
@@ -2148,7 +2148,7 @@ void CVehicle::SetWindowOpenFlag(uint8 doorId) {
 
 // 0x6D30B0
 void CVehicle::ClearWindowOpenFlag(uint8 doorId) {
-    auto frameFromId = CClumpModelInfo::GetFrameFromId(m_pRwClump, doorId);
+    auto frameFromId = CClumpModelInfo::GetFrameFromId(GetRpClump(), doorId);
     if (frameFromId) {
         RwFrameForAllObjects(frameFromId, CVehicleModelInfo::ClearAtomicFlagCB, (void*)eAtomicComponentFlag::ATOMIC_DONT_RENDER_ALPHA);
     }
@@ -2348,7 +2348,7 @@ RpAtomic* CVehicle::CreateUpgradeAtomic(CBaseModelInfo* mi, const UpgradePosnDes
     RwMatrixUpdate(mat);
 
     // Update us and parent frame
-    RpClumpAddAtomic(m_pRwClump, atomic);
+    RpClumpAddAtomic(GetRpClump(), atomic);
     RwFrameAddChild(parentComponent, frame);
 
     mi->AddRef();
@@ -2365,13 +2365,13 @@ RpAtomic* CVehicle::CreateUpgradeAtomic(CBaseModelInfo* mi, const UpgradePosnDes
 
 // 0x6D3630
 void CVehicle::RemoveUpgrade(int32 upgradeId) {
-    RpClumpForAllAtomics(m_pRwClump, RemoveUpgradeCB, &upgradeId);
+    RpClumpForAllAtomics(GetRpClump(), RemoveUpgradeCB, &upgradeId);
 }
 
 // 0x6D3650
 int32 CVehicle::GetUpgrade(int32 upgradeId) {
     struct { int32 upgradeId; RpAtomic* atomic; } data = { upgradeId, nullptr };
-    RpClumpForAllAtomics(m_pRwClump, FindUpgradeCB, &data);
+    RpClumpForAllAtomics(GetRpClump(), FindUpgradeCB, &data);
     if (data.atomic) {
         return CVisibilityPlugins::GetModelInfoIndex(data.atomic);
     }
@@ -2409,7 +2409,7 @@ RpAtomic* CVehicle::CreateReplacementAtomic(CBaseModelInfo* mi, RwFrame* parentF
     mi->AddRef();
 
     // Update us and parent frame
-    RpClumpAddAtomic(m_pRwClump, atomic);
+    RpClumpAddAtomic(GetRpClump(), atomic);
 
     if (bIsWheel) {
         const auto mat = RwFrameGetMatrix(frame);
@@ -2441,11 +2441,11 @@ void CVehicle::AddReplacementUpgrade(int32 modelIndex, int32 nodeId) {
 
 // 0x6D39E0
 void CVehicle::RemoveReplacementUpgrade(int32 frameId) {
-    auto frameOfUpgrade = CClumpModelInfo::GetFrameFromId(m_pRwClump, frameId);
+    auto frameOfUpgrade = CClumpModelInfo::GetFrameFromId(GetRpClump(), frameId);
     RwFrameForAllObjects(frameOfUpgrade, RemoveObjectsCB, &frameOfUpgrade);
     RwFrameForAllChildren(frameOfUpgrade, RemoveObjectsCB, &frameOfUpgrade);
 
-    CopyObjectsCB_TargetClump = m_pRwClump;
+    CopyObjectsCB_TargetClump = GetRpClump();
     RwFrameForAllObjects(
         CClumpModelInfo::GetFrameFromId(GetModelInfo()->GetRpClump(), frameId),
         CopyObjectsCB,
@@ -2455,7 +2455,7 @@ void CVehicle::RemoveReplacementUpgrade(int32 frameId) {
 
 // 0x6D3A50
 int32 CVehicle::GetReplacementUpgrade(int32 nodeId) {
-    auto frame = CClumpModelInfo::GetFrameFromId(m_pRwClump, nodeId);
+    auto frame = CClumpModelInfo::GetFrameFromId(GetRpClump(), nodeId);
     tCompSearchStructById data = { nodeId, nullptr };
     RwFrameForAllObjects(frame, FindReplacementUpgradeCB, &data);
     if (data.m_pFrame)
@@ -2466,7 +2466,7 @@ int32 CVehicle::GetReplacementUpgrade(int32 nodeId) {
 
 // 0x6D3AB0
 void CVehicle::RemoveAllUpgrades() {
-    RpClumpForAllAtomics(m_pRwClump, RemoveAllUpgradesCB, nullptr);
+    RpClumpForAllAtomics(GetRpClump(), RemoveAllUpgradesCB, nullptr);
     m_anUpgrades.fill(-1);
 }
 
@@ -2835,7 +2835,7 @@ void CVehicle::DoPlaneGunFireFX(CWeapon* weapon, CVector& particlePos, CVector& 
                 part = g_fxMan.CreateFxSystem(
                     "gunflash",
                     CVector{0.f, 0.f, 0.f},
-                    RwFrameGetMatrix(RpClumpGetFrame(m_pRwClump)),
+                    RwFrameGetMatrix(RpClumpGetFrame(GetRpClump())),
                     false
                 );
             }
@@ -3152,7 +3152,7 @@ void CVehicle::SetupRender() {
 
     CVehicleModelInfo::SetupLightFlags(this);
     CVehicleModelInfo::ms_pRemapTexture = m_pRemapTexture;
-    CVehicleModelInfo::SetEditableMaterials(m_pRwClump);
+    CVehicleModelInfo::SetEditableMaterials(GetRpClump());
 }
 
 // 0x6D6C00
@@ -3465,7 +3465,7 @@ bool CVehicle::BladeColSectorList(PtrListType& ptrList, CColModel& colModel, CMa
         entity->SetCurrentScanCode();
 
         auto entityCM = entity->GetIsTypePed()
-            ? entity->GetModelInfo()->AsPedModelInfoPtr()->AnimatePedColModelSkinned(entity->m_pRwClump)
+            ? entity->GetModelInfo()->AsPedModelInfoPtr()->AnimatePedColModelSkinned(entity->GetRpClump())
             : entity->GetColModel();
 
         if (!entityCM) {

--- a/source/game_sa/Events/EventDamage.cpp
+++ b/source/game_sa/Events/EventDamage.cpp
@@ -436,7 +436,7 @@ void CEventDamage::ComputeDeathAnim(CPed* ped, bool bMakeActiveTaskAbortable) {
             && pSimplestActiveTask && (pSimplestActiveTask->GetTaskType() == TASK_SIMPLE_FALL || pSimplestActiveTask->GetTaskType() == TASK_SIMPLE_GET_UP))
         {
             m_bFallDown = true;
-            m_nAnimID = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
+            m_nAnimID = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
         }
         else
         {
@@ -687,7 +687,7 @@ void CEventDamage::ComputeDamageAnim(CPed* ped, bool bMakeActiveTaskAbortable) {
         && (pSimplestActiveTask->GetTaskType() == TASK_SIMPLE_FALL|| pSimplestActiveTask->GetTaskType() == TASK_SIMPLE_GET_UP))
     {
         m_bFallDown = true;
-        m_nAnimID = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
+        m_nAnimID = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_FRONT) ? ANIM_ID_FLOOR_HIT_F : ANIM_ID_FLOOR_HIT;
     }
     else if (m_pedPieceType == PED_PIECE_TORSO) {
         bool bMultiplyForceWithPedStrength = false;

--- a/source/game_sa/Events/EventHandler.cpp
+++ b/source/game_sa/Events/EventHandler.cpp
@@ -993,7 +993,7 @@ void CEventHandler::ComputeDamageResponse(CEventDamage* e, CTask* tactive, CTask
                 e->m_fAnimBlend = 4.f;
                 e->m_fAnimSpeed = 1.f;
                 e->m_nAnimGroup = ANIM_GROUP_DEFAULT;
-                if (const auto a = RpAnimBlendClumpGetFirstAssociation(m_Ped->m_pRwClump, ANIMATION_IS_FRONT)) { // 0x4C094E
+                if (const auto a = RpAnimBlendClumpGetFirstAssociation(m_Ped->GetRpClump(), ANIMATION_IS_FRONT)) { // 0x4C094E
                     e->m_nAnimID = ANIM_ID_FLOOR_HIT_F;
                     return DoDieMaybeFall();
                 }
@@ -1005,7 +1005,7 @@ void CEventHandler::ComputeDamageResponse(CEventDamage* e, CTask* tactive, CTask
                     if (tgup->m_bHasPedGotUp) {
                         return DoDieMaybeFall();
                     }
-                    e->m_nAnimID = RpAnimBlendClumpGetFirstAssociation(m_Ped->m_pRwClump, ANIMATION_IS_FRONT)
+                    e->m_nAnimID = RpAnimBlendClumpGetFirstAssociation(m_Ped->GetRpClump(), ANIMATION_IS_FRONT)
                         ? ANIM_ID_FLOOR_HIT_F
                         : ANIM_ID_FLOOR_HIT;
                     
@@ -1070,14 +1070,14 @@ void CEventHandler::ComputeDamageResponse(CEventDamage* e, CTask* tactive, CTask
                 if (CAnimManager::GetAnimAssociation(e->m_nAnimGroup, e->m_nAnimID)->m_Flags & ANIMATION_DONT_ADD_TO_PARTIAL_BLEND) { // 0x4C04B7
                     if (!e->GetAnimAdded()) {
                         if (!notsa::contains({ANIM_ID_SHOT_PARTIAL, ANIM_ID_SHOT_LEFTP, ANIM_ID_SHOT_PARTIAL_B, ANIM_ID_SHOT_RIGHTP}, e->m_nAnimID)) {
-                            const auto a = CAnimManager::BlendAnimation(m_Ped->m_pRwClump, e->m_nAnimGroup, e->m_nAnimID, e->m_fAnimBlend);
+                            const auto a = CAnimManager::BlendAnimation(m_Ped->GetRpClump(), e->m_nAnimGroup, e->m_nAnimID, e->m_fAnimBlend);
                             a->SetSpeed(e->m_fAnimSpeed);
                             a->SetCurrentTime(0.f);
                             e->m_bAnimAdded = true;
                         } else {
-                            auto a = RpAnimBlendClumpGetAssociation(m_Ped->m_pRwClump, e->GetAnimId()); // 0x4C04DE
+                            auto a = RpAnimBlendClumpGetAssociation(m_Ped->GetRpClump(), e->GetAnimId()); // 0x4C04DE
                             if (!a) {
-                                a = CAnimManager::BlendAnimation(m_Ped->m_pRwClump, e->GetAnimGroup(), e->GetAnimId());
+                                a = CAnimManager::BlendAnimation(m_Ped->GetRpClump(), e->GetAnimGroup(), e->GetAnimId());
                             }
                             a->SetBlend(0.f, e->m_fAnimBlend);
                             a->SetSpeed(e->m_fAnimSpeed);

--- a/source/game_sa/FileLoader.cpp
+++ b/source/game_sa/FileLoader.cpp
@@ -168,7 +168,7 @@ bool CFileLoader::LoadAtomicFile(RwStream* stream, uint32 modelId) {
         RpClumpDestroy(pReadClump);
     }
 
-    if (mi && !mi->m_pRwObject) // FIX_BUGS: V1004 The 'mi' pointer was used unsafely after it was verified against nullptr.
+    if (mi && !mi->GetRwObject()) // FIX_BUGS: V1004 The 'mi' pointer was used unsafely after it was verified against nullptr.
         return false;
 
     if (bUseCommonVehicleTexDictionary)

--- a/source/game_sa/Fx/FxSystem.cpp
+++ b/source/game_sa/Fx/FxSystem.cpp
@@ -166,7 +166,7 @@ void FxSystem_c::Kill() {
 
 // 0x4AA400
 void FxSystem_c::AttachToBone(CEntity* entity, eBoneTag boneId) {
-    auto animHier = GetAnimHierarchyFromSkinClump(entity->m_pRwClump);
+    auto animHier = GetAnimHierarchyFromSkinClump(entity->GetRpClump());
     auto index = RpHAnimIDGetIndex(animHier, boneId);
     m_ParentMatrix = &RpHAnimHierarchyGetMatrixArray(animHier)[index];
 }

--- a/source/game_sa/IKChainManager_c.cpp
+++ b/source/game_sa/IKChainManager_c.cpp
@@ -192,7 +192,7 @@ bool IKChainManager_c::CanAcceptLookAt(CPed* ped) {
         return false;
     }
 
-    return !RpAnimBlendClumpGetAssociation(ped->m_pRwClump, {
+    return !RpAnimBlendClumpGetAssociation(ped->GetRpClump(), {
         ANIM_ID_DRNKBR_PRTL,
         ANIM_ID_SMKCIG_PRTL,
         ANIM_ID_DRNKBR_PRTL_F,

--- a/source/game_sa/Models/AtomicModelInfo.cpp
+++ b/source/game_sa/Models/AtomicModelInfo.cpp
@@ -52,14 +52,14 @@ void CAtomicModelInfo::Init()
 // 0x4C4440
 void CAtomicModelInfo::DeleteRwObject()
 {
-    if (!m_pRwAtomic)
+    if (!GetRpAtomic())
         return;
 
-    auto uiEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(m_pRwAtomic));
+    auto uiEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(GetRpAtomic()));
     m_n2dfxCount -= uiEffectsCount;
 
-    auto frame = RpAtomicGetFrame(m_pRwAtomic);
-    RpAtomicDestroy(m_pRwAtomic);
+    auto frame = RpAtomicGetFrame(GetRpAtomic());
+    RpAtomicDestroy(GetRpAtomic());
     RwFrameDestroy(frame);
     m_pRwObject = nullptr;
 
@@ -71,11 +71,11 @@ void CAtomicModelInfo::DeleteRwObject()
 
 RwObject* CAtomicModelInfo::CreateInstance()
 {
-    if (!m_pRwObject)
+    if (!GetRpAtomic())
         return nullptr;
 
     CBaseModelInfo::AddRef();
-    auto clonedAtomic = RpAtomicClone(m_pRwAtomic);
+    auto clonedAtomic = RpAtomicClone(GetRpAtomic());
     auto frame = RwFrameCreate();
     RpAtomicSetFrame(clonedAtomic, frame);
     CBaseModelInfo::RemoveRef();
@@ -85,11 +85,11 @@ RwObject* CAtomicModelInfo::CreateInstance()
 
 RwObject* CAtomicModelInfo::CreateInstance(RwMatrix* matrix)
 {
-    if (!m_pRwObject)
+    if (!GetRpAtomic())
         return nullptr;
 
     CBaseModelInfo::AddRef();
-    auto clonedAtomic = RpAtomicClone(m_pRwAtomic);
+    auto clonedAtomic = RpAtomicClone(GetRpAtomic());
     auto frame = RwFrameCreate();
     memcpy(RwFrameGetMatrix(frame), matrix, sizeof(RwMatrix));
     RpAtomicSetFrame(clonedAtomic, frame);
@@ -102,12 +102,12 @@ RwObject* CAtomicModelInfo::CreateInstance(RwMatrix* matrix)
 void CAtomicModelInfo::SetAtomic(RpAtomic* atomic)
 {
     if (m_pRwObject) {
-        auto uiEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(m_pRwAtomic));
+        auto uiEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(GetRpAtomic()));
         m_n2dfxCount -= uiEffectsCount;
     }
 
-    m_pRwAtomic = atomic;
-    auto uiNewEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(m_pRwAtomic));
+    m_pRwObject            = reinterpret_cast<RwObject*>(atomic);
+    auto uiNewEffectsCount = RpGeometryGet2dFxCount(RpAtomicGetGeometry(GetRpAtomic()));
     m_n2dfxCount += uiNewEffectsCount;
 
     CBaseModelInfo::AddTexDictionaryRef();
@@ -115,21 +115,23 @@ void CAtomicModelInfo::SetAtomic(RpAtomic* atomic)
     if (iAnimIndex != -1)
         CAnimManager::AddAnimBlockRef(iAnimIndex);
 
-    if (CCustomBuildingRenderer::IsCBPCPipelineAttached(m_pRwAtomic))
-        CCustomBuildingRenderer::AtomicSetup(m_pRwAtomic);
-    else if (CCarFXRenderer::IsCCPCPipelineAttached(m_pRwAtomic))
-        CCarFXRenderer::SetCustomFXAtomicRenderPipelinesVMICB(m_pRwAtomic, nullptr);
+    if (CCustomBuildingRenderer::IsCBPCPipelineAttached(GetRpAtomic()))
+        CCustomBuildingRenderer::AtomicSetup(GetRpAtomic());
+    else if (CCarFXRenderer::IsCCPCPipelineAttached(GetRpAtomic()))
+        CCarFXRenderer::SetCustomFXAtomicRenderPipelinesVMICB(GetRpAtomic(), nullptr);
 
     if (!bTagDisabled && IsTagModel())
-        CTagManager::SetupAtomic(m_pRwAtomic);
+        CTagManager::SetupAtomic(GetRpAtomic());
 
     SetHasBeenPreRendered(true);
-}RpAtomic* CAtomicModelInfo::GetAtomicFromDistance(float distance)
+}
+
+RpAtomic* CAtomicModelInfo::GetAtomicFromDistance(float distance)
 {
     if (TheCamera.m_fLODDistMultiplier * m_fDrawDistance <= distance)
         return nullptr;
 
-    return m_pRwAtomic;
+    return GetRpAtomic();
 }
 
 void CAtomicModelInfo::SetupVehicleUpgradeFlags(const char* name)

--- a/source/game_sa/Models/BaseModelInfo.cpp
+++ b/source/game_sa/Models/BaseModelInfo.cpp
@@ -175,11 +175,11 @@ void CBaseModelInfo::DeleteCollisionModel() {
 C2dEffect* CBaseModelInfo::Get2dEffect(int32 index) const {
     auto uiStoredEffectsCount = m_n2dfxCount;
     RpGeometry* geometry = nullptr;
-    if (m_pRwObject) {
+    if (GetRwObject()) {
         if (GetRwModelType() == rpATOMIC) {
-            geometry = RpAtomicGetGeometry(m_pRwAtomic);
+            geometry = RpAtomicGetGeometry(GetRpAtomic());
         } else if (GetRwModelType() == rpCLUMP) {
-            auto atomic = Get2DEffectAtomic(m_pRwClump);
+            auto atomic = Get2DEffectAtomic(GetRpClump());
             if (atomic) {
                 geometry = RpAtomicGetGeometry(atomic);
             }

--- a/source/game_sa/Models/BaseModelInfo.h
+++ b/source/game_sa/Models/BaseModelInfo.h
@@ -131,13 +131,12 @@ public:
             };
         };
     };
+
     CColModel* m_pColModel;     // 20
     float      m_fDrawDistance; // 24
-    union {
-        RwObject* m_pRwObject;
-        RpClump*  m_pRwClump;
-        RpAtomic* m_pRwAtomic;
-    };
+
+protected:
+    RwObject* m_pRwObject; //< Use GetRpClump()/GetRpAtomic() to access
 
 public:
     CBaseModelInfo();
@@ -237,6 +236,11 @@ public:
         AddRef();
         return inst;
     }
+
+
+    RwObject* GetRwObject() const noexcept { assert(!m_pRwObject || RwObjectGetType(m_pRwObject) == GetRwModelType()); return m_pRwObject; }
+    RpClump*  GetRpClump()  const noexcept { assert(!m_pRwObject || RwObjectGetType(m_pRwObject) == rpCLUMP); return reinterpret_cast<RpClump*>(m_pRwObject); }
+    RpAtomic* GetRpAtomic() const noexcept { assert(!m_pRwObject || RwObjectGetType(m_pRwObject) == rpATOMIC); return reinterpret_cast<RpAtomic*>(m_pRwObject); }
 
 private:
     friend void InjectHooksMain();

--- a/source/game_sa/Models/ClumpModelInfo.cpp
+++ b/source/game_sa/Models/ClumpModelInfo.cpp
@@ -65,14 +65,14 @@ void CClumpModelInfo::Shutdown()
 // 0x4C4E70
 void CClumpModelInfo::DeleteRwObject()
 {
-    if (!m_pRwObject)
+    if (!GetRwObject())
         return;
 
-    auto atomic = Get2DEffectAtomic(m_pRwClump);
-    if (atomic)
+    if (auto* const atomic = Get2DEffectAtomic(GetRpClump())) {
         m_n2dfxCount -= RpGeometryGet2dFxCount(RpAtomicGetGeometry(atomic));
+    }
 
-    RpClumpDestroy(m_pRwClump);
+    RpClumpDestroy(GetRpClump());
     m_pRwObject = nullptr;
 
     CBaseModelInfo::RemoveTexDictionaryRef();
@@ -86,11 +86,11 @@ void CClumpModelInfo::DeleteRwObject()
 
 RwObject* CClumpModelInfo::CreateInstance()
 {
-    if (!m_pRwObject)
+    if (!GetRwObject())
         return nullptr;
 
     CBaseModelInfo::AddRef();
-    auto clonedClump = RpClumpClone(m_pRwClump);
+    auto clonedClump = RpClumpClone(GetRpClump());
     auto atomic = GetFirstAtomic(clonedClump);
     if (atomic && RpSkinGeometryGetSkin(RpAtomicGetGeometry(atomic)) && !bHasComplexHierarchy) {
         auto hierarchy = GetAnimHierarchyFromClump(clonedClump);
@@ -113,7 +113,7 @@ RwObject* CClumpModelInfo::CreateInstance()
 
 RwObject* CClumpModelInfo::CreateInstance(RwMatrix* matrix)
 {
-    if (!m_pRwObject)
+    if (!GetRwObject())
         return nullptr;
 
     auto clump = CreateInstance();
@@ -159,36 +159,36 @@ CBox* CClumpModelInfo::GetBoundingBox()
 // 0x4C4F70
 void CClumpModelInfo::SetClump(RpClump* clump)
 {
-    if (m_pRwObject) {
-        if (auto atomic = Get2DEffectAtomic(m_pRwClump))
+    if (GetRwObject()) {
+        if (auto atomic = Get2DEffectAtomic(GetRpClump()))
             m_n2dfxCount -= RpGeometryGet2dFxCount(RpAtomicGetGeometry(atomic));
     }
 
-    m_pRwClump = clump;
-    if (m_pRwClump) {
-        if (auto atomic = Get2DEffectAtomic(m_pRwClump))
+    m_pRwObject = reinterpret_cast<RwObject*>(clump);
+    if (GetRpClump()) {
+        if (auto atomic = Get2DEffectAtomic(GetRpClump()))
             m_n2dfxCount += RpGeometryGet2dFxCount(RpAtomicGetGeometry(atomic));
     }
 
-    CVisibilityPlugins::SetClumpModelInfo(m_pRwClump, this);
+    CVisibilityPlugins::SetClumpModelInfo(GetRpClump(), this);
     CBaseModelInfo::AddTexDictionaryRef();
 
     auto iAnimIndex = GetAnimFileIndex();
     if (iAnimIndex != -1)
         CAnimManager::AddAnimBlockRef(iAnimIndex);
 
-    RpClumpForAllAtomics(m_pRwClump, AtomicSetupLightingCB, this);
-    auto firstAtomic = GetFirstAtomic(m_pRwClump);
+    RpClumpForAllAtomics(GetRpClump(), AtomicSetupLightingCB, this);
+    auto firstAtomic = GetFirstAtomic(GetRpClump());
     if (firstAtomic && RpSkinGeometryGetSkin(RpAtomicGetGeometry(firstAtomic))) {
         if (bHasComplexHierarchy) {
-            RpClumpForAllAtomics(m_pRwClump, SetHierarchyForSkinAtomic, nullptr);
+            RpClumpForAllAtomics(GetRpClump(), SetHierarchyForSkinAtomic, nullptr);
         }
         else {
             auto sphere = RpMorphTargetGetBoundingSphere(RpGeometryGetMorphTarget(RpAtomicGetGeometry(firstAtomic), 0));
             sphere->radius *= 1.2F;
 
-            auto hierarchy = GetAnimHierarchyFromClump(m_pRwClump);
-            RpClumpForAllAtomics(m_pRwClump, SetHierarchyForSkinAtomic, hierarchy);
+            auto hierarchy = GetAnimHierarchyFromClump(GetRpClump());
+            RpClumpForAllAtomics(GetRpClump(), SetHierarchyForSkinAtomic, hierarchy);
 
             auto geometry = RpAtomicGetGeometry(firstAtomic);
             auto skin = RpSkinGeometryGetSkin(geometry);
@@ -215,7 +215,7 @@ void CClumpModelInfo::SetFrameIds(RwObjectNameIdAssocation* data) {
     while (curComponent->m_pName) {
         if ((curComponent->m_dwFlags & 1) == 0) {
             auto searchInfo = tCompSearchStructByName(curComponent->m_pName, nullptr);
-            RwFrameForAllChildren(RpClumpGetFrame(m_pRwClump), FindFrameFromNameWithoutIdCB, &searchInfo);
+            RwFrameForAllChildren(RpClumpGetFrame(GetRpClump()), FindFrameFromNameWithoutIdCB, &searchInfo);
             if (searchInfo.m_pFrame)
                 CVisibilityPlugins::SetFrameHierarchyId(searchInfo.m_pFrame, curComponent->m_dwHierarchyId);
         }

--- a/source/game_sa/Models/PedModelInfo.cpp
+++ b/source/game_sa/Models/PedModelInfo.cpp
@@ -37,8 +37,8 @@ void CPedModelInfo::SetClump(RpClump* clump) {
     if (!m_pHitColModel)
         CPedModelInfo::CreateHitColModelSkinned(clump);
 
-    RpClumpForAllAtomics(m_pRwClump, CClumpModelInfo::SetAtomicRendererCB, CVisibilityPlugins::RenderPedCB);
-    GetAnimHierarchyFromClump(m_pRwClump); // Unused? Or indirectly passes through EAX somehow?
+    RpClumpForAllAtomics(GetRpClump(), CClumpModelInfo::SetAtomicRendererCB, CVisibilityPlugins::RenderPedCB);
+    GetAnimHierarchyFromClump(GetRpClump()); // Unused? Or indirectly passes through EAX somehow?
 }
 
 // 0x4C6D40

--- a/source/game_sa/Models/VehicleModelInfo.cpp
+++ b/source/game_sa/Models/VehicleModelInfo.cpp
@@ -246,20 +246,20 @@ void CVehicleModelInfo::SetAtomicRenderCallbacks()
 {
     switch (m_nVehicleType) {
     case VEHICLE_TYPE_TRAIN:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicRendererCB_Train, nullptr);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicRendererCB_Train, nullptr);
         break;
     case VEHICLE_TYPE_PLANE:
     case VEHICLE_TYPE_FPLANE:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicRendererCB_Plane, nullptr);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicRendererCB_Plane, nullptr);
         break;
     case VEHICLE_TYPE_BOAT:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicRendererCB_Boat, m_pRwClump);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicRendererCB_Boat, GetRpClump());
         break;
     case VEHICLE_TYPE_HELI:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicRendererCB_RealHeli, m_pRwClump);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicRendererCB_RealHeli, GetRpClump());
         break;
     default:
-        RpClumpForAllAtomics(m_pRwClump, SetAtomicRendererCB, m_pRwClump);
+        RpClumpForAllAtomics(GetRpClump(), SetAtomicRendererCB, GetRpClump());
         break;
     }
 }
@@ -302,7 +302,7 @@ void CVehicleModelInfo::SetVehicleComponentFlags(RwFrame* component, uint32 flag
 
 void CVehicleModelInfo::GetWheelPosn(int32 wheel, CVector& outVec, bool local) const
 {
-    auto frame = CClumpModelInfo::GetFrameFromId(m_pRwClump, ms_wheelFrameIDs[wheel]);
+    auto frame = CClumpModelInfo::GetFrameFromId(GetRpClump(), ms_wheelFrameIDs[wheel]);
 
     if (m_nVehicleType != VEHICLE_TYPE_PLANE || local)
         outVec = *RwMatrixGetPos(RwFrameGetMatrix(frame));
@@ -322,7 +322,7 @@ void CVehicleModelInfo::GetWheelPosn(int32 wheel, CVector& outVec, bool local) c
 
 bool CVehicleModelInfo::GetOriginalCompPosition(CVector& outVec, int32 component)
 {
-    auto frame = CClumpModelInfo::GetFrameFromId(m_pRwClump, component);
+    auto frame = CClumpModelInfo::GetFrameFromId(GetRpClump(), component);
     if (!frame)
         return false;
 
@@ -459,7 +459,7 @@ void CVehicleModelInfo::AddRemap(int32 txd)
 
 void CVehicleModelInfo::SetRenderPipelines()
 {
-    CCarFXRenderer::CustomCarPipeClumpSetup(m_pRwClump);
+    CCarFXRenderer::CustomCarPipeClumpSetup(GetRpClump());
     if (carFrame)
         return;
 
@@ -497,7 +497,7 @@ void CVehicleModelInfo::ReduceMaterialsInVehicle()
     matList.materials = new RpMaterial*[matList.space];
 
     // CTimer::GetCurrentTimeInCycles(); // unused code used for performance diagnostics i guess
-    RpClumpForAllAtomics(m_pRwClump, StoreAtomicUsedMaterialsCB, &matList);
+    RpClumpForAllAtomics(GetRpClump(), StoreAtomicUsedMaterialsCB, &matList);
     for (int32 i = 0; i < m_pVehicleStruct->m_nNumExtras; ++i)
         StoreAtomicUsedMaterialsCB(m_pVehicleStruct->m_apExtras[i], &matList);
 
@@ -505,7 +505,7 @@ void CVehicleModelInfo::ReduceMaterialsInVehicle()
     // CTimer::GetCyclesPerMillisecond();
     _rpMaterialListDeinitialize(&matList);
     CMemoryMgr::ReleaseScratchPad();
-    CVisibilityPlugins::ClearClumpForAllAtomicsFlag(m_pRwClump, eAtomicComponentFlag::ATOMIC_UNIQUE_MATERIALS);
+    CVisibilityPlugins::ClearClumpForAllAtomicsFlag(GetRpClump(), eAtomicComponentFlag::ATOMIC_UNIQUE_MATERIALS);
 }
 
 void CVehicleModelInfo::SetCarCustomPlate()
@@ -517,26 +517,26 @@ void CVehicleModelInfo::SetCarCustomPlate()
     char plateBuffer[8 + 1] = "DEFAULT";
 
     CCustomCarPlateMgr::GeneratePlateText(plateBuffer, sizeof(plateBuffer) - 1);
-    if (auto* material = CCustomCarPlateMgr::SetupClump(m_pRwClump, plateBuffer, m_nPlateType)) {
+    if (auto* material = CCustomCarPlateMgr::SetupClump(GetRpClump(), plateBuffer, m_nPlateType)) {
         m_pPlateMaterial = material;
     }
 }
 
 void CVehicleModelInfo::DisableEnvMap()
 {
-    if (!m_pRwObject)
+    if (!GetRwObject())
         return;
 
-    RpClumpForAllAtomics(m_pRwClump, SetEnvironmentMapAtomicCB, (void*)0xFFFF);
+    RpClumpForAllAtomics(GetRpClump(), SetEnvironmentMapAtomicCB, (void*)0xFFFF);
 }
 
 void CVehicleModelInfo::SetEnvMapCoeff(float coeff)
 {
     auto iUsedCoeff = static_cast<int32>(floor(coeff * 1000.0F));
-    if (!m_pRwObject)
+    if (!GetRwObject())
         return;
 
-    RpClumpForAllAtomics(m_pRwClump, SetEnvMapCoeffAtomicCB, (void*)iUsedCoeff);
+    RpClumpForAllAtomics(GetRpClump(), SetEnvMapCoeffAtomicCB, (void*)iUsedCoeff);
 }
 
 int32 CVehicleModelInfo::GetNumDoors()
@@ -556,7 +556,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
 
         if (flags.bIsDummy || flags.bIsExtra || flags.bIsUpgrade) {
             auto searchStruct = tCompSearchStructByName(nameIdAssoc->m_pName, nullptr);
-            RwFrameForAllChildren(RpClumpGetFrame(m_pRwClump), CClumpModelInfo::FindFrameFromNameWithoutIdCB, &searchStruct);
+            RwFrameForAllChildren(RpClumpGetFrame(GetRpClump()), CClumpModelInfo::FindFrameFromNameWithoutIdCB, &searchStruct);
             if (searchStruct.m_pFrame) {
                 if (flags.bIsDummy) {
                     auto& vecDummyPos = GetModelDummyPosition(static_cast<eVehicleDummy>(nameIdAssoc->m_dwHierarchyId));
@@ -580,7 +580,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
                 }
                 else {
                     auto atomic = reinterpret_cast<RpAtomic*>(GetFirstObject(searchStruct.m_pFrame));
-                    RpClumpRemoveAtomic(m_pRwClump, atomic);
+                    RpClumpRemoveAtomic(GetRpClump(), atomic);
                     RwFrameRemoveChild(searchStruct.m_pFrame);
                     SetVehicleComponentFlags(searchStruct.m_pFrame, nameIdAssoc->m_dwFlags);
                     m_pVehicleStruct->m_apExtras[m_pVehicleStruct->m_nNumExtras] = atomic;
@@ -591,7 +591,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
 
         if (flags.bIsMainWheel || flags.bIsTrainFrontBogie) {
             auto searchStruct = tCompSearchStructById(nameIdAssoc->m_dwHierarchyId, nullptr);
-            RwFrameForAllChildren(RpClumpGetFrame(m_pRwClump), CClumpModelInfo::FindFrameFromIdCB, &searchStruct);
+            RwFrameForAllChildren(RpClumpGetFrame(GetRpClump()), CClumpModelInfo::FindFrameFromIdCB, &searchStruct);
             if (searchStruct.m_pFrame) {
                 auto frame = searchStruct.m_pFrame;
                 auto bNoChild = false;
@@ -625,7 +625,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
         }
 
         auto searchStruct = tCompSearchStructById(nameIdAssoc->m_dwHierarchyId, nullptr);
-        RwFrameForAllChildren(RpClumpGetFrame(m_pRwClump), CClumpModelInfo::FindFrameFromIdCB, &searchStruct);
+        RwFrameForAllChildren(RpClumpGetFrame(GetRpClump()), CClumpModelInfo::FindFrameFromIdCB, &searchStruct);
         if (!searchStruct.m_pFrame) {
             nameIdAssoc++;
             continue;
@@ -658,7 +658,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
                 else {
                     auto pClone = RpAtomicClone(mainWheelAtomic);
                     RpAtomicSetFrame(pClone, frame);
-                    RpClumpAddAtomic(m_pRwClump, pClone);
+                    RpClumpAddAtomic(GetRpClump(), pClone);
                     if (nameIdAssoc->m_dwHierarchyId != CAR_WHEEL_RF
                         && nameIdAssoc->m_dwHierarchyId != CAR_WHEEL_LF
                         && handling.m_bDoubleRwheels) {
@@ -674,7 +674,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
                         *RwMatrixGetAt(matrix)    = { 0.0F, 0.0F, 1.0F };
                         *RwMatrixGetPos(matrix)   = { fOffset, 0.0F, 0.0F };
                         matrix->flags |= (rwMATRIXINTERNALIDENTITY | rwMATRIXTYPEORTHONORMAL);
-                        RpClumpAddAtomic(m_pRwClump, clone2);
+                        RpClumpAddAtomic(GetRpClump(), clone2);
                         CVisibilityPlugins::SetAtomicRenderCallback(clone2, CVisibilityPlugins::RenderWheelAtomicCB);
                     }
                 }
@@ -683,7 +683,7 @@ void CVehicleModelInfo::PreprocessHierarchy()
         else if (flags.bIsTrainRearBogie && pTrainBogieAtomic) {
             auto pClone = RpAtomicClone(pTrainBogieAtomic);
             RpAtomicSetFrame(pClone, frame);
-            RpClumpAddAtomic(m_pRwClump, pClone);
+            RpClumpAddAtomic(GetRpClump(), pClone);
             CVisibilityPlugins::SetAtomicRenderCallback(pClone, CVisibilityPlugins::RenderWheelAtomicCB);
         }
 

--- a/source/game_sa/PedIK.cpp
+++ b/source/game_sa/PedIK.cpp
@@ -74,7 +74,7 @@ bool CPedIK::PointGunInDirection(float zAngle, float distance, bool flag, float 
     bTorsoUsed = true;
 
     const auto angle = CGeneral::LimitRadianAngle(zAngle - m_pPed->m_fCurrentRotation);
-    const auto hier  = GetAnimHierarchyFromSkinClump(m_pPed->m_pRwClump);
+    const auto hier  = GetAnimHierarchyFromSkinClump(m_pPed->GetRpClump());
     const auto index = RpHAnimIDGetIndex(hier, m_pPed->m_apBones[PED_NODE_RIGHT_CLAVICLE]->BoneTag);
 
     // unused code
@@ -136,8 +136,8 @@ void CPedIK::PointGunAtPosition(const CVector& aimAt, float normalize) {
 
 // 0x5FE0E0
 void CPedIK::PitchForSlope() {
-    const auto clumpData = RpAnimBlendClumpGetData(m_pPed->m_pRwClump);
-    const auto hier = GetAnimHierarchyFromSkinClump(m_pPed->m_pRwClump);
+    const auto clumpData = RpAnimBlendClumpGetData(m_pPed->GetRpClump());
+    const auto hier = GetAnimHierarchyFromSkinClump(m_pPed->GetRpClump());
 
     if (std::abs(m_fBodyRoll) > 0.01f) {
         m_fBodyRoll = std::clamp(m_fBodyRoll, DegreesToRadians(-30.0f), DegreesToRadians(30.0f));

--- a/source/game_sa/PedIntelligence.cpp
+++ b/source/game_sa/PedIntelligence.cpp
@@ -340,7 +340,7 @@ bool CPedIntelligence::GetUsingParachute() {
         return false;
     }
 
-    auto animAssoc = RpAnimBlendClumpGetFirstAssociation(m_pPed->m_pRwClump, ANIMATION_IS_PARTIAL);
+    auto animAssoc = RpAnimBlendClumpGetFirstAssociation(m_pPed->GetRpClump(), ANIMATION_IS_PARTIAL);
     if (!animAssoc) {
         return false;
     }
@@ -586,7 +586,7 @@ void CPedIntelligence::ProcessAfterPreRender() {
     CWeapon* activeWeapon = &m_pPed->GetActiveWeapon();
     if (activeWeapon->m_Type == WEAPON_MOLOTOV && activeWeapon->m_FxSystem)
     {
-        RpHAnimHierarchy* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->m_pRwClump);
+        RpHAnimHierarchy* animHierarchy = GetAnimHierarchyFromSkinClump(m_pPed->GetRpClump());
         int32 animIDIndex = RpHAnimIDGetIndex(animHierarchy, 24); // 24 = BONE_R_HAND? - "BONE_R" xDDD
         RwMatrix* matrixArray = RpHAnimHierarchyGetMatrixArray(animHierarchy);
 

--- a/source/game_sa/Pools.cpp
+++ b/source/game_sa/Pools.cpp
@@ -269,24 +269,29 @@ bool CPools::LoadVehiclePool() {
 
 // 0x550080
 void CPools::MakeSureSlotInObjectPoolIsEmpty(int32 slot) {
-    if (GetObjectPool()->IsFreeSlotAtIndex(slot))
-        return;
-
-    auto* obj = GetObjectPool()->GetAt(slot);
-    if (obj->IsTemporary()) {
-        CWorld::Remove(obj);
-        delete obj;
-    } else if (CProjectileInfo::RemoveIfThisIsAProjectile(obj)) {
-        auto newObj = new CObject(obj->m_nModelIndex, false);
-        CWorld::Remove(obj);
-        *newObj = *obj;
-        CWorld::Add(newObj);
-
-        obj->m_pRwObject = nullptr;
-        delete obj;
-
-        newObj->m_pReferences = nullptr;
-    }
+    // All code paths to this function are unreachable
+    // The only caller is `CPickup::GiveUsAPickUpObject`, 
+    // but all calls of it pass `-1` as the slot, so this function is never actually used.
+    // The implementation is messy, as it acceses `m_pRwObject` of the Entity, which is no good.
+    NOTSA_UNREACHABLE();
+    //if (GetObjectPool()->IsFreeSlotAtIndex(slot))
+    //    return;
+    //
+    //auto* obj = GetObjectPool()->GetAt(slot);
+    //if (obj->IsTemporary()) {
+    //    CWorld::Remove(obj);
+    //    delete obj;
+    //} else if (CProjectileInfo::RemoveIfThisIsAProjectile(obj)) {
+    //    auto newObj = new CObject(obj->m_nModelIndex, false);
+    //    CWorld::Remove(obj);
+    //    *newObj = *obj;
+    //    CWorld::Add(newObj);
+    //
+    //    obj->m_pRwObject = nullptr;
+    //    delete obj;
+    //
+    //    newObj->m_pReferences = nullptr;
+    //}
 }
 
 // 0x5D0880

--- a/source/game_sa/Population.cpp
+++ b/source/game_sa/Population.cpp
@@ -707,7 +707,7 @@ void CPopulation::ManagePed(CPed* ped, const CVector& playerPosn) {
     }
 
     // If we've faded the ped completely out, remove it
-    if (ped->bFadeOut && CVisibilityPlugins::GetClumpAlpha(ped->m_pRwClump) == 0) {
+    if (ped->bFadeOut && CVisibilityPlugins::GetClumpAlpha(ped->GetRpClump()) == 0) {
         RemovePed(ped);
         return;
     }
@@ -957,7 +957,7 @@ CPed* CPopulation::AddDeadPedInFrontOfCar(const CVector& createPedAt, CVehicle* 
         return nullptr;
     }
 
-    CVisibilityPlugins::SetClumpAlpha(ped->m_pRwClump, 0);
+    CVisibilityPlugins::SetClumpAlpha(ped->GetRpClump(), 0);
 
     return ped;
 }
@@ -1164,7 +1164,7 @@ void CPopulation::CreateWaitingCoppers(CVector createAt, float createaWithHeadin
 
             // Now, update the RW matrix too
             if (veh->GetRwObject()) {
-                vehMat.UpdateRwMatrix(RwFrameGetMatrix(RpClumpGetFrame(veh->m_pRwClump)));
+                vehMat.UpdateRwMatrix(RwFrameGetMatrix(RpClumpGetFrame(veh->GetRpClump())));
             }
 
             CCarCtrl::JoinCarWithRoadSystem(veh);
@@ -1376,7 +1376,7 @@ void CPopulation::PlaceCouple(ePedType husbandPedType, eModelID husbandModelId, 
     if (!husb) {
         return;
     }
-    CVisibilityPlugins::SetClumpAlpha(husb->m_pRwClump, 0);
+    CVisibilityPlugins::SetClumpAlpha(husb->GetRpClump(), 0);
 
     const auto wifey = CreatePed(PED_TYPE_CIVFEMALE, wifeyModelId);
     if (!wifey) {
@@ -1405,7 +1405,7 @@ void CPopulation::PlaceCouple(ePedType husbandPedType, eModelID husbandModelId, 
         wifey->GetColModel()->GetBoundRadius(),
         { husb, wifey }
     )) {
-        CVisibilityPlugins::SetClumpAlpha(wifey->m_pRwClump, 0); // All good
+        CVisibilityPlugins::SetClumpAlpha(wifey->GetRpClump(), 0); // All good
     }  else { // Blocked by something
         RemovePed(wifey);
         RemovePed(husb);

--- a/source/game_sa/Population.cpp
+++ b/source/game_sa/Population.cpp
@@ -931,7 +931,7 @@ CPed* CPopulation::AddDeadPedInFrontOfCar(const CVector& createPedAt, CVehicle* 
         return nullptr;
     }
 
-    if (!CModelInfo::GetModelInfo(MODEL_MALE01)->m_pRwObject) {
+    if (!CModelInfo::GetModelInfo(MODEL_MALE01)->GetRwObject()) {
         NOTSA_LOG_DEBUG("Didn't create ped, because `MODEL_MALE01` has no RW object!");
         return nullptr;
     }
@@ -1246,7 +1246,7 @@ CPed* CPopulation::AddPedInCar(
         }
 
         const auto FixIfInvalid = [&](eModelID model, bool checkRWObj = false) {
-            return model != MODEL_INVALID && (!checkRWObj || CModelInfo::GetPedModelInfo(model)->m_pRwObject)
+            return model != MODEL_INVALID && (!checkRWObj || CModelInfo::GetPedModelInfo(model)->GetRwObject())
                 ? model
                 : MODEL_MALE01;
         };
@@ -1366,7 +1366,7 @@ void CPopulation::PlaceCouple(ePedType husbandPedType, eModelID husbandModelId, 
     }
 
     const auto CreatePed = [&](ePedType ptype, eModelID model) -> CPed* {
-        if (!CModelInfo::GetPedModelInfo(model)->m_pRwObject) {
+        if (!CModelInfo::GetPedModelInfo(model)->GetRwObject()) {
             return nullptr;
         }
         return AddPed(ptype, model, placeAt, true);

--- a/source/game_sa/RealTimeShadow.cpp
+++ b/source/game_sa/RealTimeShadow.cpp
@@ -103,7 +103,7 @@ RwTexture* CRealTimeShadow::Update() {
             &m_baseSphere.m_vecCenter,
             &m_boundingSphere.m_vecCenter,
             1,
-            RwFrameGetMatrix(RpClumpGetFrame(m_pOwner->m_pRwClump))
+            RwFrameGetMatrix(RpClumpGetFrame(m_pOwner->GetRpClump()))
         );
         break;
     }
@@ -115,10 +115,10 @@ RwTexture* CRealTimeShadow::Update() {
     // Render object onto the camera's raster
     switch (m_nRwObjectType) {
     case rpATOMIC:
-        m_camera.Update(m_pOwner->m_pRwAtomic);
+        m_camera.Update(m_pOwner->GetRpAtomic());
         break;
     case rpCLUMP:
-        m_camera.Update(m_pOwner->m_pRwClump);
+        m_camera.Update(m_pOwner->GetRpClump());
         break;
     }
 

--- a/source/game_sa/Renderer.cpp
+++ b/source/game_sa/Renderer.cpp
@@ -456,7 +456,7 @@ int32 CRenderer::SetupMapEntityVisibility(CEntity* entity, CBaseModelInfo* baseM
             fDrawDistanceRadius *= ms_lowLodDistScale;
     }
 
-    if (!baseModelInfo->m_pRwObject) {
+    if (!baseModelInfo->GetRwObject()) {
         if (entity->GetLod() && entity->GetLod()->GetNumLodChildren() > 1u &&
             fFadingDistance + fDistance - MAX_FADING_DISTANCE < fDrawDistanceRadius)
         {
@@ -465,10 +465,10 @@ int32 CRenderer::SetupMapEntityVisibility(CEntity* entity, CBaseModelInfo* baseM
         }
     }
 
-    if (!baseModelInfo->m_pRwObject || (fFadingDistance + fDistance - MAX_FADING_DISTANCE >= fDrawDistanceRadius)) {
+    if (!baseModelInfo->GetRwObject() || (fFadingDistance + fDistance - MAX_FADING_DISTANCE >= fDrawDistanceRadius)) {
         if (entity->m_bDontStream)
             return RENDERER_INVISIBLE;
-        if (baseModelInfo->m_pRwObject && fDistance - MAX_FADING_DISTANCE < fDrawDistanceRadius) {
+        if (baseModelInfo->GetRwObject() && fDistance - MAX_FADING_DISTANCE < fDrawDistanceRadius) {
             if (!entity->GetRwObject()) {
                 entity->CreateRwObject();
                 if (!entity->GetRwObject())
@@ -597,13 +597,13 @@ int32 CRenderer::SetupEntityVisibility(CEntity* entity, float& outDistance) {
             int32 otherTimeModel = modelTimeInfo->GetOtherTimeModel();
             if (CClock::GetIsTimeInRange(modelTimeInfo->GetTimeOn(), modelTimeInfo->GetTimeOff()))
             {
-                if (otherTimeModel != -1 && CModelInfo::GetModelInfo(otherTimeModel)->m_pRwObject) {
+                if (otherTimeModel != -1 && CModelInfo::GetModelInfo(otherTimeModel)->GetRwObject()) {
                     baseModelInfo->m_nAlpha = 255;
                 }
             }
             else
             {
-                if (otherTimeModel == -1 || CModelInfo::GetModelInfo(otherTimeModel)->m_pRwObject)
+                if (otherTimeModel == -1 || CModelInfo::GetModelInfo(otherTimeModel)->GetRwObject())
                 {
                     entity->DeleteRwObject();
                     return RENDERER_INVISIBLE;
@@ -671,12 +671,12 @@ int32 CRenderer::SetupBigBuildingVisibility(CEntity* entity, float& outDistance)
         int32 otherTimeModel = timeInfo->GetOtherTimeModel();
         if (CClock::GetIsTimeInRange(timeInfo->GetTimeOn(), timeInfo->GetTimeOff()))
         {
-            if (otherTimeModel != -1 && CModelInfo::GetModelInfo(otherTimeModel)->m_pRwObject)
+            if (otherTimeModel != -1 && CModelInfo::GetModelInfo(otherTimeModel)->GetRwObject())
                 baseModelInfo->m_nAlpha = 255;
         }
         else
         {
-            if (otherTimeModel == -1 || CModelInfo::GetModelInfo(otherTimeModel)->m_pRwObject) {
+            if (otherTimeModel == -1 || CModelInfo::GetModelInfo(otherTimeModel)->GetRwObject()) {
                 entity->DeleteRwObject();
                 return RENDERER_INVISIBLE;
             }

--- a/source/game_sa/Renderer.cpp
+++ b/source/game_sa/Renderer.cpp
@@ -112,7 +112,7 @@ void CRenderer::RenderOneNonRoad(CEntity* entity) {
     bool bSetupLighting = entity->SetupLighting();
     auto* vehicle = entity->AsVehicle();
     if (entity->GetIsTypeVehicle()) {
-        CVisibilityPlugins::SetupVehicleVariables(entity->m_pRwClump);
+        CVisibilityPlugins::SetupVehicleVariables(entity->GetRpClump());
         CVisibilityPlugins::InitAlphaAtomicList();
         vehicle->RenderDriverAndPassengers();
         vehicle->SetupRender();
@@ -356,7 +356,7 @@ void CRenderer::RenderEverythingBarRoads() {
             continue;
 
         bool bInserted = false;
-        if (entity->GetIsTypeVehicle() || (entity->GetIsTypePed() && CVisibilityPlugins::GetClumpAlpha(entity->m_pRwClump) != 255)) {
+        if (entity->GetIsTypeVehicle() || (entity->GetIsTypePed() && CVisibilityPlugins::GetClumpAlpha(entity->GetRpClump()) != 255)) {
             // todo: R* nice check | or we missed smth here?
             if (entity->GetIsTypeVehicle()) {
                 bool bInsertIntoSortedList = false;
@@ -365,7 +365,7 @@ void CRenderer::RenderEverythingBarRoads() {
                     const auto& lookDirection = TheCamera.GetLookDirection();
                     if (camMode == MODE_WHEELCAM || camMode == MODE_1STPERSON &&
                         lookDirection != LOOKING_DIRECTION_FORWARD && lookDirection != LOOKING_DIRECTION_UNKNOWN_1 ||
-                        CVisibilityPlugins::GetClumpAlpha(entity->m_pRwClump) != 255
+                        CVisibilityPlugins::GetClumpAlpha(entity->GetRpClump()) != 255
                     )
                     {
                         bInsertIntoSortedList = true;

--- a/source/game_sa/Replay.cpp
+++ b/source/game_sa/Replay.cpp
@@ -137,7 +137,7 @@ void CReplay::EnableReplays() {
 void CReplay::StorePedAnimation(CPed* ped, CStoredAnimationState& state) {
     float blendValue{};
     CAnimBlendAssociation* second{};
-    const auto main = RpAnimBlendClumpGetMainAssociation(ped->m_pRwClump, &second, &blendValue);
+    const auto main = RpAnimBlendClumpGetMainAssociation(ped->GetRpClump(), &second, &blendValue);
     if (main) {
         state[0] = AnimationState::Make(main->m_AnimId, main->m_CurrentTime, main->m_Speed, static_cast<uint8>(main->m_AnimGroupId));
     } else {
@@ -150,7 +150,7 @@ void CReplay::StorePedAnimation(CPed* ped, CStoredAnimationState& state) {
         state[1] = AnimationState::MakeBlend(ANIM_ID_WALK, 0.0f, 0.0f, 0, 0.0f);
     }
 
-    const auto partial = RpAnimBlendClumpGetMainPartialAssociation(ped->m_pRwClump);
+    const auto partial = RpAnimBlendClumpGetMainPartialAssociation(ped->GetRpClump());
     if (partial && partial->m_AnimId >= ANIM_ID_WALK) {
         state[2] = AnimationState::MakeBlend(partial->m_AnimId, partial->m_CurrentTime, partial->m_Speed, static_cast<uint8>(partial->m_AnimGroupId), partial->m_BlendAmount);
     } else {
@@ -200,12 +200,12 @@ void CReplay::RetrievePedAnimation(CPed* ped, const CStoredAnimationState& state
     if (auto first = state[0]; first.m_nAnimId > 3u) {
         auto animBlock = CAnimManager::GetAssocGroups()[first.m_nGroupId1].m_AnimBlock;
         if (animBlock && animBlock->IsLoaded) {
-            anim = CAnimManager::BlendAnimation(ped->m_pRwClump, (AssocGroupId)first.m_nGroupId1, (AnimationId)first.m_nAnimId, 100.0f);
+            anim = CAnimManager::BlendAnimation(ped->GetRpClump(), (AssocGroupId)first.m_nGroupId1, (AnimationId)first.m_nAnimId, 100.0f);
         } else {
-            anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_WALK, 100.0f);
+            anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_WALK, 100.0f);
         }
     } else {
-        anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, (AnimationId)first.m_nAnimId, 100.0f);
+        anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, (AnimationId)first.m_nAnimId, 100.0f);
     }
     anim->SetCurrentTime(state[0].m_nTime / ANIM_TIME_COMPRESS_VALUE);
     anim->SetSpeed(state[0].m_nSpeed / ANIM_SPEED_COMPRESS_VALUE);
@@ -215,9 +215,9 @@ void CReplay::RetrievePedAnimation(CPed* ped, const CStoredAnimationState& state
     anim = nullptr;
     if (auto second = state[1]; second.m_nGroupId1 && second.m_nAnimId && CAnimManager::GetAssocGroups()[second.m_nGroupId2].m_NumAnims > 0) {
         if (second.m_nAnimId > 3u) {
-            anim = CAnimManager::BlendAnimation(ped->m_pRwClump, (AssocGroupId)second.m_nGroupId2, (AnimationId)second.m_nAnimId, 100.0f);
+            anim = CAnimManager::BlendAnimation(ped->GetRpClump(), (AssocGroupId)second.m_nGroupId2, (AnimationId)second.m_nAnimId, 100.0f);
         } else {
-            anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, (AnimationId)second.m_nAnimId, 100.0f);
+            anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, (AnimationId)second.m_nAnimId, 100.0f);
         }
 
         if (anim) {
@@ -228,11 +228,11 @@ void CReplay::RetrievePedAnimation(CPed* ped, const CStoredAnimationState& state
         }
     }
 
-    RpAnimBlendClumpRemoveAssociations(ped->m_pRwClump, ANIMATION_IS_PARTIAL);
+    RpAnimBlendClumpRemoveAssociations(ped->GetRpClump(), ANIMATION_IS_PARTIAL);
     if (auto third = state[2]; third.m_nGroupId1 && third.m_nAnimId) {
         if (/*third.m_nGroupId1 >= 0 &&*/ third.m_nAnimId != 3u) {
             if (auto animBlock = CAnimManager::GetAssocGroups()[third.m_nGroupId2].m_AnimBlock; animBlock && animBlock->IsLoaded) {
-                anim = CAnimManager::BlendAnimation(ped->m_pRwClump, (AssocGroupId)third.m_nGroupId2, (AnimationId)third.m_nAnimId, 1000.0f);
+                anim = CAnimManager::BlendAnimation(ped->GetRpClump(), (AssocGroupId)third.m_nGroupId2, (AnimationId)third.m_nAnimId, 1000.0f);
 
                 anim->SetCurrentTime(third.m_nTime / ANIM_TIME_COMPRESS_VALUE);
                 anim->SetSpeed(third.m_nSpeed / ANIM_SPEED_COMPRESS_VALUE);

--- a/source/game_sa/RoadBlocks.cpp
+++ b/source/game_sa/RoadBlocks.cpp
@@ -163,7 +163,7 @@ void CRoadBlocks::GenerateRoadBlockPedsForCar(CVehicle* vehicle, int32 pedsPosit
             ped->bCrouchWhenShooting      = !isSpecialCop || pedsPositionsType != 2;
             ped->bCullExtraFarAway        = true;
             CEntity::RegisterReference(ped->m_pVehicle = vehicle);
-            CVisibilityPlugins::SetClumpAlpha(ped->m_pRwClump, 0);
+            CVisibilityPlugins::SetClumpAlpha(ped->GetRpClump(), 0);
 
             if (pedType != PED_TYPE_COP) {
                 const auto weapon = CGangs::Gang[pedType - PED_TYPE_GANG1].GetRandomWeapon(false);

--- a/source/game_sa/Scripts/Commands/CharacterCommands.cpp
+++ b/source/game_sa/Scripts/Commands/CharacterCommands.cpp
@@ -2040,7 +2040,7 @@ auto WarpCharIntoCar(CPed& ped, CVehicle& veh) {
  * @param {float} animSpeed
  */
 auto SetCharAnimSpeed(CPed& ped, const char* animName, float speed) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName)) {
         anim->SetSpeed(speed);
     }
 }
@@ -2846,7 +2846,7 @@ auto SetCharDecisionMaker(CPed& ped, int32 scriptHandleOfDM) { // TODO: Use `Scr
  * @param {string} animationName
  */
 auto IsCharPlayingAnim(CPed& ped, const char* animName) {
-    return RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName) != nullptr;
+    return RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName) != nullptr;
 }
 
 /*
@@ -2862,7 +2862,7 @@ auto IsCharPlayingAnim(CPed& ped, const char* animName) {
  * @param {bool} flag
  */
 auto SetCharAnimPlayingFlag(CPed& ped, const char* animName, bool started) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName)) {
         anim->SetFlag(ANIMATION_IS_PLAYING, started);
     }
 }
@@ -2881,7 +2881,7 @@ auto SetCharAnimPlayingFlag(CPed& ped, const char* animName, bool started) {
  * @returns {float} time
  */
 auto GetCharAnimCurrentTime(CPed& ped, const char* animName) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName)) {
         return anim->m_CurrentTime / anim->m_BlendHier->m_fTotalTime;
     }
     return 0.f;
@@ -2900,7 +2900,7 @@ auto GetCharAnimCurrentTime(CPed& ped, const char* animName) {
  * @param {float} time
  */
 auto SetCharAnimCurrentTime(CPed& ped, const char* animName, float progress) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName)) {
         anim->SetCurrentTime(progress * anim->m_BlendHier->m_fTotalTime);
     }
 }
@@ -2920,7 +2920,7 @@ auto SetCharAnimCurrentTime(CPed& ped, const char* animName, float progress) {
  * @returns {float} totalTime
  */
 auto GetCharAnimTotalTime(CPed& ped, const char* animName) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped.GetRpClump(), animName)) {
         return anim->m_BlendHier->m_fTotalTime * 1000.f;
     }
     return 0.f;

--- a/source/game_sa/Scripts/Commands/ObjectCommands.cpp
+++ b/source/game_sa/Scripts/Commands/ObjectCommands.cpp
@@ -154,33 +154,29 @@ void EnableDisabledAttractorOnObject(CObject& object, bool enabled) {
 
 namespace Animation {
 void SetObjectAnimSpeed(CObject& obj, const char* animName, float speed) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.GetRpClump(), animName)) {
         anim->m_Speed = speed;
     }
 }
 
 bool IsObjectPlayingAnim(CObject& obj, const char* animName) {
-    if (!obj.m_pRwClump) {
-        return false;
-    }
-    if (RwObjectGetType(obj.m_pRwClump) != rpCLUMP) {
-        return false;
-    }
-    if (!RpAnimBlendClumpIsInitialized(obj.m_pRwClump)) {
-        return false;
-    }
-    return RpAnimBlendClumpGetAssociation(obj.m_pRwClump, animName) != nullptr;
+    auto* const clump = RwObjectGetType(obj.GetRwObject()) == rpCLUMP 
+        ? obj.GetRpClump() 
+        : nullptr;
+    return clump != nullptr
+        && RpAnimBlendClumpIsInitialized(clump)
+        && RpAnimBlendClumpGetAssociation(clump, animName) != nullptr;
 }
 
 auto GetObjectAnimCurrentTime(CObject& obj, const char* animName) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.GetRpClump(), animName)) {
         return anim->m_CurrentTime / anim->m_BlendHier->m_fTotalTime;
     }
     return 0.f;
 }
 
 auto SetObjectAnimCurrentTime(CObject& obj, const char* animName, float progress) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.m_pRwClump, animName)) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(obj.GetRpClump(), animName)) {
         anim->SetCurrentTime(anim->m_Speed * progress);
     }
 }

--- a/source/game_sa/Scripts/TheScripts.cpp
+++ b/source/game_sa/Scripts/TheScripts.cpp
@@ -1081,7 +1081,7 @@ bool CTheScripts::IsPedStopped(CPed* ped) {
         return false;
     }
     if (ped->IsPlayer()) {
-        if (RpAnimBlendClumpGetAssociation(ped->m_pRwClump, { ANIM_ID_RUN_STOP, ANIM_ID_RUN_STOPR, ANIM_ID_JUMP_LAUNCH, ANIM_ID_JUMP_GLIDE })) {
+        if (RpAnimBlendClumpGetAssociation(ped->GetRpClump(), { ANIM_ID_RUN_STOP, ANIM_ID_RUN_STOPR, ANIM_ID_JUMP_LAUNCH, ANIM_ID_JUMP_GLIDE })) {
             return false;
         }
     }

--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -921,7 +921,7 @@ bool CStreaming::DeleteRwObjectsBehindCameraInSectorList(PtrListType& list, size
         entity->SetCurrentScanCode() ;
 
         if (!entity->m_bImBeingRendered && !entity->m_bStreamingDontDelete
-            && entity->m_pRwObject
+            && entity->GetRwObject()
             && GetInfo(entity->m_nModelIndex).InList()
             && FindPlayerPed()->m_pContactEntity != entity
         ) {
@@ -958,7 +958,7 @@ bool CStreaming::DeleteRwObjectsNotInFrustumInSectorList(PtrListType& list, size
         entity->SetCurrentScanCode() ;
 
         if (!entity->m_bImBeingRendered && !entity->m_bStreamingDontDelete
-            && entity->m_pRwObject
+            && entity->GetRwObject()
             && (!entity->IsVisible() || entity->m_bOffscreen)
             && GetInfo(entity->m_nModelIndex).InList()
         ) {
@@ -2527,7 +2527,7 @@ void CStreaming::ProcessEntitiesInSectorList(PtrListType& list, float posX, floa
         if (!IsPointInCircle2D(entityPos, { posX, posY }, std::min(drawDistanceRadius, radius)))
             continue;
 
-        if (modelInfo->GetRwObject() && !entity->m_pRwObject)
+        if (modelInfo->GetRwObject() && !entity->GetRwObject())
             entity->CreateRwObject();
 
         RequestModel(entity->m_nModelIndex, streamingflags);
@@ -2561,7 +2561,7 @@ void CStreaming::ProcessEntitiesInSectorList(PtrListType& list, int32 streamingF
         if (timeInfo && !CClock::GetIsTimeInRange(timeInfo->GetTimeOn(), timeInfo->GetTimeOff()))
             continue;
 
-        if (modelInfo->GetRwObject() && !entity->m_pRwObject)
+        if (modelInfo->GetRwObject() && !entity->GetRwObject())
             entity->CreateRwObject();
 
         RequestModel(entity->m_nModelIndex, streamingFlags);
@@ -2920,7 +2920,7 @@ void CStreaming::InstanceLoadedModels(const CVector& point) {
 template<typename PtrListType>
 void CStreaming::InstanceLoadedModelsInSectorList(PtrListType& list) {
     for (auto* const entity : list) {
-        if (entity->IsInCurrentArea() && !entity->m_pRwObject) {
+        if (entity->IsInCurrentArea() && !entity->GetRwObject()) {
             entity->CreateRwObject();
         }
     }

--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -2527,7 +2527,7 @@ void CStreaming::ProcessEntitiesInSectorList(PtrListType& list, float posX, floa
         if (!IsPointInCircle2D(entityPos, { posX, posY }, std::min(drawDistanceRadius, radius)))
             continue;
 
-        if (modelInfo->m_pRwObject && !entity->m_pRwObject)
+        if (modelInfo->GetRwObject() && !entity->m_pRwObject)
             entity->CreateRwObject();
 
         RequestModel(entity->m_nModelIndex, streamingflags);
@@ -2561,7 +2561,7 @@ void CStreaming::ProcessEntitiesInSectorList(PtrListType& list, int32 streamingF
         if (timeInfo && !CClock::GetIsTimeInRange(timeInfo->GetTimeOn(), timeInfo->GetTimeOff()))
             continue;
 
-        if (modelInfo->m_pRwObject && !entity->m_pRwObject)
+        if (modelInfo->GetRwObject() && !entity->m_pRwObject)
             entity->CreateRwObject();
 
         RequestModel(entity->m_nModelIndex, streamingFlags);
@@ -2832,7 +2832,7 @@ void CStreaming::Init2() {
     for (int32 i = 0; i < TOTAL_DFF_MODEL_IDS; i++) {
         const int32 modelId = DFFToModelId(i);
         CONST auto mi = CModelInfo::GetModelInfo(modelId);
-        if (mi && mi->m_pRwObject) {
+        if (mi && mi->GetRwObject()) {
             CStreamingInfo& streamingInfo = GetInfo(modelId);
             streamingInfo.ClearAllFlags();
             streamingInfo.SetFlags(STREAMING_GAME_REQUIRED);

--- a/source/game_sa/TagManager.cpp
+++ b/source/game_sa/TagManager.cpp
@@ -130,8 +130,8 @@ uint8 CTagManager::GetAlpha(RpAtomic* atomic)
 
 uint8 CTagManager::GetAlpha(CEntity* entity)
 {
-    if (entity->m_pRwAtomic)
-        return static_cast<uint8>(CVisibilityPlugins::GetUserValue(entity->m_pRwAtomic));
+    if (entity->GetRpAtomic())
+        return static_cast<uint8>(CVisibilityPlugins::GetUserValue(entity->GetRpAtomic()));
 
     auto tag = FindTagDesc(entity);
     assert(tag); // Originally the function would access uninitialized memory, by clearing EAX and dereferencing pointer to [EAX + 0x4] right after that
@@ -148,8 +148,8 @@ void CTagManager::SetAlpha(RpAtomic* atomic, uint8 ucAlpha)
 // 0x49CEC0
 void CTagManager::SetAlpha(CEntity* entity, uint8 ucAlpha)
 {
-    if (entity->m_pRwAtomic)
-        SetAlpha(entity->m_pRwAtomic, ucAlpha);
+    if (entity->GetRpAtomic())
+        SetAlpha(entity->GetRpAtomic(), ucAlpha);
 
     auto tagDesc = FindTagDesc(entity);
     auto bChangedState = false;
@@ -169,11 +169,11 @@ void CTagManager::SetAlpha(CEntity* entity, uint8 ucAlpha)
 
 void CTagManager::ResetAlpha(CEntity* entity)
 {
-    if (!entity->m_pRwAtomic)
+    if (!entity->GetRpAtomic())
         return;
 
     auto tagDesc = FindTagDesc(entity);
-    SetAlpha(entity->m_pRwAtomic, tagDesc->m_nAlpha);
+    SetAlpha(entity->GetRpAtomic(), tagDesc->m_nAlpha);
 }
 
 // 0x49CFE0
@@ -182,8 +182,8 @@ void CTagManager::SetAlphaInArea(CRect* area, uint8 ucAlpha)
     for (int32 i = ms_numTags - 1; i >= 0; --i) {
         auto& tagDesc = ms_tagDesc[i];
         auto vecPos = CVector2D(tagDesc.m_pEntity->GetPosition());
-        if (area->IsPointInside(vecPos) && tagDesc.m_pEntity->m_pRwAtomic) {
-            SetAlpha(tagDesc.m_pEntity->m_pRwAtomic, ucAlpha);
+        if (area->IsPointInside(vecPos) && tagDesc.m_pEntity->GetRpAtomic()) {
+            SetAlpha(tagDesc.m_pEntity->GetRpAtomic(), ucAlpha);
             tagDesc.m_nAlpha = ucAlpha;
         }
     }

--- a/source/game_sa/Tasks/TaskTypes/Interior/TaskInteriorSitAtDesk.cpp
+++ b/source/game_sa/Tasks/TaskTypes/Interior/TaskInteriorSitAtDesk.cpp
@@ -109,6 +109,6 @@ void CTaskInteriorSitAtDesk::StartAnim(CPed* ped, AnimationId animId, float blen
     if (m_Anim) {
         m_Anim->SetDefaultFinishCallback();
     }
-    m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_INT_OFFICE, animId, blendDelta);
+    m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_INT_OFFICE, animId, blendDelta);
     m_Anim->SetFinishCallback(FinishAnimCB, this);
 }

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexEvasiveDiveAndGetUp.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexEvasiveDiveAndGetUp.cpp
@@ -58,7 +58,7 @@ CTask* CTaskComplexEvasiveDiveAndGetUp::CreateSubTask(eTaskType taskType) {
 bool CTaskComplexEvasiveDiveAndGetUp::MakeAbortable(CPed* ped, eAbortPriority priority, CEvent const* event) {
     const auto subTaskAborted = m_pSubTask->MakeAbortable(ped, priority, event);
     if (subTaskAborted && priority == ABORT_PRIORITY_IMMEDIATE) {
-        if (const auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_EV_DIVE)) {
+        if (const auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_EV_DIVE)) {
             anim->SetBlendDelta(-1000.f);
         }
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexFacial.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexFacial.cpp
@@ -74,10 +74,10 @@ CTask* CTaskComplexFacial::ControlSubTask(CPed* ped) {
         return new CTaskSimplePause{ 5'000 };
     }
 
-    if (RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE_CHAT)) {
+    if (RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE_CHAT)) {
         m_RequestB         = eFacialExpression::NONE;
         m_TalkingLastFrame = true;
-        return RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FACTALK)
+        return RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FACTALK)
             ? m_pSubTask
             : new CTaskSimpleFacial{ eFacialExpression::TALKING, 0 };
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexFallToDeath.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexFallToDeath.cpp
@@ -32,7 +32,7 @@ CTaskComplexFallToDeath::CTaskComplexFallToDeath(int32 direction, const CVector&
 void CTaskComplexFallToDeath::UpdateAnims(CPed* ped) {
     for (auto& animId : { m_nAnimId, m_nAnimId1 }) {
         if (animId != ANIM_ID_UNDEFINED) {
-            if (auto assoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, animId)) {
+            if (auto assoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), animId)) {
                 assoc->m_BlendDelta = -1000.0f;
             }
         }
@@ -105,7 +105,7 @@ CTask* CTaskComplexFallToDeath::CreateFirstSubTask(CPed* ped) {
     }();
 
     if (m_nAnimId >= ANIM_ID_WALK && m_nAnimId < ANIM_ID_ROADCROSS) {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, nullptr, m_nAnimId, 1000.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), nullptr, m_nAnimId, 1000.0f);
     }
 
     return new CTaskSimpleInAir(false, true, false);
@@ -134,12 +134,12 @@ CTask* CTaskComplexFallToDeath::CreateNextSubTask(CPed* ped) {
 
         if (!b0x4) {
             if (m_nAnimId != ANIM_ID_UNDEFINED) {
-                if (auto assoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_nAnimId)) {
+                if (auto assoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_nAnimId)) {
                     assoc->m_BlendDelta = -1000.0f;
                 }
             }
             m_nAnimId1 = ANIM_ID_KO_SKID_FRONT;
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_KO_SKID_FRONT, 8.0f);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_KO_SKID_FRONT, 8.0f);
         }
 
         ped->GetIntelligence()->ClearTasks(false, true);

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexGangLeader.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexGangLeader.cpp
@@ -226,8 +226,8 @@ CTask* CTaskComplexGangLeader::ControlSubTask(CPed* ped) {
     }
 
     if (m_exhaleTimer.IsOutOfTime()) { // 0x6624C1
-        if (ped->m_pRwClump) {
-            if (auto matrix = RwFrameGetMatrix(RpClumpGetFrame(ped->m_pRwClump))) {
+        if (ped->GetRpClump()) {
+            if (auto matrix = RwFrameGetMatrix(RpClumpGetFrame(ped->GetRpClump()))) {
                 if (const auto fx = g_fxMan.CreateFxSystem("exhale", CVector{ 0.f, 0.1f, 0.f }, matrix)) {
                     fx->AttachToBone(ped, eBoneTag::BONE_HEAD);
                     fx->PlayAndKill();
@@ -304,7 +304,7 @@ CTask* CTaskComplexGangLeader::ControlSubTask(CPed* ped) {
         DRNKBR_PRTL_F,
         SMKCIG_PRTL_F,
     };
-    const auto GetAnim = [ped](AnimationId id) { return RpAnimBlendClumpGetAssociation(ped->m_pRwClump, id); };
+    const auto GetAnim = [ped](AnimationId id) { return RpAnimBlendClumpGetAssociation(ped->GetRpClump(), id); };
     const CAnimBlendAssociation* anims[]{
         GetAnim(ANIM_ID_DRNKBR_PRTL),
         GetAnim(ANIM_ID_SMKCIG_PRTL),

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexStuckInAir.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexStuckInAir.cpp
@@ -39,7 +39,7 @@ CTask* CTaskComplexStuckInAir::ControlSubTask(CPed* ped) {
         }
         ped->bIsInTheAir = false; // 0x67BFC2
         for (int32 i = ANIM_ID_JUMP_LAUNCH; i <= ANIM_ID_FALL_GLIDE; i++) {
-            if (auto* const a = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, static_cast<AnimationId>(i))) {
+            if (auto* const a = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), static_cast<AnimationId>(i))) {
                 if (a->GetBlendAmount() > 0.f && a->GetBlendDelta() >= 0.f) {
                     a->SetBlendDelta(-8.f);
                 }

--- a/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
@@ -99,8 +99,8 @@ CTask* CTaskComplexWalkAlongsidePed::ControlSubTask(CPed* ped) {
     const auto targetPedPos = m_TargetPed->GetPosition();
     const auto pedPos       = ped->GetPosition();
 
-    const auto pedWalkAnim       = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_WALK);
-    const auto targetPedWalkAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_WALK);
+    const auto pedWalkAnim       = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
+    const auto targetPedWalkAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
 
     const auto isTargetMoving = notsa::contains({PEDMOVE_WALK, PEDMOVE_RUN, PEDMOVE_SPRINT}, m_TargetPed->GetIntelligence()->GetMoveStateFromGoToTask());
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleAnim.cpp
@@ -65,7 +65,7 @@ bool CTaskSimpleAnim::MakeAbortable(CPed* ped, eAbortPriority priority, const CE
                 if (m_pAnim->m_Flags & ANIMATION_IS_PARTIAL)
                     m_pAnim->m_BlendDelta = fBlend;
                 else
-                    CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, -fBlend);
+                    CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, -fBlend);
             }
         }
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleArrestPed.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleArrestPed.cpp
@@ -92,7 +92,7 @@ bool CTaskSimpleArrestPed::ProcessPed(CPed* ped) {
 
 // 0x68B7E0
 void CTaskSimpleArrestPed::StartAnim(CPed* ped) {
-    m_Assoc = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_ARRESTGUN, 4.0f);
+    m_Assoc = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_ARRESTGUN, 4.0f);
     m_Assoc->SetFlag(ANIMATION_IS_PLAYING, true);
     m_Assoc->SetDeleteCallback(FinishAnimArrestPedCB, this);
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleBeHit.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleBeHit.cpp
@@ -107,13 +107,13 @@ void CTaskSimpleBeHit::StartAnim(CPed* ped) {
 
     // Check if anim exists/create it
     if (m_bAnimAdded) { // Inverted
-        m_Anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_nAnimId);
+        m_Anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_nAnimId);
         if (!m_Anim) {
             m_bIsFinished = true;
             return;
         }
     } else {
-        m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_nAnimGroup, m_nAnimId, 8.f);
+        m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_nAnimGroup, m_nAnimId, 8.f);
         m_Anim->SetCurrentTime(0.f);
         m_bAnimAdded = true;
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleBikeJacked.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleBikeJacked.cpp
@@ -93,7 +93,7 @@ bool CTaskSimpleBikeJacked::ProcessPed(CPed* ped) {
         if (!m_firstAnim &&
             [this, ped] {
                 if (m_jacker) {
-                    if (const auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, { ANIM_ID_CAR_PULLOUT_RHS, ANIM_ID_CAR_PULLOUT_LHS, ANIM_ID_CAR_GETIN_BIKE_FRONT })) {
+                    if (const auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), { ANIM_ID_CAR_PULLOUT_RHS, ANIM_ID_CAR_PULLOUT_LHS, ANIM_ID_CAR_GETIN_BIKE_FRONT })) {
                         if (anim->m_CurrentTime <= 0.3f) {
                             return false;
                         }
@@ -111,7 +111,7 @@ bool CTaskSimpleBikeJacked::ProcessPed(CPed* ped) {
             }()
         ) {
             // Play animation and some sound effect
-            m_firstAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_vehicle->GetRideAnimData()->AnimGroup, ANIM_ID_BIKE_HIT);
+            m_firstAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_vehicle->GetRideAnimData()->AnimGroup, ANIM_ID_BIKE_HIT);
             m_firstAnim->SetFinishCallback(FinishAnimBikeHitCB, this);
             ped->GetAE().AddAudioEvent(AE_PED_JACKED_BIKE);
         }
@@ -127,7 +127,7 @@ bool CTaskSimpleBikeJacked::ProcessPed(CPed* ped) {
         return true;
     }
 
-    CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, m_secondAnimId);
+    CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, m_secondAnimId);
 
     // event.m_flags |= 2; => event.m_forceKnockOff = true => Already set by ctor
     ped->GetEventGroup().Add(CEventKnockOffBike{ m_vehicle, m_vehicle->GetMoveSpeed(), m_vehicle->m_vecLastCollisionImpactVelocity, 0.f, 0.f, 55u, 0u, (int32)m_time, m_jacker, m_isVictimDriver, true }, true);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarAlign.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarAlign.cpp
@@ -91,7 +91,7 @@ void CTaskSimpleCarAlign::StartAnim(CPed* ped) {
         }
     }();
     m_anim = CAnimManager::BlendAnimation(
-        ped->m_pRwClump,
+        ped->GetRpClump(),
         m_veh->GetAnimGroup().GetGroup(animId),
         animId,
         4.f

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarCloseDoorFromInside.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarCloseDoorFromInside.cpp
@@ -85,7 +85,7 @@ auto CTaskSimpleCarCloseDoorFromInside::ComputeAnimID_Helper() -> std::tuple<Ass
 // 0x64AFB0
 void CTaskSimpleCarCloseDoorFromInside::StartAnim(CPed const* ped) {
     const auto [grpId, animId] = ComputeAnimID_Helper();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 1000.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 1000.f);
     m_anim->SetFinishCallback(FinishAnimCarCloseDoorFromInsideCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarCloseDoorFromOutside.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarCloseDoorFromOutside.cpp
@@ -119,7 +119,7 @@ void CTaskSimpleCarCloseDoorFromOutside::StartAnim(CPed const* ped) {
         m_animHasFinished = true;
     } else {
         const auto [grpId, animId] = ComputeAnimID_Helper();
-        m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 1000.f);
+        m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 1000.f);
         m_anim->SetFinishCallback(FinishAnimCarCloseDoorFromOutsideCB, this);
     }
 }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarFallOut.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarFallOut.cpp
@@ -43,7 +43,7 @@ void CTaskSimpleCarFallOut::StartAnim(const CPed* ped) {
     CCarEnterExit::RemoveCarSitAnim(ped);
 
     const auto [animGrp, animId] = ComputeAnimID();
-    m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, animGrp, animId, 1000.0f);
+    m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), animGrp, animId, 1000.0f);
     m_Anim->SetFinishCallback(FinishAnimFallOutCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarGetIn.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarGetIn.cpp
@@ -79,7 +79,7 @@ void CTaskSimpleCarGetIn::StartAnim(CPed const* ped) {
         return std::make_tuple(grpId, animId);
     }();
     
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 4.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 4.f);
     m_anim->SetFinishCallback(FinishAnimCarGetInCB, this);
     
     /*

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarGetOut.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarGetOut.cpp
@@ -119,7 +119,7 @@ void CTaskSimpleCarGetOut::StartAnim(const CPed* ped) {
     CCarEnterExit::RemoveCarSitAnim(ped);
 
     const auto [groupId, animId] = ComputeAnimID();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, groupId, animId, 1000.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), groupId, animId, 1000.f);
     m_anim->SetFinishCallback(FinishAnimCarGetOutCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarJumpOut.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarJumpOut.cpp
@@ -56,7 +56,7 @@ void CTaskSimpleCarJumpOut::FinishAnimCarJumpOutCB(CAnimBlendAssociation* anim, 
 // 0x64BF00
 void CTaskSimpleCarJumpOut::StartAnim(const CPed* ped) {
     const auto [groupId, animId] = ComputeAnimID();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, groupId, animId, 8.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), groupId, animId, 8.f);
     m_anim->SetFinishCallback(FinishAnimCarJumpOutCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarOpenDoorFromOutside.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarOpenDoorFromOutside.cpp
@@ -90,7 +90,7 @@ void CTaskSimpleCarOpenDoorFromOutside::ComputeAnimID_ToHook(AssocGroupId& grp, 
 // 0x64AD90
 void CTaskSimpleCarOpenDoorFromOutside::StartAnim(const CPed* ped) {
     const auto [groupId, animId] = ComputeAnimID();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, groupId, animId, 4.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), groupId, animId, 4.f);
     m_anim->SetFinishCallback(FinishAnimCarOpenDoorFromOutsideCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarOpenLockedDoorFromOutside.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarOpenLockedDoorFromOutside.cpp
@@ -59,7 +59,7 @@ void CTaskSimpleCarOpenLockedDoorFromOutside::StartAnim(CPed* ped) {
             return ANIM_ID_CAR_DOORLOCKED_RHS;
         }
     }();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_veh->GetAnimGroup().GetGroup(animationId), animationId, 4.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_veh->GetAnimGroup().GetGroup(animationId), animationId, 4.f);
     m_anim->SetFinishCallback(FinishAnimCarOpenLockedDoorFromOutsideCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarShuffle.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarShuffle.cpp
@@ -55,7 +55,7 @@ void CTaskSimpleCarShuffle::FinishAnimCarShuffleCB(CAnimBlendAssociation* anim, 
 void CTaskSimpleCarShuffle::StartAnim(const CPed* target) {
     assert(!m_Anim);
     m_Anim = CAnimManager::BlendAnimation(
-        target->m_pRwClump,
+        target->GetRpClump(),
         m_Car->GetAnimGroup().GetGroup(ANIM_ID_CAR_SHUFFLE_RHS_1),
         ANIM_ID_CAR_SHUFFLE_RHS_1,
         1000.f

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarSlowBeDraggedOut.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarSlowBeDraggedOut.cpp
@@ -49,7 +49,7 @@ void CTaskSimpleCarSlowBeDraggedOut::StartAnim(CPed* ped) {
     CCarEnterExit::RemoveCarSitAnim(ped);
 
     const auto [animGroup, animId] = ComputeAnimID();
-    m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, animGroup, animId, 1000.f);
+    m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), animGroup, animId, 1000.f);
     m_Anim->SetFinishCallback(FinishAnimCarSlowBeDraggedOutCB, this);
     m_FrontAnim = m_Anim->HasFlag(ANIMATION_IS_FRONT);
 }
@@ -74,9 +74,9 @@ bool CTaskSimpleCarSlowBeDraggedOut::ProcessPed(CPed* ped) {
         return true;
     }
     if (m_HasAnimFinished) {
-        if (!RpAnimBlendClumpGetAssociation(ped->m_pRwClump, { ANIM_ID_FLOOR_HIT_F, ANIM_ID_FLOOR_HIT })) {
+        if (!RpAnimBlendClumpGetAssociation(ped->GetRpClump(), { ANIM_ID_FLOOR_HIT_F, ANIM_ID_FLOOR_HIT })) {
             CAnimManager::BlendAnimation(
-                ped->m_pRwClump,
+                ped->GetRpClump(),
                 ANIM_GROUP_DEFAULT,
                 m_FrontAnim
                     ? ANIM_ID_FLOOR_HIT_F
@@ -112,7 +112,7 @@ bool CTaskSimpleCarSlowBeDraggedOut::SetPedPosition(CPed* ped) {
             m_LineUpUtility->ProcessPed(ped, m_Vehicle, m_Anim);
         } else { // NOTE: I removed some weird assignment to `m_Anim` that was nulled afterwards... Maybe it was important.
             const auto [animGrp, animId] = ComputeAnimID();
-            if (const auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, animId)) {
+            if (const auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), animId)) {
                 m_LineUpUtility->ProcessPed(ped, m_Vehicle, anim);
             }
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleCarSlowDragPedOut.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleCarSlowDragPedOut.cpp
@@ -88,7 +88,7 @@ std::pair<AssocGroupId, AnimationId> CTaskSimpleCarSlowDragPedOut::ComputeAnimID
 // 0x64C010
 void CTaskSimpleCarSlowDragPedOut::StartAnim(const CPed* ped) {
     const auto [groupId, animId] = ComputeAnimID();
-    m_AnimAssoc = CAnimManager::BlendAnimation(ped->m_pRwClump, groupId, animId, 1000.f);
+    m_AnimAssoc = CAnimManager::BlendAnimation(ped->GetRpClump(), groupId, animId, 1000.f);
     m_AnimAssoc->SetFinishCallback(FinishAnimCarSlowDragPedOutCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleChoking.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleChoking.cpp
@@ -39,7 +39,7 @@ void CTaskSimpleChoking::UpdateChoke(CPed* victim, CPed* attacker, bool bIsTearg
     m_bIsFinished = false;
     if (m_pAnim && m_pAnim->m_AnimId != ANIM_ID_GAS_CWR) {
         m_pAnim->SetDefaultFinishCallback();
-        m_pAnim = CAnimManager::BlendAnimation(victim->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_GAS_CWR, 4.f);
+        m_pAnim = CAnimManager::BlendAnimation(victim->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_GAS_CWR, 4.f);
         m_pAnim->SetFinishCallback([](CAnimBlendAssociation* a, void* data) {
             const auto self = static_cast<CTaskSimpleChoking*>(data);
             self->m_bIsFinished = true;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleClimb.cpp
@@ -550,9 +550,9 @@ void CTaskSimpleClimb::StartAnim(CPed* ped) {
     case CLIMB_GRAB:
         if (m_Anim) {
             m_Anim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
-            m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_IDLE, 4.0f);
+            m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_IDLE, 4.0f);
         } else {
-            m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0f);
+            m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0f);
         }
         m_HeightForPos    = CLIMB_GRAB;
         m_HasToChangePosition  = false;
@@ -562,11 +562,11 @@ void CTaskSimpleClimb::StartAnim(CPed* ped) {
         if (m_HeightForPos == CLIMB_NOT_READY) {
             m_HeightForAnim = CLIMB_STANDUP;
             m_HeightForPos  = CLIMB_STANDUP;
-            m_Anim          = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_STAND, 4.0f);
+            m_Anim          = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_STAND, 4.0f);
             m_Anim->m_Flags &= ~ANIMATION_IS_PLAYING;
         } else {
             m_Anim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
-            m_Anim         = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_PULL, 1000.0f);
+            m_Anim         = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_PULL, 1000.0f);
             m_HeightForPos = CLIMB_PULLUP;
         }
         m_HasToChangePosition  = false;
@@ -576,13 +576,13 @@ void CTaskSimpleClimb::StartAnim(CPed* ped) {
         if (m_Anim) {
             m_Anim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
         }
-        m_Anim            = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_STAND, 1000.0f);
+        m_Anim            = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_STAND, 1000.0f);
         m_HasToChangePosition  = true;
         m_HasToChangeAnimation = false;
         break;
     case CLIMB_FINISHED:
     case CLIMB_FINISHED_V:
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
         ped->SetMoveState(PEDMOVE_STILL);
         ped->SetMoveAnim();
         if (ped->GetPlayerData()) {
@@ -592,7 +592,7 @@ void CTaskSimpleClimb::StartAnim(CPed* ped) {
             m_Anim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
         }
         m_Anim = CAnimManager::BlendAnimation(
-            ped->m_pRwClump, ANIM_GROUP_DEFAULT, m_HeightForAnim == CLIMB_FINISHED_V ? ANIM_ID_CLIMB_JUMP2FALL : ANIM_ID_CLIMB_STAND_FINISH, 1000.0F
+            ped->GetRpClump(), ANIM_GROUP_DEFAULT, m_HeightForAnim == CLIMB_FINISHED_V ? ANIM_ID_CLIMB_JUMP2FALL : ANIM_ID_CLIMB_STAND_FINISH, 1000.0F
         );
         m_HasToChangePosition  = true;
         m_HasToChangeAnimation = false;
@@ -601,7 +601,7 @@ void CTaskSimpleClimb::StartAnim(CPed* ped) {
         if (m_Anim) {
             m_Anim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
         }
-        m_Anim            = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP_B, m_Anim && m_Anim->m_AnimId == ANIM_ID_CLIMB_STAND ? 16.0f : 1000.0f);
+        m_Anim            = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP_B, m_Anim && m_Anim->m_AnimId == ANIM_ID_CLIMB_STAND ? 16.0f : 1000.0f);
         m_HasToChangePosition  = true;
         m_HasToChangeAnimation = false;
         break;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleDie.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleDie.cpp
@@ -48,9 +48,9 @@ CTaskSimpleDie::~CTaskSimpleDie() {
 // 0x637520
 void CTaskSimpleDie::StartAnim(CPed* ped) {
     if (m_animHierarchy)
-        m_animAssociation = CAnimManager::BlendAnimation(ped->m_pRwClump, m_animHierarchy, m_animFlags, m_blendDelta);
+        m_animAssociation = CAnimManager::BlendAnimation(ped->GetRpClump(), m_animHierarchy, m_animFlags, m_blendDelta);
     else
-        m_animAssociation = CAnimManager::BlendAnimation(ped->m_pRwClump, m_animGroupId, m_animId, m_blendDelta);
+        m_animAssociation = CAnimManager::BlendAnimation(ped->GetRpClump(), m_animGroupId, m_animId, m_blendDelta);
 
     m_animAssociation->SetFinishCallback(FinishAnimDieCB, this);
     m_animAssociation->m_Flags &=   ANIMATION_CAN_EXTRACT_X_VELOCITY | ANIMATION_CAN_EXTRACT_VELOCITY

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleDuck.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleDuck.cpp
@@ -194,7 +194,7 @@ void CTaskSimpleDuck::ControlDuckMove(CVector2D moveDir) {
 void CTaskSimpleDuck::SetMoveAnim(CPed* ped) {
     const auto SetMoveAnimTo = [this, ped](AnimationId to) {
         m_MoveAnim = CAnimManager::BlendAnimation(
-            ped->m_pRwClump,
+            ped->GetRpClump(),
             ANIM_GROUP_DEFAULT,
             to,
             8.f
@@ -286,7 +286,7 @@ bool CTaskSimpleDuck::MakeAbortable(CPed* ped, eAbortPriority priority, CEvent c
             if (m_DuckAnim->m_Flags & ANIMATION_IS_PARTIAL) {
                 m_DuckAnim->m_BlendDelta = -1000.f;
             } else {
-                CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
+                CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
             }
             m_DuckAnim->SetDefaultFinishCallback();
             m_DuckAnim = nullptr;
@@ -331,7 +331,7 @@ bool CTaskSimpleDuck::MakeAbortable(CPed* ped, eAbortPriority priority, CEvent c
             if (m_DuckAnim->m_Flags & ANIMATION_IS_PARTIAL) {
                 m_DuckAnim->m_BlendDelta = blendDelta;
             }
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, -blendDelta);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, -blendDelta);
             ped->m_nSwimmingMoveState = eMoveState::PEDMOVE_STILL;
         }
 
@@ -428,19 +428,19 @@ bool CTaskSimpleDuck::ProcessPed(CPed* ped) {
             }
         } else {
             m_DuckAnim = CAnimManager::BlendAnimation(
-                ped->m_pRwClump,
+                ped->GetRpClump(),
                 ANIM_GROUP_DEFAULT,
                 m_DuckControlType == DUCK_STANDALONE ? ANIM_ID_DUCK_COWER : ANIM_ID_WEAPON_CROUCH,
                 4.f
             );
             m_DuckAnim->SetFinishCallback(DeleteDuckAnimCB, this);
 
-            if (const auto weaponCruchAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_WEAPON_CROUCH)) { // 0x69454F
+            if (const auto weaponCruchAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WEAPON_CROUCH)) { // 0x69454F
                 if (weaponCruchAnim->m_BlendAmount > 0 && weaponCruchAnim->m_BlendDelta >= 0.f) {
                     if (weaponCruchAnim->m_Flags & ANIMATION_IS_PARTIAL) {
                         weaponCruchAnim->m_BlendDelta = -4.f;
                     } else {
-                        CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_IDLE, 4.f);
+                        CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_IDLE, 4.f);
                     }
                 }
             }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleEvasiveDive.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleEvasiveDive.cpp
@@ -51,7 +51,7 @@ bool CTaskSimpleEvasiveDive::ProcessPed(CPed* ped) {
 void CTaskSimpleEvasiveDive::StartAnim(CPed* ped) {
     ped->Say(CTX_GLOBAL_DODGE);
 
-    m_DiveAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_EV_DIVE, 8.0f);
+    m_DiveAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_EV_DIVE, 8.0f);
     m_DiveAnim->SetFinishCallback(FinishAnimEvasiveDiveCB, this);
 
     if (m_EvadeVeh && ped->IsCop()) {

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleEvasiveStep.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleEvasiveStep.cpp
@@ -53,7 +53,7 @@ bool CTaskSimpleEvasiveStep::ProcessPed(CPed* ped) {
 
 // 0x655EA0
 void CTaskSimpleEvasiveStep::StartAnim(CPed* ped) {
-    m_Assoc = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_EV_STEP, 8.0f);
+    m_Assoc = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_EV_STEP, 8.0f);
     m_Assoc->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE, false);
     m_Assoc->SetFinishCallback(FinishAnimEvasiveStepCB, this);
 }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleFacial.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleFacial.cpp
@@ -42,7 +42,7 @@ AnimationId CTaskSimpleFacial::GetAnimId(eFacialExpression expression) {
 
 // 0x692E50
 bool CTaskSimpleFacial::MakeAbortable(CPed* ped, eAbortPriority priority, const CEvent* event) {
-    if (const auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, GetAnimId(m_Type))) {
+    if (const auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), GetAnimId(m_Type))) {
         anim->m_BlendDelta = -4.0f;
     }
     return true;
@@ -51,9 +51,9 @@ bool CTaskSimpleFacial::MakeAbortable(CPed* ped, eAbortPriority priority, const 
 // 0x692E80
 bool CTaskSimpleFacial::ProcessPed(CPed* ped) {
     const auto animId = CTaskSimpleFacial::GetAnimId(m_Type);
-    const auto anim  = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, animId);
+    const auto anim  = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), animId);
 
-    if (RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FACTALK)) {
+    if (RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FACTALK)) {
         if (animId == ANIM_ID_FACTALK) {
             if (CGeneral::GetRandomNumberInRange(0, 100) < 40) {
                 anim->SetSpeed(CGeneral::GetRandomNumberInRange(0.5f, 3.0f));
@@ -69,7 +69,7 @@ bool CTaskSimpleFacial::ProcessPed(CPed* ped) {
 
     if (!m_Timer.IsStarted()) {
         if (!anim) {
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, animId, 4.0f);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, animId, 4.0f);
             m_Timer.Start(m_Duration);
             return false;
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleFall.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleFall.cpp
@@ -82,13 +82,13 @@ bool CTaskSimpleFall::ProcessPed(CPed* ped)
 // 0x678370
 bool CTaskSimpleFall::MakeAbortable(CPed* ped, eAbortPriority priority, const CEvent* event)
 {
-    auto pFallAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_FRONT);
+    auto pFallAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_FRONT);
     if (!pFallAnim)
-        pFallAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_BACK);
+        pFallAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_BACK);
 
     if (priority == ABORT_PRIORITY_IMMEDIATE)
     {
-        auto pThisAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_nAnimId);
+        auto pThisAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_nAnimId);
 
         if (pThisAnim)
             pThisAnim->m_BlendDelta = -1000.0F;
@@ -145,16 +145,16 @@ bool CTaskSimpleFall::StartAnim(CPed* ped)
 
     if (m_nAnimId == ANIM_ID_NO_ANIMATION_SET)
     {
-        m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_BIKE_FALL_OFF);
+        m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_BIKE_FALL_OFF);
         if (!m_pAnim)
-            m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_BIKE_FALLR);
+            m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_BIKE_FALLR);
 
         if (m_pAnim)
             m_pAnim->SetFinishCallback(CTaskSimpleFall::FinishFallAnimCB, this);
     }
     else
     {
-        m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_nAnimId);
+        m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_nAnimId);
         if (m_pAnim)
         {
             m_pAnim->Start(0.0F);
@@ -165,7 +165,7 @@ bool CTaskSimpleFall::StartAnim(CPed* ped)
         }
         else
         {
-            m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_nAnimGroup, m_nAnimId, 8.0F);
+            m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_nAnimGroup, m_nAnimId, 8.0F);
             m_pAnim->m_Flags |= ANIMATION_IS_BLEND_AUTO_REMOVE;
             m_pAnim->m_Flags &= ~ANIMATION_IS_FINISH_AUTO_REMOVE;
             m_pAnim->SetFinishCallback(CTaskSimpleFall::FinishFallAnimCB, this);
@@ -186,15 +186,15 @@ void CTaskSimpleFall::ProcessFall(CPed* ped)
         )
     {
         CAnimBlendAssociation* anim;
-        auto pFirstAnim = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_PARTIAL);
+        auto pFirstAnim = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_PARTIAL);
 
         if (pFirstAnim && (pFirstAnim->m_AnimId == ANIM_ID_FALL_BACK || pFirstAnim->m_AnimId == ANIM_ID_FALL_FRONT))
             anim = pFirstAnim;
         else
-            anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_BACK);
+            anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_BACK);
 
         if (!anim)
-            anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_FRONT);
+            anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_FRONT);
 
         if (anim)
         {
@@ -210,16 +210,16 @@ void CTaskSimpleFall::ProcessFall(CPed* ped)
         else
         {
             if (pFirstAnim && pFirstAnim->m_CurrentTime > pFirstAnim->m_BlendHier->m_fTotalTime * 0.8F)
-                CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, pFirstAnim->m_Flags & ANIMATION_IS_FRONT ? ANIM_ID_FALL_FRONT : ANIM_ID_FALL_BACK, 8.0F);
+                CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, pFirstAnim->m_Flags & ANIMATION_IS_FRONT ? ANIM_ID_FALL_FRONT : ANIM_ID_FALL_BACK, 8.0F);
         }
     }
     else if ((ped->bKnockedUpIntoAir || ped->bKnockedOffBike)
         && ped->bIsStanding
         && !ped->bWasStanding)
     {
-        auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_BACK);
+        auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_BACK);
         if (!anim)
-            anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_FALL_FRONT);
+            anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_FALL_FRONT);
 
         if (anim)
         {
@@ -228,7 +228,7 @@ void CTaskSimpleFall::ProcessFall(CPed* ped)
         }
         else
         {
-            auto firstAnim = RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_PARTIAL);
+            auto firstAnim = RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_PARTIAL);
             if (firstAnim && !(firstAnim->m_Flags & ANIMATION_IS_PLAYING))
                 ped->bKnockedUpIntoAir = false;
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleGetUp.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleGetUp.cpp
@@ -120,9 +120,9 @@ bool CTaskSimpleGetUp::StartAnim(CPed* ped) {
             ped->m_pEntityIgnoredCollision = nullptr;
 
             m_Anim = CAnimManager::BlendAnimation(
-                ped->m_pRwClump,
+                ped->GetRpClump(),
                 ANIM_GROUP_DEFAULT,
-                RpAnimBlendClumpGetFirstAssociation(ped->m_pRwClump, ANIMATION_IS_FRONT) ? ANIM_ID_GETUP_FRONT : ANIM_ID_GETUP_0,
+                RpAnimBlendClumpGetFirstAssociation(ped->GetRpClump(), ANIMATION_IS_FRONT) ? ANIM_ID_GETUP_FRONT : ANIM_ID_GETUP_0,
                 1000.0F
             );
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleGiveCPR.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleGiveCPR.cpp
@@ -51,7 +51,7 @@ bool CTaskSimpleGiveCPR::ProcessPed(CPed* ped) {
         return true;
     } else {
         if (!m_pAnim) {
-            m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_MEDIC, ANIM_ID_CPR, 4.0F);
+            m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_MEDIC, ANIM_ID_CPR, 4.0F);
             m_pAnim->SetFinishCallback(FinishGiveCPRAnimCB, this);
         }
         return false;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleGoToPointFine.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleGoToPointFine.cpp
@@ -65,11 +65,11 @@ bool CTaskSimpleGoToPointFine::ProcessPed(CPed* ped) {
 // todo: IDA code, BaseRatio can be used
 // 0x65EF80
 void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
-    auto idleAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE);
-    auto walkAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_WALK);
-    auto runAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_RUN);
-    auto sprintAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SPRINT);
-    auto pIdleTiredAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE_TIRED);
+    auto idleAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE);
+    auto walkAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
+    auto runAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_RUN);
+    auto sprintAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SPRINT);
+    auto pIdleTiredAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE_TIRED);
 
     if (ped->bIsDucking && ped->GetIntelligence()->GetTaskDuck(false)) {
         float fMoveSpeedY = m_fMoveRatio * 0.5f;
@@ -91,7 +91,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
 
     if (m_fMoveRatio == 0.0f) {
         if (!idleAnimAssoc) {
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 4.0f);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 4.0f);
         }
 
         delete walkAnimAssoc;
@@ -123,7 +123,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
 
             delete walkAnimAssoc;
             if (!runAnimAssoc) {
-                runAnimAssoc = CAnimManager::AddAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_RUN);
+                runAnimAssoc = CAnimManager::AddAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_RUN);
                 runAnimAssoc->m_BlendAmount = 0.0f;
                 runAnimAssoc->m_Speed = 1.0f;
             }
@@ -131,7 +131,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
             runAnimAssoc->m_BlendDelta = 0.0f;
             runAnimAssoc->m_BlendAmount = 3.0f - m_fMoveRatio;
             if (!sprintAnimAssoc) {
-                sprintAnimAssoc = CAnimManager::AddAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_SPRINT);
+                sprintAnimAssoc = CAnimManager::AddAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_SPRINT);
                 sprintAnimAssoc->m_BlendAmount = 0.0f;
                 sprintAnimAssoc->m_Speed = 1.0f;
             }
@@ -141,7 +141,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
             sprintAnimAssoc->m_BlendAmount = m_fMoveRatio - 2.0f;
         } else {
             if (!walkAnimAssoc) {
-                walkAnimAssoc = CAnimManager::AddAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_WALK);
+                walkAnimAssoc = CAnimManager::AddAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_WALK);
                 walkAnimAssoc->m_BlendAmount = 0.0f;
                 walkAnimAssoc->m_Speed = 1.0f;
             }
@@ -149,7 +149,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
             walkAnimAssoc->m_BlendDelta = 0.0f;
             walkAnimAssoc->m_BlendAmount = 2.0f - m_fMoveRatio;
             if (!runAnimAssoc) {
-                runAnimAssoc = CAnimManager::AddAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_RUN);
+                runAnimAssoc = CAnimManager::AddAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_RUN);
                 runAnimAssoc->m_BlendAmount = 0.0f;
                 runAnimAssoc->m_Speed = 1.0f;
             }
@@ -161,7 +161,7 @@ void CTaskSimpleGoToPointFine::SetBlendedMoveAnim(CPed* ped) {
         }
     } else {
         if (!walkAnimAssoc) {
-            walkAnimAssoc = CAnimManager::AddAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_WALK);
+            walkAnimAssoc = CAnimManager::AddAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_WALK);
             walkAnimAssoc->m_BlendAmount = 0.0f;
             walkAnimAssoc->m_Speed = 1.0f;
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleGunControl.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleGunControl.cpp
@@ -150,9 +150,9 @@ bool CTaskSimpleGunControl::ProcessPed(CPed* ped) {
         return false;
     }()) {
         // 0x62546E
-        const auto anim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GANG_GUNSTAND);
+        const auto anim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GANG_GUNSTAND);
         if (!anim || (anim->m_BlendAmount < 1.f && anim->m_BlendDelta <= 0.f)) {
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_GANG_GUNSTAND);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_GANG_GUNSTAND);
         }
     }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHitHead.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHitHead.cpp
@@ -62,7 +62,7 @@ bool CTaskSimpleHitHead::ProcessPed(CPed* ped) {
         return true;
 
     if (!m_pAnim) {
-        m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_HIT_WALL, 8.0F);
+        m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_HIT_WALL, 8.0F);
         m_pAnim->SetFinishCallback(FinishAnimCB, this);
     }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleHoldEntity.cpp
@@ -302,7 +302,7 @@ bool CTaskSimpleHoldEntity::SetPedPosition(CPed* ped) {
             if (ped->bCalledPreRender) {
                 if (m_bBoneFlags & HOLD_ENTITY_UPDATE_TRANSLATION_ONLY) {
                     CVector entityToHoldPos = m_vecPosition;
-                    RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
+                    RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->GetRpClump());
                     int32 animIndex = RpHAnimIDGetIndex(pHAnimHierarchy, ped->m_apBones[m_nBoneFrameId]->BoneTag);
                     RwMatrix* pBoneMatrix = &RpHAnimHierarchyGetMatrixArray(pHAnimHierarchy)[animIndex];
                     RwV3dTransformPoints((RwV3d*)&entityToHoldPos, (RwV3d*)&entityToHoldPos, 1, pBoneMatrix);
@@ -311,7 +311,7 @@ bool CTaskSimpleHoldEntity::SetPedPosition(CPed* ped) {
                 }
                 else {
                     CVector entityToHoldPos = ped->GetMatrix().TransformVector(m_vecPosition);
-                    RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
+                    RpHAnimHierarchy* pHAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->GetRpClump());
                     int32 animIndex = RpHAnimIDGetIndex(pHAnimHierarchy, ped->m_apBones[m_nBoneFrameId]->BoneTag);
                     RwMatrix* pBoneMatrix = RpHAnimHierarchyGetMatrixArray(pHAnimHierarchy);
                     entityToHoldPos += *RwMatrixGetPos(&pBoneMatrix[animIndex]);
@@ -382,7 +382,7 @@ void CTaskSimpleHoldEntity::FinishAnimHoldEntityCB(CAnimBlendAssociation* animAs
 void CTaskSimpleHoldEntity::StartAnim(CPed* ped) {
     if (m_pAnimBlendHierarchy) {
         m_animFlags |= ANIMATION_DONT_ADD_TO_PARTIAL_BLEND | ANIMATION_IS_BLEND_AUTO_REMOVE | ANIMATION_IS_PARTIAL;
-        m_pAnimBlendAssociation = CAnimManager::BlendAnimation(ped->m_pRwClump, m_pAnimBlendHierarchy, m_animFlags, 4.0f);
+        m_pAnimBlendAssociation = CAnimManager::BlendAnimation(ped->GetRpClump(), m_pAnimBlendHierarchy, m_animFlags, 4.0f);
     } else {
         if (m_nAnimGroupId && !m_pAnimBlock) {
             CAnimBlock* animBlock = CAnimManager::GetAnimationBlock(m_nAnimGroupId);
@@ -397,7 +397,7 @@ void CTaskSimpleHoldEntity::StartAnim(CPed* ped) {
             CAnimManager::AddAnimBlockRef(blockIndex);
             m_pAnimBlock = animBlock;
         }
-        m_pAnimBlendAssociation = CAnimManager::BlendAnimation(ped->m_pRwClump, m_nAnimGroupId, m_nAnimId, 4.0f);
+        m_pAnimBlendAssociation = CAnimManager::BlendAnimation(ped->GetRpClump(), m_nAnimGroupId, m_nAnimId, 4.0f);
         m_pAnimBlendAssociation->m_Flags |= ANIMATION_IS_BLEND_AUTO_REMOVE;
         if (GetTaskType() == TASK_SIMPLE_HOLD_ENTITY) {
             m_pAnimBlendAssociation->m_Flags |= ANIMATION_DONT_ADD_TO_PARTIAL_BLEND;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleInAir.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleInAir.cpp
@@ -67,26 +67,26 @@ bool CTaskSimpleInAir::ProcessPed(CPed* ped)
         ped->bIsInTheAir = true;
         if (m_bUsingJumpGlide)
         {
-            m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_JUMP_GLIDE);
+            m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_JUMP_GLIDE);
             if (!m_pAnim)
-                m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_CLIMB_JUMP);
+                m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_CLIMB_JUMP);
             if (!m_pAnim || m_pAnim->m_BlendAmount < 1.0F && m_pAnim->m_BlendDelta <= 0.0F)
-                CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_JUMP_GLIDE, 4.0F);
+                CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_JUMP_GLIDE, 4.0F);
         }
         else if (m_bUsingFallGlide)
         {
             if (ped->m_vecMoveSpeed.z <= 0.0F)
             {
-                m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_FALL_GLIDE, 4.0F);
+                m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_FALL_GLIDE, 4.0F);
                 m_pAnim->SetDeleteCallback(CTaskSimpleInAir::DeleteAnimCB, this);
                 m_pAnim->SetBlend(1.0F, 0.5F);
             }
         }
         else
         {
-            m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_CLIMB_JUMP);
+            m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_CLIMB_JUMP);
             if (!m_pAnim || m_pAnim->m_BlendAmount < 1.0F && m_pAnim->m_BlendDelta <= 0.0F)
-                m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_FALL_GLIDE, 4.0F);
+                m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_FALL_GLIDE, 4.0F);
         }
 
         if (m_pAnim)
@@ -149,7 +149,7 @@ bool CTaskSimpleInAir::ProcessPed(CPed* ped)
                 if (m_pAnim && m_pAnim->m_AnimId != ANIM_ID_FALL_FALL)
                 {
                     m_pAnim->SetDeleteCallback(CDefaultAnimCallback::DefaultAnimCB, nullptr);
-                    m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_FALL_FALL, 4.0F);
+                    m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_FALL_FALL, 4.0F);
                     m_pAnim->SetDeleteCallback(CTaskSimpleInAir::DeleteAnimCB, this);
                 }
             }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleJetPack.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleJetPack.cpp
@@ -162,7 +162,7 @@ void CTaskSimpleJetPack::RenderJetPack(CPed* ped) {
         // Update JetPack matrix
         {
             const auto jpMat = RwFrameGetMatrix(jp);
-            *jpMat = RpHAnimHierarchyGetMatrixArray(GetAnimHierarchyFromSkinClump(ped->m_pRwClump))[PED_NODE_LEFT_ARM]; // TODO/NOTE: Not sure abt the enum
+            *jpMat = RpHAnimHierarchyGetMatrixArray(GetAnimHierarchyFromSkinClump(ped->GetRpClump()))[PED_NODE_LEFT_ARM]; // TODO/NOTE: Not sure abt the enum
             RwMatrixTranslate(jpMat, &JETPACK_POS_OFFSET, rwCOMBINEPRECONCAT);
             RwMatrixRotate(jpMat, &JETPACK_ROT_AXIS, 90.f, rwCOMBINEPRECONCAT);
         }
@@ -303,7 +303,7 @@ bool CTaskSimpleJetPack::ProcessAnims(CPed* ped) {
             ped->AsPlayer()->SetRealMoveAnim();
         }
     } else {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 4.f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 4.f);
         ped->SetMoveState(PEDMOVE_STILL);
     }
 
@@ -462,8 +462,8 @@ void CTaskSimpleJetPack::DoJetPackEffect(CPed* ped) {
         ? std::min(m_FxKeyTime + 0.1f, 1.f)
         : std::max(m_FxKeyTime - 0.1f, 0.f);
     const auto ProcessFx = [&, this](FxSystem_c*& fx, const char* jbFrameName) {
-        if (ped->m_pRwClump && !fx) {
-            if (fx = g_fxMan.CreateFxSystem("jetpack", CVector{}, RwFrameGetMatrix(RpClumpGetFrame(ped->m_pRwClump)))) {
+        if (ped->GetRpClump() && !fx) {
+            if (fx = g_fxMan.CreateFxSystem("jetpack", CVector{}, RwFrameGetMatrix(RpClumpGetFrame(ped->GetRpClump())))) {
                 fx->Play();
                 fx->SetLocalParticles(true);
                 fx->CopyParentMatrix();

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleJump.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleJump.cpp
@@ -118,11 +118,11 @@ bool CTaskSimpleJump::CheckIfJumpBlocked(CPed* ped) {
 void CTaskSimpleJump::Launch(CPed* ped) {
     float fHorizontalJumpSpeed = 0.1F;
 
-    auto pSprintAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SPRINT);
+    auto pSprintAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SPRINT);
     if (pSprintAnim)
         fHorizontalJumpSpeed = lerp(0.17F, 0.22F, pSprintAnim->m_BlendAmount);
     else {
-        auto pRunAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_RUN);
+        auto pRunAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_RUN);
         if (pRunAnim)
             fHorizontalJumpSpeed = lerp(0.1F, 0.17F, pRunAnim->m_BlendAmount);
     }
@@ -158,14 +158,14 @@ void CTaskSimpleJump::Launch(CPed* ped) {
 
     if (!m_pClimbEntity) {
         if (m_bClimbJump) {
-            auto anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0F);
+            auto anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0F);
             anim->m_Flags |= ANIMATION_IS_FINISH_AUTO_REMOVE;
         } else
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_JUMP_GLIDE, 8.0F);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_JUMP_GLIDE, 8.0F);
     }
 
     if (ped->bDoBloodyFootprints && CLocalisation::Blood()) {
-        auto hier = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
+        auto hier = GetAnimHierarchyFromSkinClump(ped->GetRpClump());
         CVector v;
         RwV3dTransformPoints(&v, &v, 1, &RpHAnimHierarchyGetMatrixArray(hier)[RpHAnimIDGetIndex(hier, ped->m_apBones[PED_NODE_LEFT_FOOT]->BoneTag)]);
 
@@ -190,9 +190,9 @@ void CTaskSimpleJump::Launch(CPed* ped) {
 
 // 0x67D7A0
 bool CTaskSimpleJump::StartLaunchAnim(CPed* ped) {
-    m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_JUMP_LAUNCH);
+    m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_JUMP_LAUNCH);
     if (!m_pAnim)
-        m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_JUMP_LAUNCH_R);
+        m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_JUMP_LAUNCH_R);
     if (m_pAnim)
         return false;
 
@@ -202,11 +202,11 @@ bool CTaskSimpleJump::StartLaunchAnim(CPed* ped) {
         return false;
     }
 
-    auto moveAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SPRINT);
+    auto moveAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SPRINT);
     if (!moveAnim || moveAnim->m_BlendAmount < 0.3F)
-        moveAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_RUN);
+        moveAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_RUN);
     if (!moveAnim || moveAnim->m_BlendAmount < 0.3F)
-        moveAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_WALK);
+        moveAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
 
     float fMoveAnimBlendAmount = 0.0F;
     if (moveAnim && moveAnim->m_BlendAmount > 0.3F) {
@@ -215,7 +215,7 @@ bool CTaskSimpleJump::StartLaunchAnim(CPed* ped) {
             fMoveAnimBlendAmount -= 1.0F;
     }
 
-    m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, fMoveAnimBlendAmount >= 0.5F ? ANIM_ID_JUMP_LAUNCH_R : ANIM_ID_JUMP_LAUNCH, 8.0F);
+    m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, fMoveAnimBlendAmount >= 0.5F ? ANIM_ID_JUMP_LAUNCH_R : ANIM_ID_JUMP_LAUNCH, 8.0F);
 
     if (ped->GetPlayerData())
         m_pAnim->m_Speed = CStats::GetFatAndMuscleModifier(STAT_MOD_2);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleLand.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleLand.cpp
@@ -41,7 +41,7 @@ bool CTaskSimpleLand::ProcessPed(CPed* ped) {
         if (!bNoAnimation) {
             AnimationId aAnimIds[3] = { ANIM_ID_WALK, ANIM_ID_RUN, ANIM_ID_SPRINT };
             for (auto animId : aAnimIds) {
-                m_pAnim = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, animId);
+                m_pAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), animId);
                 if (m_pAnim)
                     m_pAnim->SetCurrentTime(0.0F);
             }
@@ -52,7 +52,7 @@ bool CTaskSimpleLand::ProcessPed(CPed* ped) {
         return true;
     } else {
         if (!m_pAnim && !bNoAnimation) {
-            m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, m_nAnimId, 100.0F);
+            m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, m_nAnimId, 100.0F);
             m_pAnim->SetFinishCallback(CTaskSimpleLand::FinishAnimCB, this);
         }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimplePickUpBike.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimplePickUpBike.cpp
@@ -60,7 +60,7 @@ void CTaskSimplePickUpBike::StartAnim(CPed const* ped) {
             return rightZ >= 0.f ? ANIM_ID_CAR_ALIGNHI_RHS : ANIM_ID_CAR_ALIGN_RHS;
         }
     }();
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_veh->GetAnimGroup().GetGroup(animationId), animationId);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_veh->GetAnimGroup().GetGroup(animationId), animationId);
     m_anim->SetFinishCallback(FinishAnimPickUpBikeCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimplePlayHandSignalAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimplePlayHandSignalAnim.cpp
@@ -60,7 +60,7 @@ void CTaskSimplePlayHandSignalAnim::StartAnim(CPed* ped) {
     // Pointing / weapon logic
     //
     if (ped->GetEntityThatThisPedIsHolding() || g_ikChainMan.IsArmPointing(eIKArm::IK_ARM_RIGHT, ped) || ped->GetActiveWeapon().m_Type != eWeaponType::WEAPON_UNARMED) {
-        m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_HANDSIGNALL, animId, m_AnimBlenDelta);
+        m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_HANDSIGNALL, animId, m_AnimBlenDelta);
         m_pAnim->SetFinishCallback(CTaskSimpleAnim::FinishRunAnimCB, this);
 
         if (m_PlayerIdlesAnimBlockId == -1) {
@@ -75,7 +75,7 @@ void CTaskSimplePlayHandSignalAnim::StartAnim(CPed* ped) {
 
         CWorld::Add(m_LeftHand);
         auto* animHierarchy = CAnimManager::GetAnimAssociation(ANIM_GROUP_LHAND, m_PlayerIdlesAnimBlockId)->m_BlendHier;
-        CAnimManager::AddAnimation(m_LeftHand->m_pRwClump, animHierarchy, 0);
+        CAnimManager::AddAnimation(m_LeftHand->GetRpClump(), animHierarchy, 0);
         ++CObject::nNoTempObjects;
         return;
     }
@@ -83,7 +83,7 @@ void CTaskSimplePlayHandSignalAnim::StartAnim(CPed* ped) {
     //
     // Both arms logic
     //
-    m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_HANDSIGNAL, animId, m_AnimBlenDelta);
+    m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_HANDSIGNAL, animId, m_AnimBlenDelta);
     m_pAnim->SetFinishCallback(CTaskSimpleAnim::FinishRunAnimCB, this);
     if (m_PlayerIdlesAnimBlockId == -1) {
         return;
@@ -94,7 +94,7 @@ void CTaskSimplePlayHandSignalAnim::StartAnim(CPed* ped) {
         if (handObj) {
             CWorld::Add(handObj);
             CAnimManager::AddAnimation(
-                handObj->m_pRwClump,
+                handObj->GetRpClump(),
                 CAnimManager::GetAnimAssociation(ANIM_GROUP_LHAND, m_PlayerIdlesAnimBlockId)->GetAnimHierarchy(),
                 0
             );

--- a/source/game_sa/Tasks/TaskTypes/TaskSimplePlayerOnFoot.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimplePlayerOnFoot.cpp
@@ -54,7 +54,7 @@ bool CTaskSimplePlayerOnFoot::MakeAbortable(CPed* ped, eAbortPriority priority, 
     bool abortable = false;
     if (priority == ABORT_PRIORITY_IMMEDIATE) {
         ped->GetPlayerData()->m_fMoveBlendRatio = 0.0f;
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
         abortable = true;
     }
     else if (priority == ABORT_PRIORITY_URGENT) {
@@ -212,7 +212,7 @@ void CTaskSimplePlayerOnFoot::ProcessPlayerWeapon(CPlayerPed* player) {
                 fightCommand = 11;
             }
 
-            CAnimBlendAssociation* animAssoc = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_KILL_PARTIAL);
+            CAnimBlendAssociation* animAssoc = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_KILL_PARTIAL);
             if (animAssoc) {
                 animAssoc->m_BlendAmount = -2.0f;
             }
@@ -248,15 +248,15 @@ void CTaskSimplePlayerOnFoot::ProcessPlayerWeapon(CPlayerPed* player) {
                 if (player->bIsDucking) {
                     CTaskSimpleDuck* duckTask = intelligence->GetTaskDuck(true);
                     if (duckTask && duckTask->IsTaskInUseByOtherTasks()) {
-                        animAssociation = RpAnimBlendClumpGetFirstAssociation(player->m_pRwClump);
+                        animAssociation = RpAnimBlendClumpGetFirstAssociation(player->GetRpClump());
                     } else {
-                        animAssociation = CAnimManager::BlendAnimation(player->m_pRwClump, weaponInfo->m_eAnimGroup, ANIM_ID_KILL_PARTIAL, 8.0f);
+                        animAssociation = CAnimManager::BlendAnimation(player->GetRpClump(), weaponInfo->m_eAnimGroup, ANIM_ID_KILL_PARTIAL, 8.0f);
                     }
                 } else {
-                    animAssociation = CAnimManager::BlendAnimation(player->m_pRwClump, weaponInfo->m_eAnimGroup, ANIM_ID_KILL_PARTIAL, 8.0f);
+                    animAssociation = CAnimManager::BlendAnimation(player->GetRpClump(), weaponInfo->m_eAnimGroup, ANIM_ID_KILL_PARTIAL, 8.0f);
                 }
             } else {
-                animAssociation = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_KILL_PARTIAL);
+                animAssociation = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_KILL_PARTIAL);
                 if (animAssociation) {
                     animAssociation->m_BlendAmount = -2.0f;
                 }
@@ -455,17 +455,17 @@ void CTaskSimplePlayerOnFoot::ProcessPlayerWeapon(CPlayerPed* player) {
             AssocGroupId animGroupId = weaponInfo->m_eAnimGroup;
             AnimationId crouchReloadAnimID = weaponInfo->flags.bReload ? ANIM_ID_RELOAD : ANIM_ID_WALK;
             if (!player->bIsDucking) {
-                if (!RpAnimBlendClumpGetAssociation(player->m_pRwClump, crouchReloadAnimID)) {
-                    CAnimManager::BlendAnimation(player->m_pRwClump, animGroupId, crouchReloadAnimID, 4.0f);
+                if (!RpAnimBlendClumpGetAssociation(player->GetRpClump(), crouchReloadAnimID)) {
+                    CAnimManager::BlendAnimation(player->GetRpClump(), animGroupId, crouchReloadAnimID, 4.0f);
                 }
             } else {
                 auto duckTask = (CTaskSimpleDuck*)intelligence->GetTaskDuck(true);
                 if (weaponInfo->GetCrouchReloadAnimationID() && gbUnknown_8D2FE8 && duckTask) {
                     if (!duckTask->IsTaskInUseByOtherTasks()) {
                         crouchReloadAnimID = weaponInfo->GetCrouchReloadAnimationID();
-                        if (!RpAnimBlendClumpGetAssociation(player->m_pRwClump, crouchReloadAnimID)) {
+                        if (!RpAnimBlendClumpGetAssociation(player->GetRpClump(), crouchReloadAnimID)) {
                             crouchReloadAnimID = weaponInfo->GetCrouchReloadAnimationID();
-                            CAnimManager::BlendAnimation(player->m_pRwClump, animGroupId, crouchReloadAnimID, 4.0f);
+                            CAnimManager::BlendAnimation(player->GetRpClump(), animGroupId, crouchReloadAnimID, 4.0f);
                         }
                     }
                 }
@@ -703,7 +703,7 @@ void CTaskSimplePlayerOnFoot::PlayIdleAnimations(CPlayerPed* player) {
         if (playerIdlesAnimBlock->IsLoaded) {
             CStreaming::SetModelIsDeletable(IFPToModelId(m_PlayerIdlesAnimBlockId));
             CAnimBlendAssociation* animAssoc = nullptr;
-            for (animAssoc = RpAnimBlendClumpGetFirstAssociation(player->m_pRwClump); animAssoc; animAssoc = RpAnimBlendGetNextAssociation(animAssoc)) {
+            for (animAssoc = RpAnimBlendClumpGetFirstAssociation(player->GetRpClump()); animAssoc; animAssoc = RpAnimBlendGetNextAssociation(animAssoc)) {
                 if (animAssoc->m_Flags & ANIMATION_200) {
                     animAssoc->m_BlendDelta = -8.0f;
                 }
@@ -722,7 +722,7 @@ void CTaskSimplePlayerOnFoot::PlayIdleAnimations(CPlayerPed* player) {
     if (!(player->bIsLooking && player->bIsRestoringLook) && touchTimeDelta - gLastTouchTimeDelta > 20000) {
         // Check if the player already has any anims from the idle anim block playing already
         bool anyIdleAnims = false;
-        RpAnimBlendClumpForEachAssociation(player->m_pRwClump, [&](CAnimBlendAssociation* a) {
+        RpAnimBlendClumpForEachAssociation(player->GetRpClump(), [&](CAnimBlendAssociation* a) {
             if (CAnimManager::IsAnimInBlock(a->GetHier(), playerIdlesAnimBlock)) {
                 anyIdleAnims = true;
                 return false;
@@ -747,7 +747,7 @@ void CTaskSimplePlayerOnFoot::PlayIdleAnimations(CPlayerPed* player) {
                 {ANIM_ID_STRLEG, ANIM_GROUP_PLAYIDLES},
             };
             auto animation = animations[randomNumber];
-            CAnimBlendAssociation* animNewAssoc = CAnimManager::BlendAnimation(player->m_pRwClump, animation.assoc, animation.animId, 8.0f);
+            CAnimBlendAssociation* animNewAssoc = CAnimManager::BlendAnimation(player->GetRpClump(), animation.assoc, animation.animId, 8.0f);
             animNewAssoc->m_Flags |= ANIMATION_200;
             gLastTouchTimeDelta = touchTimeDelta;
             gLastRandomNumberForIdleAnimationID = randomNumber;
@@ -866,7 +866,7 @@ void CTaskSimplePlayerOnFoot::PlayerControlDucked(CPlayerPed* player) {
                 if (pedMoveBlendRatio <= 0.5f) {
                     return;
                 }
-                auto pNewAnimation = CAnimManager::BlendAnimation(player->m_pRwClump, player->m_nAnimGroup, ANIM_ID_RUN, gDuckAnimBlendData);
+                auto pNewAnimation = CAnimManager::BlendAnimation(player->GetRpClump(), player->m_nAnimGroup, ANIM_ID_RUN, gDuckAnimBlendData);
                 pNewAnimation->m_Flags |= ANIMATION_IS_PLAYING;
                 player->GetPlayerData()->m_fMoveBlendRatio = 1.5f;
                 pedMoveState = PEDMOVE_RUN;
@@ -874,7 +874,7 @@ void CTaskSimplePlayerOnFoot::PlayerControlDucked(CPlayerPed* player) {
                 if (pedMoveBlendRatio <= 0.5f) {
                     return;
                 }
-                auto pNewAnimation = CAnimManager::BlendAnimation(player->m_pRwClump, player->m_nAnimGroup, ANIM_ID_WALK, gDuckAnimBlendData);
+                auto pNewAnimation = CAnimManager::BlendAnimation(player->GetRpClump(), player->m_nAnimGroup, ANIM_ID_WALK, gDuckAnimBlendData);
                 pNewAnimation->m_Flags |= ANIMATION_IS_PLAYING;
                 player->GetPlayerData()->m_fMoveBlendRatio = 1.5f;
                 pedMoveState = PEDMOVE_WALK;
@@ -882,7 +882,7 @@ void CTaskSimplePlayerOnFoot::PlayerControlDucked(CPlayerPed* player) {
             player->m_nMoveState = pedMoveState;
             player->m_nSwimmingMoveState = pedMoveState;
         } else if (pedMoveBlendRatio > 0.5f) {
-            auto pNewAnimation = CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_GUNMOVE_FWD, gDuckAnimBlendData);
+            auto pNewAnimation = CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_GUNMOVE_FWD, gDuckAnimBlendData);
             pNewAnimation->m_Flags |= ANIMATION_IS_PLAYING;
             player->GetPlayerData()->m_fMoveBlendRatio = 1.0f;
             moveSpeed.x = 1.0f;
@@ -987,8 +987,8 @@ int32 CTaskSimplePlayerOnFoot::PlayerControlZelda(CPlayerPed* player, bool bAvoi
     player->SetRealMoveAnim();
     // What is the point of calling RpAnimBlendClumpGetAssociation here?
     // Nvm, let's keep it.
-    RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_IDLE_ARMED);
-    RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_IDLE_CHAT);
+    RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_IDLE_ARMED);
+    RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_IDLE_CHAT);
 
     if (bAvoidJumpingAndDucking) {
         PlayIdleAnimations(player);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleRunAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleRunAnim.cpp
@@ -55,7 +55,7 @@ bool CTaskSimpleRunAnim::ProcessPed(CPed* ped)
     if (m_bIsFinished)
         return true;
 
-    if (!m_pAnim && !RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_nAnimId))
+    if (!m_pAnim && !RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_nAnimId))
         StartAnim(ped);
 
     return m_bIsFinished;
@@ -64,7 +64,7 @@ bool CTaskSimpleRunAnim::ProcessPed(CPed* ped)
 // 0x61A950
 void CTaskSimpleRunAnim::StartAnim(CPed* ped)
 {
-    m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_nAnimGroup, m_nAnimId, m_fBlendDelta);
+    m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_nAnimGroup, m_nAnimId, m_fBlendDelta);
     m_pAnim->SetFinishCallback(CTaskSimpleAnim::FinishRunAnimCB, this);
 }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleRunTimedAnim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleRunTimedAnim.cpp
@@ -42,7 +42,7 @@ CTaskSimpleRunTimedAnim::CTaskSimpleRunTimedAnim(AssocGroupId groupId, Animation
 
 // 0x61AC50
 void CTaskSimpleRunTimedAnim::StartAnim(CPed* ped) {
-    m_pAnim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_animGrpId, m_animId, m_blendDelta);
+    m_pAnim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_animGrpId, m_animId, m_blendDelta);
     m_pAnim->SetDeleteCallback(CTaskSimpleAnim::FinishRunAnimCB, this);
 }
 
@@ -56,7 +56,7 @@ bool CTaskSimpleRunTimedAnim::ProcessPed(CPed* ped) {
         MakeAbortable(ped, ABORT_PRIORITY_LEISURE, nullptr);
     }
 
-    if (!m_pAnim && !RpAnimBlendClumpGetAssociation(ped->m_pRwClump, (uint32)m_animId)) {
+    if (!m_pAnim && !RpAnimBlendClumpGetAssociation(ped->GetRpClump(), (uint32)m_animId)) {
         m_timer.Start((int32)m_durationMs);
         StartAnim(ped);
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleShakeFist.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleShakeFist.cpp
@@ -40,7 +40,7 @@ void CTaskSimpleShakeFist::FinishAnimShakeFistCB(CAnimBlendAssociation*, void* d
 
 // 0x692DF0
 void CTaskSimpleShakeFist::StartAnim(CPed* ped) {
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_FUCKU, 4.f);
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_FUCKU, 4.f);
     m_anim->SetFlag(ANIMATION_IS_FINISH_AUTO_REMOVE);
     m_anim->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE);
     m_anim->SetDeleteCallback(FinishAnimShakeFistCB, this);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleSitDown.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleSitDown.cpp
@@ -48,7 +48,7 @@ void CTaskSimpleSitDown::StartAnim(CPed* ped) {
     assert(!m_anim);
 
     const auto SetAnim = [this, ped](auto grpId, auto animId) {
-        m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 4.f);
+        m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 4.f);
     };
     if (m_sitOnStep) {
         SetAnim(ANIM_GROUP_ATTRACTORS, ANIM_ID_STEPSIT_IN);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleSitIdle.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleSitIdle.cpp
@@ -33,7 +33,7 @@ CTaskSimpleSitIdle::CTaskSimpleSitIdle(const CTaskSimpleSitIdle& o) :
 void CTaskSimpleSitIdle::StartAnim(CPed* ped) {
     m_animStartedTimer.Start(m_durationMs);
 
-    const auto StartAnim = [this, ped](auto grpId, auto animId) { m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 256.f); };
+    const auto StartAnim = [this, ped](auto grpId, auto animId) { m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 256.f); };
     if (m_bSitAfterStep) {
         StartAnim(ANIM_GROUP_ATTRACTORS, ANIM_ID_STEPSIT_LOOP);
     } else {

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleStandStill.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleStandStill.cpp
@@ -37,7 +37,7 @@ bool CTaskSimpleStandStill::ProcessPed(CPed* ped) {
             ped->SetMoveState(PEDMOVE_STILL);
             ped->m_nSwimmingMoveState = PEDMOVE_STILL;
             if (!ped->bIsDucking || !ped->GetIntelligence()->GetTaskDuck(false)) {
-                CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, m_fBlendData);
+                CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, m_fBlendData);
             } else {
                 CTaskSimpleDuck* pDuckTask = ped->GetIntelligence()->GetTaskDuck(false);
                 pDuckTask->ControlDuckMove();
@@ -55,7 +55,7 @@ bool CTaskSimpleStandStill::ProcessPed(CPed* ped) {
     }
 
     if (m_bUseAnimIdleStance) {
-        auto pIdleAnimAssoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE);
+        auto pIdleAnimAssoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE);
         if (pIdleAnimAssoc && pIdleAnimAssoc->m_BlendAmount > 0.99f)
             return true;
     }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleStandUp.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleStandUp.cpp
@@ -45,7 +45,7 @@ void CTaskSimpleStandUp::FinishAnimStandUpCB(CAnimBlendAssociation* anim, void* 
 
 // 0x631410
 void CTaskSimpleStandUp::StartAnim(CPed* ped) {
-    const auto SetAnim = [this, ped](auto grpId, auto animId) { m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, grpId, animId, 4.f); };
+    const auto SetAnim = [this, ped](auto grpId, auto animId) { m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), grpId, animId, 4.f); };
     if (m_sitAfterStep) {
         SetAnim(ANIM_GROUP_ATTRACTORS, ANIM_ID_STEPSIT_OUT);
     } else {

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleStealthKill.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleStealthKill.cpp
@@ -109,7 +109,7 @@ void CTaskSimpleStealthKill::ManageAnim(CPed* ped) {
         return;
     }
 
-    m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, m_animGrpId, [&, this] {
+    m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), m_animGrpId, [&, this] {
         if (m_bKeepTargetAlive) {
             return ANIM_ID_KILL_KNIFE_PLAYER;
         }

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleSwim.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleSwim.cpp
@@ -77,12 +77,12 @@ void CTaskSimpleSwim::DestroyFxSystem() {
 
 bool CTaskSimpleSwim::MakeAbortable(class CPed* ped, eAbortPriority priority, const CEvent* event) {
     if (priority == ABORT_PRIORITY_IMMEDIATE) {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.0f);
         ped->m_nMoveState = PEDMOVE_STILL;
         ped->m_nSwimmingMoveState = PEDMOVE_STILL;
 
         if (m_AnimID != ANIM_ID_NO_ANIMATION_SET) {
-            auto assoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_AnimID);
+            auto assoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_AnimID);
             if (assoc) {
                 assoc->m_BlendDelta = -1000.0f;
             }
@@ -110,7 +110,7 @@ bool CTaskSimpleSwim::MakeAbortable(class CPed* ped, eAbortPriority priority, co
 // 0x0
 bool CTaskSimpleSwim::ProcessPed(CPed* ped) {
     if (m_pEntity) {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 8.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 8.0f);
         ped->m_nMoveState = PEDMOVE_STILL;
         ped->m_nSwimmingMoveState = PEDMOVE_STILL;
 
@@ -121,7 +121,7 @@ bool CTaskSimpleSwim::ProcessPed(CPed* ped) {
     if (m_fSwimStopTime > SWIM_STOP_TIME || ped->bInVehicle) {
         CAnimBlendAssociation* assoc = nullptr;
         if (m_AnimID != ANIM_ID_NO_ANIMATION_SET) {
-            assoc = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, m_AnimID);
+            assoc = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), m_AnimID);
         }
         AnimationId animId = ANIM_ID_IDLE;
         ped->m_nSwimmingMoveState = PEDMOVE_STILL;
@@ -142,7 +142,7 @@ bool CTaskSimpleSwim::ProcessPed(CPed* ped) {
                 ped->m_nMoveState = PEDMOVE_RUN;
             }
         }
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, animId, 4.0f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, animId, 4.0f);
         ped->RestoreHeadingRate();
         DestroyFxSystem();
         return true;
@@ -162,7 +162,7 @@ bool CTaskSimpleSwim::ProcessPed(CPed* ped) {
             ped->GetPlayerData()->m_fMoveBlendRatio = DistanceBetweenPoints2D(ped->GetPosition(), m_vecPos);
             if (ped->GetPlayerData()->m_fMoveBlendRatio < 0.5f) {
                 ped->GetPlayerData()->m_fMoveBlendRatio = 0.0f;
-                CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 4.0f);
+                CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 4.0f);
                 ped->RestoreHeadingRate();
                 DestroyFxSystem();
                 return true;
@@ -177,7 +177,7 @@ bool CTaskSimpleSwim::ProcessPed(CPed* ped) {
         float fDecreaseAirMult = 1.0f;
         if (m_nSwimState == SWIM_UNDERWATER_SPRINTING) {
             bDecreaseAir = true;
-            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_UNDER);
+            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_UNDER);
             if (assocUnder) {
                 fDecreaseAirMult = assocUnder->m_Speed * assocUnder->m_BlendAmount + 1.0f;
             }
@@ -230,18 +230,18 @@ void CTaskSimpleSwim::ApplyRollAndPitch(CPed* ped) const {
 void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
     auto* player = ped->AsPlayer();
     const CVector& pedPos = player->GetPosition();
-    CAnimBlendAssociation* assocTread = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_TREAD);
+    CAnimBlendAssociation* assocTread = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_TREAD);
     if (m_bFinishedBlending) {
         if (assocTread && assocTread->m_BlendAmount < 1.0f && assocTread->m_BlendDelta <= 0.0f) {
-            CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_SWIM_TREAD, 8.0f);
+            CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_SWIM_TREAD, 8.0f);
         }
     } else {
-        if (assocTread || (assocTread = CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_SWIM_TREAD, 8.0f)) != nullptr) {
+        if (assocTread || (assocTread = CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_SWIM_TREAD, 8.0f)) != nullptr) {
             if (assocTread->m_BlendAmount >= 1.0f) {
                 m_bFinishedBlending = true;
             }
         }
-        RpAnimBlendClumpSetBlendDeltas(player->m_pRwClump, 0x10, -8.0f); // todo: ANIMATION_IS_PARTIAL ?
+        RpAnimBlendClumpSetBlendDeltas(player->GetRpClump(), 0x10, -8.0f); // todo: ANIMATION_IS_PARTIAL ?
         FxSystem_c::SafeKillAndClear(player->GetActiveWeapon().m_FxSystem); // Removes fire or something in water
 
         if (player->IsPlayer() && !m_nSwimState) {
@@ -289,7 +289,7 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
             { ANIM_ID_CLIMB_JUMP,       -4.0f },
         };
         for (const auto& [anim, delta] : mapping) {
-            if (auto* assoc = RpAnimBlendClumpGetAssociation(player->m_pRwClump, anim)) {
+            if (auto* assoc = RpAnimBlendClumpGetAssociation(player->GetRpClump(), anim)) {
                 assoc->m_BlendDelta = delta;
             }
         }
@@ -298,7 +298,7 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
     }
     case SWIM_SPRINT: {
         if (m_AnimID == ANIM_ID_SWIM_BREAST) {
-            CAnimBlendAssociation* assoc = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_BREAST);
+            CAnimBlendAssociation* assoc = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_BREAST);
             if (!assoc) {
                 m_nSwimState = SWIM_TREAD;
                 break;
@@ -309,14 +309,14 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
                 assoc->m_Speed = m_fAnimSpeed;
             }
         } else {
-            CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_BREAST, 2.0f);
+            CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_BREAST, 2.0f);
             m_AnimID = ANIM_ID_SWIM_BREAST;
         }
         break;
     }
     case SWIM_SPRINTING: {
         if (m_AnimID == ANIM_ID_SWIM_CRAWL) {
-            CAnimBlendAssociation* assoc = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_CRAWL);
+            CAnimBlendAssociation* assoc = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_CRAWL);
             if (!assoc) {
                 m_nSwimState = SWIM_TREAD;
                 break;
@@ -328,14 +328,14 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
                 assoc->m_Speed = std::min(1.5f, m_fAnimSpeed - 1.0f);
             }
         } else {
-            CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_CRAWL, 2.0f);
+            CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_CRAWL, 2.0f);
             m_AnimID = ANIM_ID_SWIM_CRAWL;
         }
         break;
     }
     case SWIM_DIVE_UNDERWATER: {
         if (m_AnimID == ANIM_ID_SWIM_DIVE_UNDER) {
-            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_DIVE_UNDER);
+            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_DIVE_UNDER);
             if (!assocUnder) {
                 m_nSwimState = SWIM_TREAD;
                 break;
@@ -345,7 +345,7 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
                 m_nSwimState = SWIM_UNDERWATER_SPRINTING;
             }
         } else {
-            CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_DIVE_UNDER, 8.0f);
+            CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_DIVE_UNDER, 8.0f);
             m_AnimID = ANIM_ID_SWIM_DIVE_UNDER;
         }
         break;
@@ -353,9 +353,9 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
     case SWIM_UNDERWATER_SPRINTING: {
         if ((m_AnimID == ANIM_ID_SWIM_UNDER || m_AnimID == ANIM_ID_SWIM_GLIDE) && m_fStateChanger >= 0.0f) {
             if (player->GetPlayerData() && player->GetButtonSprintResults(SPRINT_UNDERWATER) >= 1.0f) {
-                CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_UNDER);
+                CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_UNDER);
                 if (!assocUnder || assocUnder->m_BlendDelta < 0.0f || assocUnder->m_BlendAmount == 0.0f) {
-                    assocUnder = CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_UNDER, 4.0f);
+                    assocUnder = CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_UNDER, 4.0f);
                 }
                 if (assocUnder->m_BlendHier->m_fTotalTime == assocUnder->m_CurrentTime) {
                     assocUnder->Start(0.0f);
@@ -363,14 +363,14 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
                 }
                 m_AnimID = ANIM_ID_SWIM_UNDER;
             } else {
-                CAnimBlendAssociation* assocGlide = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_GLIDE);
+                CAnimBlendAssociation* assocGlide = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_GLIDE);
                 if (!assocGlide || assocGlide->m_BlendDelta < 0.0f || assocGlide->m_BlendAmount == 0.0f) {
-                    CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_GLIDE, 4.0f);
+                    CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_GLIDE, 4.0f);
                 }
                 m_AnimID = ANIM_ID_SWIM_GLIDE;
             }
         } else {
-            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_UNDER);
+            CAnimBlendAssociation* assocUnder = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_UNDER);
             if (assocUnder) {
                 if (m_fStateChanger < 0.0f && assocUnder->m_BlendAmount >= 0.99f) {
                     if (m_fStateChanger > -2.0f) {
@@ -382,7 +382,7 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
                     }
                 }
             } else {
-                CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_UNDER, 1000.0f);
+                CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_UNDER, 1000.0f);
                 if (m_AnimID == ANIM_ID_SWIM_TREAD || m_AnimID == ANIM_ID_NO_ANIMATION_SET) {
                     m_fStateChanger = -2.0f;
                     m_AnimID = ANIM_ID_SWIM_UNDER;
@@ -396,10 +396,10 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
     }
     case SWIM_BACK_TO_SURFACE: {
         if (m_AnimID == ANIM_ID_SWIM_JUMPOUT) {
-            CAnimBlendAssociation* assocJumpOut = RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_SWIM_JUMPOUT);
+            CAnimBlendAssociation* assocJumpOut = RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_SWIM_JUMPOUT);
             if (assocJumpOut) {
                 if (assocJumpOut->m_BlendHier->m_fTotalTime / 4.0f <= assocJumpOut->m_TimeStep + assocJumpOut->m_CurrentTime) {
-                    assocJumpOut = CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0f);
+                    assocJumpOut = CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_CLIMB_JUMP, 8.0f);
                     assocJumpOut->m_Flags |= ANIMATION_IS_FINISH_AUTO_REMOVE;
                     m_AnimID = ANIM_ID_CLIMB_JUMP;
                 }
@@ -407,14 +407,14 @@ void CTaskSimpleSwim::ProcessSwimAnims(CPed* ped) {
             }
         } else {
             if (m_AnimID != ANIM_ID_CLIMB_JUMP) {
-                CAnimManager::BlendAnimation(player->m_pRwClump, ANIM_GROUP_SWIM, ANIM_ID_SWIM_JUMPOUT, 8.0f);
+                CAnimManager::BlendAnimation(player->GetRpClump(), ANIM_GROUP_SWIM, ANIM_ID_SWIM_JUMPOUT, 8.0f);
                 m_AnimID = ANIM_ID_SWIM_JUMPOUT;
                 player->m_vecMoveSpeed.z = 8.0f / player->m_fMass;
                 m_pEntity = CTaskSimpleClimb::TestForClimb(player, m_pClimbPos, m_fAngle, m_nSurfaceType, true);
                 CEntity::SafeRegisterRef(m_pEntity);
                 break;
             }
-            if (RpAnimBlendClumpGetAssociation(player->m_pRwClump, ANIM_ID_CLIMB_JUMP)) { // 0x689C4B
+            if (RpAnimBlendClumpGetAssociation(player->GetRpClump(), ANIM_ID_CLIMB_JUMP)) { // 0x689C4B
                 float waterLevel1 = 0.0f;
                 if (CWaterLevel::GetWaterLevel(pedPos, waterLevel1, true)) {
                     if (pedPos.z + 0.5f < waterLevel1) {
@@ -449,13 +449,13 @@ void CTaskSimpleSwim::ProcessSwimmingResistance(CPed* ped) {
         float fAnimBlendSum = 0.0f;
         float fAnimBlendDifference = 1.0f;
 
-        CAnimBlendAssociation* animSwimBreast = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_BREAST);
+        CAnimBlendAssociation* animSwimBreast = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_BREAST);
         if (animSwimBreast) {
             fAnimBlendSum = 0.4f * animSwimBreast->m_BlendAmount;
             fAnimBlendDifference = 1.0f - animSwimBreast->m_BlendAmount;
         }
 
-        CAnimBlendAssociation* animSwimCrawl = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_CRAWL);
+        CAnimBlendAssociation* animSwimCrawl = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_CRAWL);
         if (animSwimCrawl) {
             fAnimBlendSum += 0.2f * animSwimCrawl->m_BlendAmount;
             fAnimBlendDifference -= animSwimCrawl->m_BlendAmount;
@@ -474,7 +474,7 @@ void CTaskSimpleSwim::ProcessSwimmingResistance(CPed* ped) {
         vecPedMoveSpeed =  ped->m_vecAnimMovingShiftLocal.x * ped->GetRight();
         vecPedMoveSpeed += ped->m_vecAnimMovingShiftLocal.y * ped->GetForward();
 
-        auto animSwimDiveUnder = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_DIVE_UNDER);
+        auto animSwimDiveUnder = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_DIVE_UNDER);
         if (animSwimDiveUnder) {
             vecPedMoveSpeed.z = animSwimDiveUnder->m_CurrentTime / animSwimDiveUnder->m_BlendHier->m_fTotalTime * -0.1f;
         }
@@ -487,9 +487,9 @@ void CTaskSimpleSwim::ProcessSwimmingResistance(CPed* ped) {
         break;
     }
     case SWIM_BACK_TO_SURFACE: {
-        auto animClimb = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_CLIMB_JUMP);
+        auto animClimb = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_CLIMB_JUMP);
         if (!animClimb)
-            animClimb = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_SWIM_JUMPOUT);
+            animClimb = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_SWIM_JUMPOUT);
 
         if (animClimb) {
             if (animClimb->m_BlendHier->m_fTotalTime > animClimb->m_CurrentTime &&
@@ -626,7 +626,7 @@ void CTaskSimpleSwim::ProcessEffects(CPed* ped) {
         ped->GetAE().AddAudioEvent(AE_PED_SWIM_WAKE, 0.0f, 1.0f);
 
         if (m_nSwimState == SWIM_SPRINTING) {
-            RpHAnimHierarchy* animHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump); // todo: almost CPed::GetBoneMatrix
+            RpHAnimHierarchy* animHierarchy = GetAnimHierarchyFromSkinClump(ped->GetRpClump()); // todo: almost CPed::GetBoneMatrix
             const auto GetBonePos = [&](auto boneId) {
                 auto index = RpHAnimIDGetIndex(animHierarchy, boneId);
                 return &RpHAnimHierarchyGetMatrixArray(animHierarchy)[index].pos;
@@ -663,7 +663,7 @@ void CTaskSimpleSwim::ProcessEffects(CPed* ped) {
             oxygen = static_cast<uint32>(((100.0f - ped->GetPlayerData()->m_fBreath / CStats::GetFatAndMuscleModifier(STAT_MOD_AIR_IN_LUNG) * 100.0f) / 3.0f));
         }
         if ((unsigned)CGeneral::GetRandomNumberInRange(0, 100) < oxygen) {
-            RpHAnimHierarchy* hier = GetAnimHierarchyFromSkinClump(ped->m_pRwClump); // todo: almost CPed::GetBoneMatrix
+            RpHAnimHierarchy* hier = GetAnimHierarchyFromSkinClump(ped->GetRpClump()); // todo: almost CPed::GetBoneMatrix
             CVector* bonePos = static_cast<CVector*>(&RpHAnimHierarchyGetMatrixArray(hier)[BONE_JAW].pos); // FIX_BUGS: Air bubbles from ass :D (BONE_SPINE1)
 
             static FxPrtMult_c fxPrtMult(1.0f, 1.0f, 1.0f, 0.25f, 0.3f, 0.0f, 0.5f);

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleThrowProjectile.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleThrowProjectile.cpp
@@ -80,7 +80,7 @@ void CTaskSimpleThrowProjectile::FinishAnimThrowProjectileCB(CAnimBlendAssociati
 // 0x6259E0
 void CTaskSimpleThrowProjectile::StartAnim(CPed* ped) {
     const auto StartAnim = [&, this](AnimationId animId, float blendDelta) {
-        VERIFY(m_Anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ped->GetActiveWeapon().GetWeaponInfo().m_eAnimGroup, animId, blendDelta));
+        VERIFY(m_Anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ped->GetActiveWeapon().GetWeaponInfo().m_eAnimGroup, animId, blendDelta));
         m_Anim->SetFinishCallback(FinishAnimThrowProjectileCB, this);
     };
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleTired.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleTired.cpp
@@ -31,7 +31,7 @@ void CTaskSimpleTired::StartAnim(CPed* ped) {
     m_TiredDurationMs_Copy = m_TiredDurationMs;
     m_AnimHasStarted = true;
     m_TiredAnim = CAnimManager::BlendAnimation(
-        ped->m_pRwClump,
+        ped->GetRpClump(),
         FindPlayerPed() == ped && CClothes::GetDefaultPlayerMotionGroup() == ANIM_GROUP_FAT ? ANIM_GROUP_FAT_TIRED : ANIM_GROUP_DEFAULT,
         ANIM_ID_IDLE_TIRED,
         4.f
@@ -40,7 +40,7 @@ void CTaskSimpleTired::StartAnim(CPed* ped) {
 
 // 0x630FF0
 bool CTaskSimpleTired::MakeAbortable(CPed* ped, eAbortPriority priority, const CEvent* event) {
-    if (m_TiredAnim && m_TiredAnim == RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_IDLE_TIRED)) {
+    if (m_TiredAnim && m_TiredAnim == RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_IDLE_TIRED)) {
         m_TiredAnim->m_BlendDelta = -4.f;
     }
     return true;

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleTurn180.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleTurn180.cpp
@@ -42,7 +42,7 @@ bool CTaskSimpleTurn180::ProcessPed(CPed* ped) {
 
     if (!m_anim) {
         ped->m_fHeadingChangeRate = 0.f;
-        m_anim = CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_TURN_180, 4.f);
+        m_anim = CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_TURN_180, 4.f);
         m_anim->SetFinishCallback(FinishAnimTurn180CB, this);
     }
 

--- a/source/game_sa/Tasks/TaskTypes/TaskSimpleUseGun.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskSimpleUseGun.cpp
@@ -142,7 +142,7 @@ void CTaskSimpleUseGun::RemoveStanceAnims(CPed* ped, float x) {
         ANIM_ID_GUNMOVE_BWD,
         ANIM_ID_GUNMOVE_R,
     }) {
-        if (const auto a = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, animId)) {
+        if (const auto a = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), animId)) {
             a->SetFlag(ANIMATION_IS_BLEND_AUTO_REMOVE);
             pedHasStanceAnims = true;
         }
@@ -156,7 +156,7 @@ void CTaskSimpleUseGun::RemoveStanceAnims(CPed* ped, float x) {
     }
 
     const auto DoBlendAnimAndStart = [ped](AnimationId animId) {
-        const auto animWalk = CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, animId);
+        const auto animWalk = CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, animId);
         animWalk->SetFlag(ANIMATION_IS_PLAYING);
     };
 
@@ -184,7 +184,7 @@ void CTaskSimpleUseGun::RemoveStanceAnims(CPed* ped, float x) {
         case ANIM_GROUP_PLAYERROCKETM:
             break;
         default:
-            CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, ANIM_ID_GUN_2_IDLE, 8.f);
+            CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, ANIM_ID_GUN_2_IDLE, 8.f);
         }
     }
 }
@@ -403,7 +403,7 @@ bool CTaskSimpleUseGun::MakeAbortable(CPed* ped, eAbortPriority priority, const 
     }
     RemoveStanceAnims(ped, -4.f);
     if (priority == ABORT_PRIORITY_IMMEDIATE) {
-        CAnimManager::BlendAnimation(ped->m_pRwClump, ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
+        CAnimManager::BlendAnimation(ped->GetRpClump(), ped->m_nAnimGroup, ANIM_ID_IDLE, 1000.f);
     }
     if (m_Anim) {
         if (priority == ABORT_PRIORITY_IMMEDIATE) {
@@ -605,11 +605,11 @@ void CTaskSimpleUseGun::Reset(CPed* ped, CEntity* targetEntity, CVector targetPo
 // 0x61E3F0
 void CTaskSimpleUseGun::SetMoveAnim(CPed* ped) {
     const auto
-        animGunStand   = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GUN_STAND),
-        animGunMoveFwd = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GUNMOVE_FWD),
-        animGunMoveL   = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GUNMOVE_L),
-        animGunMoveBwd = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GUNMOVE_BWD),
-        animGunMoveR   = RpAnimBlendClumpGetAssociation(ped->m_pRwClump, ANIM_ID_GUNMOVE_R);
+        animGunStand   = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GUN_STAND),
+        animGunMoveFwd = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GUNMOVE_FWD),
+        animGunMoveL   = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GUNMOVE_L),
+        animGunMoveBwd = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GUNMOVE_BWD),
+        animGunMoveR   = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_GUNMOVE_R);
 
     // 0x61E444
     if (ped->bIsDucking) {
@@ -636,7 +636,7 @@ void CTaskSimpleUseGun::SetMoveAnim(CPed* ped) {
         : 0.f;
 
     const auto DoBlendAnim = [ped](AnimationId animId, float blendDelta) {
-        return CAnimManager::BlendAnimation(ped->m_pRwClump, ANIM_GROUP_DEFAULT, animId, blendDelta);
+        return CAnimManager::BlendAnimation(ped->GetRpClump(), ANIM_GROUP_DEFAULT, animId, blendDelta);
     };
 
     // 0x61E505
@@ -709,7 +709,7 @@ void CTaskSimpleUseGun::SetMoveAnim(CPed* ped) {
 
         // If new anim doesn't exists, create it
         if (!toAnim) {
-            toAnim = CAnimManager::AddAnimation(ped->m_pRwClump,ANIM_GROUP_DEFAULT, toAnimId);
+            toAnim = CAnimManager::AddAnimation(ped->GetRpClump(),ANIM_GROUP_DEFAULT, toAnimId);
         }
 
         // Set params of the anim we're transitioning to
@@ -783,7 +783,7 @@ void CTaskSimpleUseGun::StartAnim(CPed* ped) {
         }
 
         m_Anim = CAnimManager::BlendAnimation( // 0x62503A
-            ped->m_pRwClump,
+            ped->GetRpClump(),
             m_WeaponInfo->m_eAnimGroup,
             ped->bIsDucking && m_WeaponInfo->flags.bCrouchFire
                 ? ANIM_ID_CROUCHFIRE
@@ -812,7 +812,7 @@ void CTaskSimpleUseGun::StartAnim(CPed* ped) {
 
         if (m_BurstShots > 0) { // 0x625196 - Inverted
             m_Anim = CAnimManager::BlendAnimation( // 0x62511C
-                ped->m_pRwClump,
+                ped->GetRpClump(),
                 m_WeaponInfo->m_eAnimGroup,
                 ped->bIsDucking && m_WeaponInfo->flags.bCrouchFire
                     ? ANIM_ID_CROUCHRELOAD
@@ -833,7 +833,7 @@ void CTaskSimpleUseGun::StartAnim(CPed* ped) {
             return;
         }
         m_Anim = CAnimManager::BlendAnimation( // 0x6251DC
-            ped->m_pRwClump,
+            ped->GetRpClump(),
             CTaskSimpleFight::m_aComboData[12].m_nAnimGroup,
             ped->bIsDucking
                 ? ANIM_ID_FIGHT_2

--- a/source/game_sa/VisibilityPlugins.cpp
+++ b/source/game_sa/VisibilityPlugins.cpp
@@ -579,9 +579,9 @@ void CVisibilityPlugins::RenderEntity(void* obj, float dist) {
         }
         bool bLightingSetup = entity->SetupLighting();
         if (RwObjectGetType(entity->GetRwObject()) == rpATOMIC) {
-            RenderFadingAtomic(mi, entity->m_pRwAtomic, alpha);
+            RenderFadingAtomic(mi, entity->GetRpAtomic(), alpha);
         } else {
-            RenderFadingClump(mi, entity->m_pRwClump, alpha);
+            RenderFadingClump(mi, entity->GetRpClump(), alpha);
         }
         entity->RemoveLighting(bLightingSetup);
         entity->m_bImBeingRendered = false;
@@ -1016,7 +1016,7 @@ void CVisibilityPlugins::RenderWeaponPedsForPC() {
         if (ped && ped->m_pWeaponObject) {
             ped->SetupLighting();
             const CWeapon& activeWeapon = ped->GetActiveWeapon();
-            RpHAnimHierarchy* pRpAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->m_pRwClump);
+            RpHAnimHierarchy* pRpAnimHierarchy = GetAnimHierarchyFromSkinClump(ped->GetRpClump());
             const int32 boneID = activeWeapon.m_Type != WEAPON_PARACHUTE ? BONE_R_HAND : BONE_SPINE1;
             int32 animIDIndex = RpHAnimIDGetIndex(pRpAnimHierarchy, boneID);
             RwMatrix* pRightHandMatrix = &RpHAnimHierarchyGetMatrixArray(pRpAnimHierarchy)[animIDIndex];

--- a/source/game_sa/Weapon.cpp
+++ b/source/game_sa/Weapon.cpp
@@ -181,9 +181,9 @@ bool CWeapon::GenerateDamageEvent(CPed* victim, CEntity* creator, eWeaponType we
         && victim->GetTaskManager().GetSimplestActiveTask()->GetTaskType() == TASK_SIMPLE_DEAD
     ) {
         const auto floorHitAnim = CAnimManager::BlendAnimation(
-            victim->m_pRwClump,
+            victim->GetRpClump(),
             ANIM_GROUP_DEFAULT,
-            RpAnimBlendClumpGetFirstAssociation(victim->m_pRwClump, ANIMATION_IS_FRONT)
+            RpAnimBlendClumpGetFirstAssociation(victim->GetRpClump(), ANIMATION_IS_FRONT)
                 ? ANIM_ID_FLOOR_HIT_F
                 : ANIM_ID_FLOOR_HIT
         );
@@ -223,10 +223,10 @@ bool CWeapon::GenerateDamageEvent(CPed* victim, CEntity* creator, eWeaponType we
         case ANIM_ID_SHOT_LEFTP:
         case ANIM_ID_SHOT_PARTIAL_B:
         case ANIM_ID_SHOT_RIGHTP: { //> 0x73A769 - Inverted
-            auto anim = RpAnimBlendClumpGetAssociation(victim->m_pRwClump, eventDmg.m_nAnimID);
+            auto anim = RpAnimBlendClumpGetAssociation(victim->GetRpClump(), eventDmg.m_nAnimID);
             if (!anim) {
                 anim = CAnimManager::AddAnimation(
-                    victim->m_pRwClump,
+                    victim->GetRpClump(),
                     (AssocGroupId)eventDmg.m_nAnimGroup,
                     (AnimationId)eventDmg.m_nAnimID
                 );
@@ -244,7 +244,7 @@ bool CWeapon::GenerateDamageEvent(CPed* victim, CEntity* creator, eWeaponType we
             break;
         default: { //< 0x73A7B5
             const auto a = CAnimManager::BlendAnimation(
-                victim->m_pRwClump,
+                victim->GetRpClump(),
                 (AssocGroupId)eventDmg.m_nAnimGroup,
                 (AnimationId)eventDmg.m_nAnimID,
                 eventDmg.m_fAnimBlend
@@ -1067,11 +1067,11 @@ void CWeapon::Update(CPed* owner) {
             };
             if (wi->flags.bReload && (!owner->IsPlayer() || !FindPlayerInfo().m_bFastReload)) { // 0x73DCCE
                 auto animRLoad = RpAnimBlendClumpGetAssociation(
-                    owner->m_pRwClump,
+                    owner->GetRpClump(),
                     ANIM_ID_RELOAD //(wi->m_Flags & 0x1000) != 0 ? ANIM_ID_RELOAD : ANIM_ID_WALK // Always going to be `ANIM_ID_RELOAD`
                 );
                 if (!animRLoad) {
-                    animRLoad = RpAnimBlendClumpGetAssociation(owner->m_pRwClump, wi->GetCrouchReloadAnimationID());
+                    animRLoad = RpAnimBlendClumpGetAssociation(owner->GetRpClump(), wi->GetCrouchReloadAnimationID());
                 }
                 if (animRLoad) { // 0x73DD30
                     ProcessReloadAudioIf([&](uint32 rloadMs, eAudioEvents ae) {
@@ -2001,7 +2001,7 @@ void FireOneInstantHitRound(const CVector& startPoint, const CVector& endPoint, 
             if (!notsa::contains({ PEDSTATE_DIE, PEDSTATE_DEAD }, hitPed->GetPedState())) {
                 const auto pedHitDir = hitPed->GetLocalDirection(startPoint - hitPed->GetPosition2D());
                 CAnimManager::AddAnimation(
-                    hitPed->m_pRwClump,
+                    hitPed->GetRpClump(),
                     ANIM_GROUP_DEFAULT,
                     std::to_array({ANIM_ID_SHOT_PARTIAL, ANIM_ID_SHOT_LEFTP, ANIM_ID_SHOT_PARTIAL_B, ANIM_ID_SHOT_RIGHTP})[pedHitDir]
                 );

--- a/source/game_sa/World.cpp
+++ b/source/game_sa/World.cpp
@@ -1795,7 +1795,7 @@ bool CWorld::ProcessLineOfSightSectorList(PtrListType& ptrList, const CColLine& 
                 || ped->m_pAttachedTo
                 || (bIncludeDeadPeds && !ped->IsAlive())
                 || (bIncludeBikers && ped->bTestForShotInVehicle)) {
-                ProcessColModel(CModelInfo::GetModelInfo(entity->m_nModelIndex)->AsPedModelInfoPtr()->AnimatePedColModelSkinned(entity->m_pRwClump));
+                ProcessColModel(CModelInfo::GetModelInfo(entity->m_nModelIndex)->AsPedModelInfoPtr()->AnimatePedColModelSkinned(entity->GetRpClump()));
             }
             break;
         }


### PR DESCRIPTION
**Also adds checks for the actual object type (clump, atomic).**

Tested briefly, no crashes after leaving CJ's house :D
If anything comes up, it's just a bug surfacing because of the new asserts for object type added.