### PR TITLE
fix(Ped): Correct swapped look-restore times in Ped::ClearLookFlag (2000/4000 inverted)

### DIFF
--- a/source/game_sa/Entity/Ped/Ped.cpp
+++ b/source/game_sa/Entity/Ped/Ped.cpp
@@ -2009,7 +2009,7 @@ void CPed::ClearLookFlag() {
         m_pedIK.bTorsoUsed = false;
     }
 
-    m_nLookTime = CTimer::GetTimeInMS() + (IsPlayer() ? 4000 : 2000);
+    m_nLookTime = CTimer::GetTimeInMS() + (IsPlayer() ? 2000 : 4000);
 
     // .. } while ((PEDSTATE_LOOK_HEADING || PEDSTATE_LOOK_ENTITY) && bIsLooking), but `bIsLooking` will never be true at this point.
 }


### PR DESCRIPTION
Fix:
<img width="904" height="459" alt="image" src="https://github.com/user-attachments/assets/3bb20fd5-9ba2-4e14-bca1-8eefd9cff8ff" />


By @j0y