### PR TITLE
fix(Streaming): Clear stale flags on NOT_LOADED -> REQUESTED transition in `RequestModel`

### DIFF
--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -1447,7 +1447,8 @@ void CStreaming::RequestModel(int32 modelId, int32 streamingFlags) {
         ++ms_numModelsRequested;
         if (streamingFlags & STREAMING_PRIORITY_REQUEST)
             ++ms_numPriorityRequests;
-
+        
+        info.ClearAllFlags();
         info.SetFlags(streamingFlags);
         info.m_LoadState = LOADSTATE_REQUESTED;
         break;


### PR DESCRIPTION
NOT_LOADED path missing ClearAllFlags before SetFlags. 

Original: m_Flags=0 then m_Flags|=streamingFlags. 

Reversed: only SetFlags (OR) without clearing. Pre-existing stale flags from prior load/unload cycles survive into the new REQUESTED state.

By: @j0y