### PR TITLE
fix(CInformFriendsEventQueue): Use signed cast for random time offset in Add

### DIFF
--- a/source/game_sa/InformFriendsEventQueue.cpp
+++ b/source/game_sa/InformFriendsEventQueue.cpp
@@ -50,7 +50,8 @@ bool CInformFriendsEventQueue::Add(CPed* ped, CEvent* event) {
     freeField->m_Ped   = ped;
     CEntity::SafeRegisterRef(freeField->m_Ped);
     freeField->m_Event = event;
-    freeField->m_Time  = CTimer::GetTimeInMS() - static_cast<uint32>(CGeneral::GetRandomNumberInRange(-500.0f, 0.0f)) + 300;
+    // Signed cast to match the original `ftol` (casting the negative random to `uint32` is UB)
+    freeField->m_Time  = CTimer::GetTimeInMS() - static_cast<int32>(CGeneral::GetRandomNumberInRange(-500.0f, 0.0f)) + 300;
     return true;
 }
 

--- a/source/game_sa/InformFriendsEventQueue.cpp
+++ b/source/game_sa/InformFriendsEventQueue.cpp
@@ -50,8 +50,7 @@ bool CInformFriendsEventQueue::Add(CPed* ped, CEvent* event) {
     freeField->m_Ped   = ped;
     CEntity::SafeRegisterRef(freeField->m_Ped);
     freeField->m_Event = event;
-    // Signed cast to match the original `ftol` (casting the negative random to `uint32` is UB)
-    freeField->m_Time  = CTimer::GetTimeInMS() - static_cast<int32>(CGeneral::GetRandomNumberInRange(-500.0f, 0.0f)) + 300;
+    freeField->m_Time  = CTimer::GetTimeInMS() + CGeneral::GetRandomNumberInRange(300u, 800u);
     return true;
 }
 


### PR DESCRIPTION
`CInformFriendsEventQueue::Add` (0x4AC1E0) casts the random time offset to `uint32`, but the original uses `ftol` a signed float->int conversion. `CGeneral::GetRandomNumberInRange(-500.0f, 0.0f)` returns a negative value, and `static_cast<uint32>` of a negative float is undefined behaviour. it happens to produce the intended result on msvc via modular wraparound, but it's UB and doesn't reflect the original conversion.

switching to `static_cast<int32>` mirrors `ftol`, stays well-defined, and yields the same `m_Time` (`now + [300..800]`), so there's no behaviour change on msvc.

while i was here i also checked the existing `FIXME` in `Process` about `static_cast<uint32>(m_Time)`: the original compares `(uint)m_Time < now` too, and `m_Time` is always positive when that branch runs, so that cast is actually faithful left it alone.

only touches `Add`.