### PR TITLE
fix(Entity): lost virtual dispatch in `CEntity::SetModelIndex`

### DIFF
--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -232,8 +232,8 @@ void CEntity::Remove() {
 // Sets the entity's model by index and then creates its RenderWare object
 // 0x532AE0
 void CEntity::SetModelIndex(uint32 index) {
-    CEntity::SetModelIndexNoCreate(index);
-    CEntity::CreateRwObject();
+    SetModelIndexNoCreate(index);
+    CreateRwObject();
 }
 
 // Sets the entity's model by index without creating its RenderWare object


### PR DESCRIPTION
Uses non-virtual CEntity::SetModelIndexNoCreate and CEntity::CreateRwObject. Original vtable-dispatches. Derived overrides lost.

pseudocode android:

<img width="823" height="94" alt="image" src="https://github.com/user-attachments/assets/267114c7-001a-4639-9211-62b853b97642" />


by @j0y