### PR TITLE
re(CBike): DamageKnockOffRider

### DIFF
--- a/source/game_sa/Entity/Ped/Ped.h
+++ b/source/game_sa/Entity/Ped/Ped.h
@@ -99,6 +99,14 @@ class CVehicle;
 class CPedStat;
 class CPedStats;
 
+// Values of `CPed::CantBeKnockedOffBike` (how hard it is to knock this ped off a bike)
+enum eCantBeKnockedOffBike : uint8 {
+    CANT_BE_KNOCKED_OFF_DEFAULT       = 0, // resistance scales with the ped's bike riding skill
+    CANT_BE_KNOCKED_OFF_NEVER         = 1, // never knocked off
+    CANT_BE_KNOCKED_OFF_ALWAYS_NORMAL = 2, // knocked off regardless of riding skill
+    CANT_BE_KNOCKED_OFF_ALWAYS_HARD   = 3, // knocked off even at a much lower impact force
+};
+
 class NOTSA_EXPORT_VTABLE CPed : public CPhysical {
 public:
     using Ref = notsa::EntityRef<CPed>;
@@ -222,7 +230,7 @@ public:
         bool bWaitingForScriptBrainToLoad : 1 = false;
         bool bHasGroupDriveTask : 1 = false;
         bool bCanExitCar : 1 = true;
-        bool CantBeKnockedOffBike : 2 = false; // (harder for mission peds)   normal(also for mission peds)
+        uint8 CantBeKnockedOffBike : 2 = CANT_BE_KNOCKED_OFF_DEFAULT; // 2-bit value, see eCantBeKnockedOffBike (was mis-typed as `bool`)
         bool bHasBeenRendered : 1 = false;
         bool bIsCached : 1 = false;
         bool bPushOtherPeds : 1 = false;   // GETS RESET EVERY FRAME - SET IN TASK: want to push other peds around (eg. leader of a group or ped trying to get in a car)

--- a/source/game_sa/Entity/Ped/Ped.h
+++ b/source/game_sa/Entity/Ped/Ped.h
@@ -106,6 +106,7 @@ enum eCantBeKnockedOffBike : uint8 {
     CANT_BE_KNOCKED_OFF_ALWAYS_NORMAL = 2, // knocked off regardless of riding skill
     CANT_BE_KNOCKED_OFF_ALWAYS_HARD   = 3, // knocked off even at a much lower impact force
 };
+static_assert(CANT_BE_KNOCKED_OFF_ALWAYS_HARD <= 0b11, "eCantBeKnockedOffBike must fit in the 2-bit CantBeKnockedOffBike field");
 
 class NOTSA_EXPORT_VTABLE CPed : public CPhysical {
 public:

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -19,7 +19,7 @@ void CBike::InjectHooks() {
     RH_ScopedInstall(Constructor, 0x6BF430);
     RH_ScopedInstall(Destructor, 0x6B57A0);
     RH_ScopedInstall(dmgDrawCarCollidingParticles, 0x6B5A00);
-    RH_ScopedInstall(DamageKnockOffRider, 0x6B5A10, { .reversed = false });
+    RH_ScopedInstall(DamageKnockOffRider, 0x6B5A10);
     RH_ScopedInstall(KnockOffRider, 0x6B5F40);
     RH_ScopedInstall(SetRemoveAnimFlags, 0x6B5F50, { .reversed = false });
     RH_ScopedInstall(ReduceHornCounter, 0x6B5F90);
@@ -170,8 +170,108 @@ void CBike::dmgDrawCarCollidingParticles(const CVector& position, float power, e
 }
 
 // 0x6B5A10
-bool CBike::DamageKnockOffRider(CVehicle* arg0, float arg1, uint16 arg2, CEntity* arg3, CVector& arg4, CVector& arg5) {
-    return ((bool(__cdecl*)(CVehicle*, float, uint16, CEntity*, CVector&, CVector&))0x6B5A10)(arg0, arg1, arg2, arg3, arg4, arg5);
+bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16 pieceType, CEntity* damager, const CVector& collisionPos, const CVector& collisionImpactVelocity) {
+    const auto driver    = vehicle->m_pDriver;
+    const auto passenger = vehicle->m_apPassengers[0];
+
+    // Impact force relative to the bike's mass
+    auto force = damageIntensity / vehicle->m_fMass * 800.0f;
+
+    // A skilled rider resists being knocked off (unless flagged to always come off)
+    if (vehicle->GetStatus() != STATUS_PLAYER) {
+        if (driver && driver->CantBeKnockedOffBike != CANT_BE_KNOCKED_OFF_ALWAYS_NORMAL) {
+            force *= 1.0f - driver->GetBikeRidingSkill() * 0.6f;
+        }
+    } else {
+        force *= 0.75f;
+        if (driver) {
+            force *= 1.0f - driver->GetBikeRidingSkill() * 0.5f;
+        }
+    }
+
+    // Only an actual driver gets knocked off
+    if (!driver || !driver->IsStateDriving() || force <= 10.0f) {
+        return false;
+    }
+
+    // A ped already reacting to a hit isn't also knocked off (cops are exempt)
+    if (const auto task = driver->GetIntelligence()->GetTaskManager().GetActiveTask()) {
+        if (task->GetTaskType() == TASK_SIMPLE_BE_HIT && driver->m_nPedType != PED_TYPE_COP) {
+            return false;
+        }
+    }
+
+    const auto& mat = *vehicle->m_matrix;
+    const auto fwdDot   = DotProduct(mat.GetForward(), collisionImpactVelocity);
+    const auto upDot    = DotProduct(mat.GetUp(), collisionImpactVelocity);
+    const auto rightDot = DotProduct(mat.GetRight(), collisionImpactVelocity);
+
+    // Per-axis weighting of the impact
+    auto fwdWeight = 0.6f;
+    if (std::abs(fwdDot) > 0.85f) {
+        const auto vertical = collisionImpactVelocity.z < 0.85f ? 0.0f : collisionImpactVelocity.z;
+        fwdWeight = 7.0f * vertical * vertical + 0.6f;
+    }
+    if (mat.GetUp().z < 0.0f) { // bike lying on its side / upside down
+        fwdWeight = 5.0f;
+    }
+
+    auto backWeight = 1.5f;
+    auto upWeight   = 0.05f;
+    if (vehicle->m_nModelIndex == MODEL_SANCHEZ) {
+        fwdWeight *= 0.65f;
+        upWeight  *= 0.75f;
+    } else if (vehicle->IsSubQuad()) {
+        backWeight = 3.0f;
+        fwdWeight *= 0.65f;
+        upWeight  *= 0.75f;
+    }
+
+    if (fwdDot > 0.0f) {
+        fwdWeight *= 1.0f - driver->GetBikeRidingSkill() * 0.6f;
+    }
+
+    force *= std::abs(fwdDot) * fwdWeight
+           + std::max(upDot, 0.0f) * upWeight
+           + std::abs(rightDot) * 0.45f
+           - std::min(upDot, 0.0f) * backWeight;
+
+    // Don't knock the player off while they're on stairs
+    if (driver->IsPlayer() && CCullZones::CamStairsForPlayer() && CCullZones::FindZoneWithStairsAttributeForPlayer()) {
+        force = 0.0f;
+    }
+
+    // ALWAYS_HARD peds come off at a much lower force threshold
+    if (force <= 75.0f && (driver->CantBeKnockedOffBike != CANT_BE_KNOCKED_OFF_ALWAYS_HARD || force <= 20.0f)) {
+        return false;
+    }
+
+    // NEVER peds are never knocked off
+    if (driver->CantBeKnockedOffBike == CANT_BE_KNOCKED_OFF_NEVER) {
+        return false;
+    }
+    if (passenger && passenger->CantBeKnockedOffBike == CANT_BE_KNOCKED_OFF_NEVER) {
+        return false;
+    }
+
+    const CVector2D localDir{ -collisionImpactVelocity.x, -collisionImpactVelocity.y };
+    constexpr int32 DIR_NOT_SET = -10;
+    auto knockOffDir = DIR_NOT_SET;
+
+    // Both driver and passenger are thrown off; each reacts using its own facing
+    {
+        knockOffDir = driver->GetLocalDirection(localDir);
+        auto ev = CEventKnockOffBike{ vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, (uint8)knockOffDir, 0, nullptr, true, false };
+        driver->GetEventGroup().Add(&ev);
+    }
+    if (passenger) {
+        if (knockOffDir == DIR_NOT_SET) {
+            knockOffDir = passenger->GetLocalDirection(localDir);
+        }
+        auto ev = CEventKnockOffBike{ vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, (uint8)knockOffDir, 0, nullptr, false, false };
+        passenger->GetEventGroup().Add(&ev);
+    }
+    return true;
 }
 
 // dummy function

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -201,10 +201,9 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
         }
     }
 
-    const auto& mat = *vehicle->m_matrix;
-    const auto impactFwdMag   = mat.GetForward().Dot(collisionImpactVelocity);
-    const auto impactUpMag    = mat.GetUp().Dot(collisionImpactVelocity);
-    const auto impactRightMag = mat.GetRight().Dot(collisionImpactVelocity);
+    const auto impactFwdMag   = vehicle->GetForward().Dot(collisionImpactVelocity);
+    const auto impactUpMag    = vehicle->GetUp().Dot(collisionImpactVelocity);
+    const auto impactRightMag = vehicle->GetRight().Dot(collisionImpactVelocity);
 
     // Per-axis weighting of the impact
     auto fwdWeight = 0.6f;
@@ -212,7 +211,7 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
         const auto vertical = collisionImpactVelocity.z < 0.85f ? 0.0f : collisionImpactVelocity.z;
         fwdWeight = 7.0f * sq(vertical) + 0.6f;
     }
-    if (mat.GetUp().z < 0.0f) { // bike lying on its side / upside down
+    if (vehicle->GetUp().z < 0.0f) { // bike lying on its side / upside down
         fwdWeight = 5.0f;
     }
 

--- a/source/game_sa/Entity/Vehicle/Bike.cpp
+++ b/source/game_sa/Entity/Vehicle/Bike.cpp
@@ -196,21 +196,21 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
 
     // A ped already reacting to a hit isn't also knocked off (cops are exempt)
     if (const auto task = driver->GetIntelligence()->GetTaskManager().GetActiveTask()) {
-        if (task->GetTaskType() == TASK_SIMPLE_BE_HIT && driver->m_nPedType != PED_TYPE_COP) {
+        if (task->GetTaskType() == TASK_SIMPLE_BE_HIT && !driver->IsCop()) {
             return false;
         }
     }
 
     const auto& mat = *vehicle->m_matrix;
-    const auto fwdDot   = DotProduct(mat.GetForward(), collisionImpactVelocity);
-    const auto upDot    = DotProduct(mat.GetUp(), collisionImpactVelocity);
-    const auto rightDot = DotProduct(mat.GetRight(), collisionImpactVelocity);
+    const auto impactFwdMag   = mat.GetForward().Dot(collisionImpactVelocity);
+    const auto impactUpMag    = mat.GetUp().Dot(collisionImpactVelocity);
+    const auto impactRightMag = mat.GetRight().Dot(collisionImpactVelocity);
 
     // Per-axis weighting of the impact
     auto fwdWeight = 0.6f;
-    if (std::abs(fwdDot) > 0.85f) {
+    if (std::abs(impactFwdMag) > 0.85f) {
         const auto vertical = collisionImpactVelocity.z < 0.85f ? 0.0f : collisionImpactVelocity.z;
-        fwdWeight = 7.0f * vertical * vertical + 0.6f;
+        fwdWeight = 7.0f * sq(vertical) + 0.6f;
     }
     if (mat.GetUp().z < 0.0f) { // bike lying on its side / upside down
         fwdWeight = 5.0f;
@@ -227,14 +227,14 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
         upWeight  *= 0.75f;
     }
 
-    if (fwdDot > 0.0f) {
+    if (impactFwdMag > 0.0f) {
         fwdWeight *= 1.0f - driver->GetBikeRidingSkill() * 0.6f;
     }
 
-    force *= std::abs(fwdDot) * fwdWeight
-           + std::max(upDot, 0.0f) * upWeight
-           + std::abs(rightDot) * 0.45f
-           - std::min(upDot, 0.0f) * backWeight;
+    force *= std::abs(impactFwdMag) * fwdWeight
+           + std::max(impactUpMag, 0.0f) * upWeight
+           + std::abs(impactRightMag) * 0.45f
+           - std::min(impactUpMag, 0.0f) * backWeight;
 
     // Don't knock the player off while they're on stairs
     if (driver->IsPlayer() && CCullZones::CamStairsForPlayer() && CCullZones::FindZoneWithStairsAttributeForPlayer()) {
@@ -242,7 +242,7 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
     }
 
     // ALWAYS_HARD peds come off at a much lower force threshold
-    if (force <= 75.0f && (driver->CantBeKnockedOffBike != CANT_BE_KNOCKED_OFF_ALWAYS_HARD || force <= 20.0f)) {
+    if (force <= (driver->CantBeKnockedOffBike == CANT_BE_KNOCKED_OFF_ALWAYS_HARD ? 20.0f : 75.0f)) {
         return false;
     }
 
@@ -254,22 +254,16 @@ bool CBike::DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16
         return false;
     }
 
-    const CVector2D localDir{ -collisionImpactVelocity.x, -collisionImpactVelocity.y };
-    constexpr int32 DIR_NOT_SET = -10;
-    auto knockOffDir = DIR_NOT_SET;
+    // The driver (guaranteed present here) is thrown off, and so is the passenger, both reacting with the driver's facing
+    const auto knockOffDir = (uint8)driver->GetLocalDirection(-CVector2D{ collisionImpactVelocity });
 
-    // Both driver and passenger are thrown off; each reacts using its own facing
-    {
-        knockOffDir = driver->GetLocalDirection(localDir);
-        auto ev = CEventKnockOffBike{ vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, (uint8)knockOffDir, 0, nullptr, true, false };
-        driver->GetEventGroup().Add(&ev);
-    }
+    driver->GetEventGroup().Add(CEventKnockOffBike{
+        vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, knockOffDir, 0, nullptr, true, false
+    });
     if (passenger) {
-        if (knockOffDir == DIR_NOT_SET) {
-            knockOffDir = passenger->GetLocalDirection(localDir);
-        }
-        auto ev = CEventKnockOffBike{ vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, (uint8)knockOffDir, 0, nullptr, false, false };
-        passenger->GetEventGroup().Add(&ev);
+        passenger->GetEventGroup().Add(CEventKnockOffBike{
+            vehicle, vehicle->m_vecMoveSpeed, collisionImpactVelocity, damageIntensity, 0.05f * force, KNOCK_OFF_TYPE_SKIDBACKFRONT, knockOffDir, 0, nullptr, false, false
+        });
     }
     return true;
 }

--- a/source/game_sa/Entity/Vehicle/Bike.h
+++ b/source/game_sa/Entity/Vehicle/Bike.h
@@ -136,7 +136,7 @@ public:
 
     void SetupModelNodes();
     void dmgDrawCarCollidingParticles(const CVector& position, float power, eWeaponType weaponType);
-    static bool DamageKnockOffRider(CVehicle* arg0, float arg1, uint16 arg2, CEntity* arg3, CVector& arg4, CVector& arg5);
+    static bool DamageKnockOffRider(CVehicle* vehicle, float damageIntensity, uint16 pieceType, CEntity* damager, const CVector& collisionPos, const CVector& collisionImpactVelocity);
     CPed* KnockOffRider(eWeaponType arg0, uint8 arg1, CPed* ped, bool arg3);
     void SetRemoveAnimFlags(CPed* ped);
     void ReduceHornCounter();


### PR DESCRIPTION
reverses `CBike::DamageKnockOffRider` (`0x6B5A10`), the function that decides whether a bike's driver and passenger get thrown off when the bike takes a hit. it scales the impact force by the bike's mass and the rider's `GetBikeRidingSkill`, bails out unless there's an actual driver in `PEDSTATE_DRIVING`, weights the collision against the bike's forward/up/right axes (keeping the original `MODEL_SANCHEZ` and quad-bike special cases), and once the force clears the threshold it hands a `CEventKnockOffBike` to the driver and passenger through their event groups. peds already running `TASK_SIMPLE_BE_HIT` (non-cops) and the player while on stairs are skipped, matching the original.

while doing this i had to fix `CPed::CantBeKnockedOffBike`. it was declared `bool : 2`, but the game stores a 2-bit value there (`0`-`3`) and this function branches on all four states (`NEVER`, `ALWAYS_NORMAL`, `ALWAYS_HARD`), which a `bool` can't represent. it's now `uint8 : 2` backed by a new `eCantBeKnockedOffBike` enum. the other two readers (`GameLogic.cpp` and `CEventKnockOffBike::AffectsPed`) only test it for non-zero, so they keep working, and `VALIDATE_SIZE(CPed, 0x79C)` still holds, so the layout is unchanged.

tested in-game by riding different bikes (incl. sanchez and a quad) and crashing them into walls and traffic, toggling the hook on/off in the reversible hooks menu to compare against the original: the driver gets knocked off on hard enough impacts, and a passenger on a two-seater is thrown off together with the driver. 