### PR TITLE
fix(SetAtomicAlpha): Preserve geometry flags instead of overwriting them

### DIFF
--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -2392,7 +2392,7 @@ bool CEntity::ProcessScan() {
 // 0x533290
 RpAtomic* SetAtomicAlpha(RpAtomic* atomic, void* data) {
     auto geometry = RpAtomicGetGeometry(atomic);
-    RpGeometrySetFlags(geometry, rpGEOMETRYMODULATEMATERIALCOLOR);
+    RpGeometrySetFlags(geometry, RpGeometryGetFlags(geometry) | rpGEOMETRYMODULATEMATERIALCOLOR);
     RpGeometryForAllMaterials(geometry, SetCompAlphaCB, data);
     return atomic;
 }


### PR DESCRIPTION
RpGeometrySetFlags replaces all flags with 0x40. Should OR with existing.

Fix:

<img width="927" height="185" alt="image" src="https://github.com/user-attachments/assets/06e631d6-409b-4546-85ae-af08008d46e1" />



by: @j0y