### PR TITLE
fix(SetRwObjectAlpha): preserve geometry flags in rpATOMIC case

### DIFF
--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -909,7 +909,9 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
 
     switch (RwObjectGetType(GetRwObject())) {
     case rpATOMIC:
-        RpGeometryForAllMaterials(RpAtomicGetGeometry(GetRpAtomic()), SetCompAlphaCB, (void*)alpha);
+        auto geometry = RpAtomicGetGeometry(GetRpAtomic());
+        RpGeometrySetFlags(geometry, RpGeometryGetFlags(geometry) | rpGEOMETRYMODULATEMATERIALCOLOR);
+        RpGeometryForAllMaterials(geometry, SetCompAlphaCB, (void*)alpha);
         break;
     case rpCLUMP:
         RpClumpForAllAtomics(GetRpClump(), SetAtomicAlpha, (void*)alpha);

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -903,17 +903,14 @@ void CEntity::PreRenderForGlassWindow() {
 // Sets the alpha transparency for all materials of the entity's RenderWare object
 // 0x5332C0
 void CEntity::SetRwObjectAlpha(int32 alpha) {
-    if (!GetRwObject()) {
+    auto* const object = GetRwObject();
+    if (!object) {
         return;
     }
-
-    switch (RwObjectGetType(GetRwObject())) {
-        SetAtomicAlpha(GetRpAtomic(), (void*)(alpha));
-        break;
-    }
-    case rpCLUMP:
-        RpClumpForAllAtomics(GetRpClump(), SetAtomicAlpha, (void*)alpha);
-        break;
+    switch (const auto type = RwObjectGetType(object)) {
+    case rpATOMIC: SetAtomicAlpha(GetRpAtomic(), (void*)(alpha)); break;
+    case rpCLUMP:  RpClumpForAllAtomics(GetRpClump(), SetAtomicAlpha, (void*)alpha); break;
+    default:       NOTSA_UNREACHABLE_CASE(type);
     }
 }
 

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -908,7 +908,7 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
     }
 
     switch (RwObjectGetType(GetRwObject())) {
-    SetAtomicAlpha(GetRpAtomic(), (void*)(alpha));
+        SetAtomicAlpha(GetRpAtomic(), (void*)(alpha));
         break;
     }
     case rpCLUMP:

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -908,8 +908,7 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
     }
 
     switch (RwObjectGetType(GetRwObject())) {
-    case rpATOMIC: {
-        auto geometry = RpAtomicGetGeometry(GetRpAtomic());
+        auto* const geometry = RpAtomicGetGeometry(GetRpAtomic());
         RpGeometrySetFlags(geometry, RpGeometryGetFlags(geometry) | rpGEOMETRYMODULATEMATERIALCOLOR);
         RpGeometryForAllMaterials(geometry, SetCompAlphaCB, (void*)alpha);
         break;

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -908,11 +908,12 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
     }
 
     switch (RwObjectGetType(GetRwObject())) {
-    case rpATOMIC:
+    case rpATOMIC: {
         auto geometry = RpAtomicGetGeometry(GetRpAtomic());
         RpGeometrySetFlags(geometry, RpGeometryGetFlags(geometry) | rpGEOMETRYMODULATEMATERIALCOLOR);
         RpGeometryForAllMaterials(geometry, SetCompAlphaCB, (void*)alpha);
         break;
+    }
     case rpCLUMP:
         RpClumpForAllAtomics(GetRpClump(), SetAtomicAlpha, (void*)alpha);
         break;

--- a/source/game_sa/Entity/Entity.cpp
+++ b/source/game_sa/Entity/Entity.cpp
@@ -908,9 +908,7 @@ void CEntity::SetRwObjectAlpha(int32 alpha) {
     }
 
     switch (RwObjectGetType(GetRwObject())) {
-        auto* const geometry = RpAtomicGetGeometry(GetRpAtomic());
-        RpGeometrySetFlags(geometry, RpGeometryGetFlags(geometry) | rpGEOMETRYMODULATEMATERIALCOLOR);
-        RpGeometryForAllMaterials(geometry, SetCompAlphaCB, (void*)alpha);
+    SetAtomicAlpha(GetRpAtomic(), (void*)(alpha));
         break;
     }
     case rpCLUMP:


### PR DESCRIPTION
rpATOMIC case missing geometry flags |= rpGEOMETRYMODULATEMATERIALCOLOR.

Fix: 

<img width="1019" height="379" alt="image" src="https://github.com/user-attachments/assets/5e3b9e78-d0c2-4f9e-b484-4f0cd78d3840" />


by: @j0y