### PR TITLE
fix(CCutsceneMgr): Use 1-based object id for particle effect matrix lookup

### DIFF
--- a/source/game_sa/CutsceneMgr.cpp
+++ b/source/game_sa/CutsceneMgr.cpp
@@ -380,13 +380,13 @@ void CCutsceneMgr::LoadCutsceneData_loading() {
         const auto objMat = [&]() -> RwMatrix* {
             const auto objIdx = csfx.m_nObjectId;
 
-            // If not a cutscene object we don't have an object matrix - i'm not quite sure how this works, but okay.
-            if (objIdx < 0 || objIdx >= ms_numCutsceneObjs + 1) { // TODO: Bug? Pretty sure the +1 is erroneous...
+            // The effect's object id is 1-based (0 means "no object"), see 0x5B11C0
+            if (objIdx <= 0 || objIdx >= ms_numCutsceneObjs + 1) {
                 return nullptr;
             }
 
             // If it's a skinned object, we use bone indencies
-            const auto csobj = ms_pCutsceneObjects[objIdx];
+            const auto csobj = ms_pCutsceneObjects[objIdx - 1];
             if (const auto atomic = GetFirstAtomic(csobj->GetRpClump()); atomic && RpSkinGeometryGetSkin(RpAtomicGetGeometry(atomic))) {
                 const auto nodeIdx = notsa::ston<uint32>({ csfx.m_szObjectPart }); // Obj Part is just an node index in this case
                 const auto hier = GetAnimHierarchyFromSkinClump(csobj->GetRpClump());


### PR DESCRIPTION
while chasing a `TODO: Bug?` in `LoadCutsceneData_loading`, the peffect object-matrix lookup turned out to be genuinely wrong. it did `ms_pCutsceneObjects[objIdx]`, but the original at `0x5B11C0` indexes that array 1-based: it requires `objIdx > 0` and reads `ms_pCutsceneObjects[objIdx - 1]` (in the decompile the access is off the `array - 1` base, whereas the nearby `attach` loop uses the plain `array` base, so the two really do differ). the effect's `m_nObjectId` is parsed straight from the `.CUT` file with no adjustment, same as the original, so the read side has to compensate.

net effect of the old code: cutscene particle effects bound to an object were attached to the object one slot over, `objIdx == 0` (meant to select "no object") read slot 0 instead of returning early, and `objIdx == ms_numCutsceneObjs` read one element past the array.

the `+ 1` on the upper bound that the old `TODO` suspected is actually correct (the original really does allow `objIdx == ms_numCutsceneObjs`); the real problems were the 0-based access and the `objIdx == 0` case, so i fixed those and dropped the misleading comment.

verified against the decompile and by compiling the unity chunk. testable in cutscenes that pin particle effects to cutscene objects.