### PR TITLE
feature(CWeather): Reverse UpdateInTunnelness

### DIFF
--- a/source/game_sa/Weather.cpp
+++ b/source/game_sa/Weather.cpp
@@ -31,7 +31,7 @@ void CWeather::InjectHooks() {
     RH_ScopedInstall(RenderRainStreaks, 0x72AF70);
     RH_ScopedInstall(SetWeatherToAppropriateTypeNow, 0x72A790);
     RH_ScopedInstall(Update, 0x72B850, { .reversed = false });
-    RH_ScopedInstall(UpdateInTunnelness, 0x72B630, { .reversed = false });
+    RH_ScopedInstall(UpdateInTunnelness, 0x72B630);
     //RH_ScopedInstall(UpdateWeatherRegion, 0x72A640, true, { .reversed = false }); // bad
     RH_ScopedInstall(IsRainy, 0x4ABF50);
 }
@@ -266,7 +266,52 @@ void CWeather::Update() {
 
 // 0x72B630
 void CWeather::UpdateInTunnelness() {
-    plugin::Call<0x72B630>();
+    ZoneScoped;
+
+    // Tunnel entrance reference points (originally lazily-initialised function-local statics @ 0xC81430, 0xC81424)
+    static const CVector s_TunnelPoint1{ 85.0f, -1020.0f, 0.0f };
+    static const CVector s_TunnelPoint2{ 1683.0f, -1956.0f, 0.0f };
+
+    float target = 0.0f;
+    if (CCullZones::CurrentFlags_Camera & 0x2000) { // TODO: Unnamed tunnel-related eZoneAttributes flag (bit 0x2000)
+        target = 1.0f;
+
+        // Build a line from the camera position going 100 units along its forward direction (on the XY plane)
+        const auto& camPos = TheCamera.GetPosition();
+        const CVector from{ camPos.x, camPos.y, 0.0f };
+
+        CVector dir;
+        if (TheCamera.m_matrix) {
+            const auto& fwd = TheCamera.GetForward();
+            dir = CVector{ fwd.x, fwd.y, 0.0f };
+        } else {
+            const auto heading = TheCamera.m_placement.m_fHeading;
+            dir = CVector{ -std::sin(heading), std::cos(heading), 0.0f };
+        }
+        dir.Normalise();
+
+        const CVector to = from + dir * 100.0f;
+
+        // Tunnelness ramps down as the forward line gets closer to a tunnel entrance
+        float dist = 100.0f;
+        if (const auto d = CCollision::DistToLine(from, to, s_TunnelPoint1); d <= 100.0f) {
+            dist = d;
+        }
+        if (const auto d = CCollision::DistToLine(from, to, s_TunnelPoint2); d <= dist) {
+            dist = d;
+        }
+        if (dist * 0.01f <= 1.0f) {
+            target = dist * 0.01f;
+        }
+    }
+
+    // Smoothly approach the target value
+    const float step = CTimer::GetTimeStep() * 0.01f;
+    if (step <= std::abs(target - InTunnelness)) {
+        InTunnelness += (target - InTunnelness >= 0.0f) ? step : -step;
+    } else {
+        InTunnelness = target;
+    }
 }
 
 // Based on 0x72A640

--- a/source/game_sa/Weather.cpp
+++ b/source/game_sa/Weather.cpp
@@ -268,50 +268,22 @@ void CWeather::Update() {
 void CWeather::UpdateInTunnelness() {
     ZoneScoped;
 
-    // Tunnel entrance reference points (originally lazily-initialised function-local statics @ 0xC81430, 0xC81424)
-    static const CVector s_TunnelPoint1{ 85.0f, -1020.0f, 0.0f };
-    static const CVector s_TunnelPoint2{ 1683.0f, -1956.0f, 0.0f };
+    static const CVector s_TunnelPoint1{ 85.0f, -1020.0f, 0.0f }; // 0xC81430
+    static const CVector s_TunnelPoint2{ 1683.0f, -1956.0f, 0.0f }; // 0xC81424
 
     float target = 0.0f;
     if (CCullZones::CurrentFlags_Camera & 0x2000) { // TODO: Unnamed tunnel-related eZoneAttributes flag (bit 0x2000)
-        target = 1.0f;
-
-        // Build a line from the camera position going 100 units along its forward direction (on the XY plane)
-        const auto& camPos = TheCamera.GetPosition();
-        const CVector from{ camPos.x, camPos.y, 0.0f };
-
-        CVector dir;
-        if (TheCamera.m_matrix) {
-            const auto& fwd = TheCamera.GetForward();
-            dir = CVector{ fwd.x, fwd.y, 0.0f };
-        } else {
-            const auto heading = TheCamera.m_placement.m_fHeading;
-            dir = CVector{ -std::sin(heading), std::cos(heading), 0.0f };
-        }
-        dir.Normalise();
-
-        const CVector to = from + dir * 100.0f;
-
-        // Tunnelness ramps down as the forward line gets closer to a tunnel entrance
-        float dist = 100.0f;
-        if (const auto d = CCollision::DistToLine(from, to, s_TunnelPoint1); d <= 100.0f) {
-            dist = d;
-        }
-        if (const auto d = CCollision::DistToLine(from, to, s_TunnelPoint2); d <= dist) {
-            dist = d;
-        }
-        if (dist * 0.01f <= 1.0f) {
-            target = dist * 0.01f;
-        }
+        const CVector from{ CVector2D{ TheCamera.GetPosition() } };
+        const CVector to = from + CVector{ CVector2D{ TheCamera.GetForwardVector() }.Normalized() } * 100.0f;
+        const auto dist = std::min({
+            CCollision::DistToLine(from, to, s_TunnelPoint1),
+            CCollision::DistToLine(from, to, s_TunnelPoint2),
+            100.0f,
+        });
+        target = std::min(1.0f, dist / 100.0f);
     }
 
-    // Smoothly approach the target value
-    const float step = CTimer::GetTimeStep() * 0.01f;
-    if (step <= std::abs(target - InTunnelness)) {
-        InTunnelness += (target - InTunnelness >= 0.0f) ? step : -step;
-    } else {
-        InTunnelness = target;
-    }
+    InTunnelness = notsa::step_to(InTunnelness, target, CTimer::GetTimeStep() * 0.01f);
 }
 
 // Based on 0x72A640


### PR DESCRIPTION
reverses `CWeather::UpdateInTunnelness` (0x72B630), previously a `plugin::Call` stub.

the function updates `InTunnelness`: when the camera zone has the `0x2000` attribute it walks a 100-unit line from the camera along its forward direction and measures the distance to the two hardcoded tunnel-entrance points (`85, -1020` and `1683, -1956`), ramping the target down from `1.0` based on that distance, then eases `InTunnelness` toward the target by `timeStep * 0.01` per frame.

one thing worth flagging: bit `0x2000` isn't present in `eZoneAttributes` (bit 13 is a gap, like `0x20`), so i kept it as a literal with a `TODO` instead of inventing a name. happy to add an enumerator if someone knows the canonical one.

tested in-game through the F7 reversible-hooks menu: toggling the hook produces identical tunnel darkening to the original with no crash, and a temporary `InTunnelness = 1.0f` override confirmed the reversed path actually executes (whole screen switches to tunnel lighting when enabled).