### PR TITLE
fix(ProcessLoadingChannel): store finishing model state in slot 0 during channel processing

### DIFF
--- a/source/game_sa/Streaming.cpp
+++ b/source/game_sa/Streaming.cpp
@@ -1924,8 +1924,8 @@ bool CStreaming::ProcessLoadingChannel(int32 chIdx) {
 
                 if (info.IsLoadingFinishing()) {
                     ch.LoadStatus = eChannelState::STARTED;
-                    ch.modelStreamingBufferOffsets[i] = bufferOffsetInSectors;
-                    ch.modelIds[i] = modelId;
+                    ch.modelStreamingBufferOffsets[0] = bufferOffsetInSectors;
+                    ch.modelIds[0] = modelId;
                     if (i == 0)
                         continue;
                 }


### PR DESCRIPTION
When info.IsLoadingFinishing(), lines 1927-1928 write to ch.modelStreamingBufferOffsets[i] and ch.modelIds[i], but original always writes to index [0]. When i>0 the finishing model's info is lost (overwritten by MODEL_INVALID on next line), breaking large model loading.

By: @j0y