### PR TITLE
fix(CRopes): Check m_pRopeAttachObject in IsCarriedByRope

### DIFF
--- a/source/game_sa/Ropes.cpp
+++ b/source/game_sa/Ropes.cpp
@@ -112,7 +112,7 @@ bool CRopes::IsCarriedByRope(CPhysical* entity) {
         return false;
 
     for (auto& rope : aRopes) {
-        if (rope.m_nType != eRopeType::NONE && rope.m_pAttachedEntity == entity)
+        if (rope.m_nType != eRopeType::NONE && rope.m_pRopeAttachObject == entity)
             return true;
     }
     return false;


### PR DESCRIPTION
`IsCarriedByRope` compared each rope's `m_pAttachedEntity` (offset `0x314`), but the original at `0x555F80` compares `m_pRopeAttachObject` (offset `0x318`).

verified in the decompile: the loop reads the pointer at `aRopes + 0x318` and tests the `m_nType` byte 13 bytes later at `0x325` (`aRopes` base is `0xB768B8`, and `0xB768B8 + 0x318 == 0xB76BD0`, the address the original walks). so the field being compared is `m_pRopeAttachObject`, one slot past the `m_pAttachedEntity` the reversed code used.

one-line change plus a local unity compile to confirm it builds. originally reported via differential testing.

fixes #1261