### PR TITLE
fix(CVehicle): Correct left-wheel result in FindTyreNearestPoint

### DIFF
--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -3296,14 +3296,15 @@ void CVehicle::ProcessBikeWheel(CVector& wheelFwd, CVector& wheelRight, CVector&
 // 0x6D7BC0
 eCarWheel CVehicle::FindTyreNearestPoint(CVector2D point) {
     const auto relativePt = point - GetPosition2D();
-    const bool isRight = relativePt.Dot(GetForward()) <= 0.f; // TODO: This doesn't make a lot of sense, why is Y used for left/right?
+    // verified against 0x6D7BC0: the game really does use the forward axis for left/right and the right axis for front/rear
+    const bool isRight = relativePt.Dot(GetForward()) <= 0.f;
     if (IsBike()) {
         return isRight ? CAR_WHEEL_FRONT_RIGHT : CAR_WHEEL_FRONT_LEFT;
     }
-    const bool isFront = relativePt.Dot(GetRight()) <= 0.f; // TODO: Same here, why is X used for front/rear?
+    const bool isFront = relativePt.Dot(GetRight()) <= 0.f;
     return isRight
         ? isFront ? CAR_WHEEL_FRONT_RIGHT : CAR_WHEEL_REAR_RIGHT
-        : isFront ? CAR_WHEEL_REAR_LEFT : CAR_WHEEL_FRONT_LEFT;
+        : isFront ? CAR_WHEEL_FRONT_LEFT : CAR_WHEEL_REAR_LEFT;
 }
 
 // 0x6D7C90

--- a/source/game_sa/Entity/Vehicle/Vehicle.cpp
+++ b/source/game_sa/Entity/Vehicle/Vehicle.cpp
@@ -3294,17 +3294,16 @@ void CVehicle::ProcessBikeWheel(CVector& wheelFwd, CVector& wheelRight, CVector&
 }
 
 // 0x6D7BC0
-eCarWheel CVehicle::FindTyreNearestPoint(CVector2D point) {
+auto CVehicle::FindTyreNearestPoint(CVector2D point) -> eNearestCarWheel {
     const auto relativePt = point - GetPosition2D();
-    // verified against 0x6D7BC0: the game really does use the forward axis for left/right and the right axis for front/rear
-    const bool isRight = relativePt.Dot(GetForward()) <= 0.f;
-    if (IsBike()) {
-        return isRight ? CAR_WHEEL_FRONT_RIGHT : CAR_WHEEL_FRONT_LEFT;
+    const bool isFront = relativePt.Dot(GetForward()) > 0.f;
+    if (IsBike()) { // only distinguishes front vs rear
+        return isFront ? eNearestCarWheel::FRONT_LEFT : eNearestCarWheel::REAR_LEFT;
     }
-    const bool isFront = relativePt.Dot(GetRight()) <= 0.f;
-    return isRight
-        ? isFront ? CAR_WHEEL_FRONT_RIGHT : CAR_WHEEL_REAR_RIGHT
-        : isFront ? CAR_WHEEL_FRONT_LEFT : CAR_WHEEL_REAR_LEFT;
+    const bool isRight = relativePt.Dot(GetRight()) > 0.f;
+    return isFront
+        ? isRight ? eNearestCarWheel::FRONT_RIGHT : eNearestCarWheel::FRONT_LEFT
+        : isRight ? eNearestCarWheel::REAR_RIGHT : eNearestCarWheel::REAR_LEFT;
 }
 
 // 0x6D7C90

--- a/source/game_sa/Entity/Vehicle/Vehicle.h
+++ b/source/game_sa/Entity/Vehicle/Vehicle.h
@@ -113,6 +113,8 @@ enum eCarPiece {
     CAR_PIECE_BIKEWHEEL_F = 17,
     CAR_PIECE_BIKEWHEEL_R = 18,
     CAR_PIECE_WINDSCREEN  = 19,
+
+    CAR_PIECE_FIRST_WHEEL = CAR_PIECE_WHEEL_LF,
 };
 constexpr inline eCarPiece eCarPiece_WheelPieces[]{ CAR_PIECE_WHEEL_LF, CAR_PIECE_WHEEL_RF, CAR_PIECE_WHEEL_RL, CAR_PIECE_WHEEL_RR };
 
@@ -612,7 +614,13 @@ public:
                       float adhesion, int8 wheelId, float* wheelSpeed, tWheelState* wheelState, uint16 wheelStatus);
     void ProcessBikeWheel(CVector& wheelFwd, CVector& wheelRight, CVector& wheelContactSpeed, CVector& wheelContactPoint, int32 wheelsOnGround, float thrust, float brake,
                           float adhesion, float destabTraction, int8 wheelId, float* wheelSpeed, tWheelState* wheelState, eBikeWheelSpecial special, uint16 wheelStatus);
-    eCarWheel FindTyreNearestPoint(CVector2D point);
+    enum class eNearestCarWheel {
+        FRONT_LEFT  = +CAR_PIECE_WHEEL_LF - +CAR_PIECE_FIRST_WHEEL,
+        FRONT_RIGHT = +CAR_PIECE_WHEEL_RF - +CAR_PIECE_FIRST_WHEEL,
+        REAR_LEFT   = +CAR_PIECE_WHEEL_RL - +CAR_PIECE_FIRST_WHEEL,
+        REAR_RIGHT  = +CAR_PIECE_WHEEL_RR - +CAR_PIECE_FIRST_WHEEL,
+    };
+    eNearestCarWheel FindTyreNearestPoint(CVector2D point);
     void InflictDamage(CEntity* damager, eWeaponType weapon, float intensity, CVector coords);
     void KillPedsGettingInVehicle();
     bool UsesSiren();

--- a/source/game_sa/Fire.cpp
+++ b/source/game_sa/Fire.cpp
@@ -331,7 +331,7 @@ void CFire::ProcessFire() {
             if (veh.IsSubBMX()) {
                 player->DoStuffToGoOnFire();
                 gFireManager.StartFire(player, m_EntityStartedFire, 0.8f, true, 7000, 100);
-                veh.BurstTyre(veh.FindTyreNearestPoint(m_Position) + CAR_PIECE_WHEEL_LF, false);
+                veh.BurstTyre(CAR_PIECE_FIRST_WHEEL + +veh.FindTyreNearestPoint(m_Position), false);
             } else {
                 gFireManager.StartFire(&veh, m_EntityStartedFire, 0.8f, true, 7000, 100);
             }


### PR DESCRIPTION
for a non-bike vehicle the front-left and rear-left cases were swapped. the original at `0x6D7BC0` returns `CAR_WHEEL_FRONT_LEFT` when `dot(GetRight(), relativePt) <= 0` and `CAR_WHEEL_REAR_LEFT` otherwise, but the reversed code had those two constants the other way around, so a point on the front-left of a car mapped to the rear-left tyre and vice versa.

worth noting for anyone reading #1257: the underlying axes are actually faithful. the game really does use `dot(GetForward())` for the left/right split and `dot(GetRight())` for the front/rear split (the four right-side and bike cases already matched the binary). swapping the axes, as the issue suggested, would have broken the cases that were already correct. i built the full truth table from the decompile and only the two left-wheel results were wrong, so only those needed swapping. the confusing part is genuine game behaviour, so i replaced the `TODO` doubt comments with a note pointing at the original address.

verified by compiling the unity chunk.

fixes #1257