### PR TITLE
chore: fix a bunch of CI, docs and script issues

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,8 +17,6 @@ HeaderFilterRegex: 'source/.*'
 
 FormatStyle: file
 
-AnalyzeTemporaryDtors: false
-
 CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,6 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
   - key:             readability-identifier-naming.VariableCase
-    value:           lower_case
+    value:           camelBack
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Logs
       description: |
-        If applicable, provide any relevant logs or error messages that can help in diagnosing the issue (See `scripts/logs/log.log` in your game folder)
+        If applicable, provide any relevant logs or error messages that can help in diagnosing the issue (See `logs/log.log` in your game folder)
         You can paste it down below, or if it's too long, upload it as an attachment.
       value: |
         <details>

--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -2,14 +2,6 @@ name: Setup CMake using Conan
 description: A workflow to setup CMake using Conan, which can be used as a dependency for other workflows.
 
 inputs:
-    os:
-        description: "The operating system to use for the setup. [Values: windows-2025-vs2026]"
-        required: true
-        default: "windows-2025-vs2026"
-    arch:
-        description: "The architecture to use for the setup. [Values: x86]"
-        required: true
-        default: "x86"
     conf:
         description: "The build configuration to use for the setup. [Values: Debug, Release]"
         required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodule"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,11 @@ env:
     # Path to the CMake build directory.
     build: "${{ github.workspace }}/build"
 
-# Triggers the workflow on push or pull request events for all branches.
-on: [push, pull_request]
+# Triggers on pushes to master and on pull requests (a branch with an open PR would build twice otherwise).
+on:
+    push:
+        branches: [master]
+    pull_request:
 
 permissions:
     contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-2025-vs2026]
-                arch: [x86]
                 conf: [Debug, Release]
                 preset: [NoUnity, Unity]
         runs-on: ${{ matrix.os }}
@@ -32,8 +31,6 @@ jobs:
             - name: Setup CMake using Conan
               uses: ./.github/actions/setup-cmake
               with:
-                  os: ${{ matrix.os }}
-                  arch: ${{ matrix.arch }}
                   conf: ${{ matrix.conf }}
                   preset: ${{ matrix.preset }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,11 +49,9 @@ jobs:
         include:
         - language: c-cpp
           build-mode: manual
-          arch: x86
           conf: Debug
         - language: c-cpp
           build-mode: manual
-          arch: x86
           conf: Release
         - language: actions
           build-mode: none
@@ -101,7 +99,6 @@ jobs:
       if: matrix.language == 'c-cpp'
       with:
           conf: ${{ matrix.conf }}
-          arch: ${{ matrix.arch }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Install Doxygen
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,8 +7,11 @@ env:
     # Path to the CMake build directory.
     build: "${{ github.workspace }}/build"
 
-# Triggers the workflow on push or pull request events for all branches.
-on: [push, pull_request]
+# Triggers on pushes to master and on pull requests (a branch with an open PR would be analyzed twice otherwise).
+on:
+    push:
+        branches: [master]
+    pull_request:
 
 permissions:
     contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -31,8 +31,6 @@ jobs:
             - name: Setup CMake using Conan
               uses: ./.github/actions/setup-cmake
               with:
-                  os: ${{ matrix.os }}
-                  arch: x86
                   conf: ${{ matrix.conf }}
                   preset: Unity # Builds faster, and analysis results are the same
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,9 +32,9 @@ jobs:
               uses: ./.github/actions/setup-cmake
               with:
                   os: ${{ matrix.os }}
-                  arch: ${{ matrix.arch }}
+                  arch: x86
                   conf: ${{ matrix.conf }}
-                  preset: ${{ matrix.preset }}
+                  preset: Unity # Builds faster, and analysis results are the same
 
             - name: Initialize MSVC Code Analysis
               uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,6 +47,6 @@ jobs:
 
               # Upload SARIF file to GitHub Code Scanning Alerts
             - name: Upload SARIF to GitHub
-              uses: github/codeql-action/upload-sarif@v3
+              uses: github/codeql-action/upload-sarif@v4
               with:
                   sarif_file: ${{ steps.analysis.outputs.sarif }}

--- a/.github/workflows/update-re-progress.yml
+++ b/.github/workflows/update-re-progress.yml
@@ -39,6 +39,13 @@ jobs:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       
+      - name: Get GitHub App user ID
+        id: get-user-id
+        shell: bash
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Setup Git user for GitHub App
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'

--- a/.github/workflows/update-re-progress.yml
+++ b/.github/workflows/update-re-progress.yml
@@ -65,8 +65,6 @@ jobs:
       - name: Setup project using CMake
         uses: ./.github/actions/setup-cmake
         with:
-          os: windows-2025-vs2026
-          arch: x86
           conf: Debug # Builds faster, and there's functionally no difference in this case
           preset: Unity
           dump_hooks_only: true

--- a/.github/workflows/update-re-progress.yml
+++ b/.github/workflows/update-re-progress.yml
@@ -59,9 +59,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
-
       - name: Setup project using CMake
         uses: ./.github/actions/setup-cmake
         with:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please join our community Discord: [GTA Groupies](https://discord.gg/FG8XJ5Npqe)
 Building this project will result in a DLL file that can be injected into GTA:SA using any ASI loader out there. After the DLL file has been injected, the ingame functions will be replaced by the reversed ones. The game will behave the same. Now if we make any changes to the reversed code, it will take effect in the game. The goal is to keep reversing until we have the entire game reversed to compile a standalone executable.
 
 ## Progress
-The progress of reversed classes can be tracked [here](docs/ReversedClasses.md). (needs to be updated)
+The progress of reversed classes can be tracked [here](docs/ReversedClasses.md), it's regenerated automatically whenever the hooks change.
 We currently estimate that about 50-60% of the code is done.
 Since this project is done as a hobby, and worked on at irregular intervals, **there's no time estimate on when it'll be finished.**
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Using other (than the ones we've tested) plugins is strongly discouraged and we 
 ## Contributing
 
 ### Coding/Contributing Guidelines
-Before you start writing code, please make sure to read the [coding guidelines](docs/CodingGuidelines.MD) for this project. Consider these points before opening a PR:
+Before you start writing code, please make sure to read the [coding guidelines](docs/CodingGuidelines.md) for this project. Consider these points before opening a PR:
 
 * Follow the coding guidelines, it exists for a reason.
 * Try to focus your changes onto single subject, do not create PRs that cover many things at once. This is because it's hard to properly test and review such PRs.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since this project is done as a hobby, and worked on at irregular intervals, **t
 * [Visual Studio 2026](https://visualstudio.microsoft.com/en/downloads/)
 * [Python](https://www.python.org/downloads/) >= 3.x (For Conan)
 * [Conan](https://docs.conan.io/2/installation.html#install-with-pip-recommended) (>= 2.x)
-* [CMake](https://cmake.org/download/) (>= 4.20)
+* [CMake](https://cmake.org/download/) (>= 3.23)
 
 > [!NOTE]
 > Visual Studio 2022 should still work but don't forget to change `compiler.version` to 194 in

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Alternatively, you can install them by yourself:
     * [ASI Loader](https://gtaforums.com/topic/523982-relopensrc-silents-asi-loader/)
     * Mouse Fix (**dinput8.dll**) [Can be found in the zip in the `contrib` folder]
 
-    You can download them in a single [archive](https://github.com/gta-reversed/gta-reversed-modern/blob/master/contrib/plugins.zip).
+    You can download them in a single [archive](https://github.com/gta-reversed/gta-reversed/blob/master/contrib/plugins.zip).
 
 ### Other plugins
 Using other (than the ones we've tested) plugins is strongly discouraged and we provide __**no support**__.
@@ -60,7 +60,7 @@ Before you start writing code, please make sure to read the [coding guidelines](
 * If you intend to add non-vanilla features please first consult with us, so you don't waste your time.
 
 ### What to work on?
-Check out [this discussion](https://github.com/gta-reversed/gta-reversed-modern/discussions/402) for some inspiration ;)
+Check out [this discussion](https://github.com/gta-reversed/gta-reversed/discussions/402) for some inspiration ;)
 
 ### Debugging
 0) Make sure the latest DLL is in the `scripts` folder of your GTASA installation - Skip this step if you've used `contrib/install.py` (As it uses symlinks!)

--- a/contrib/hooks2md.py
+++ b/contrib/hooks2md.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 GITHUB_SHA = os.environ.get("GITHUB_SHA", "unknown")
-GITHUB_REPO_URL = os.environ.get("GITHUB_REPO_URL")
+GITHUB_REPO_URL = os.environ.get("GITHUB_REPO_URL", "https://github.com/gta-reversed/gta-reversed")
 
 ap = argparse.ArgumentParser(description="Generate a Markdown file with reversed classes stats from hooks.csv")
 ap.add_argument("--input", default=None, help="Path to the hooks.csv file (if not provided, a file dialog will be shown to select the input file)")

--- a/contrib/hooks2md.py
+++ b/contrib/hooks2md.py
@@ -35,10 +35,6 @@ class Klass:
     @property
     def num_fn(self):
         return self.num_not_reversed + self.num_reversed
-    
-    @property
-    def is_completely_reversed(self):
-        return self.num_not_reversed == 0
 
 def main():
     klass_info : dict[str, Klass] = {}

--- a/contrib/hooks2md.py
+++ b/contrib/hooks2md.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 import csv
 import datetime
 import os
-import tkinter.filedialog as tkFileDialog
 from dataclasses import dataclass
 from typing import Any
 
@@ -15,10 +14,13 @@ ap.add_argument("--input", default=None, help="Path to the hooks.csv file (if no
 ap.add_argument("--output", default=None, help="Path to the output Markdown file (if not provided, a file dialog will be shown to select the output location)")
 args = ap.parse_args()
 
-if args.input is None:
-    args.input = tkFileDialog.askopenfilename(title='Please select the hooks.csv file')
-if args.output is None:
-    args.output = tkFileDialog.asksaveasfilename(title='Please select the output MD file location', defaultextension=".md")
+if args.input is None or args.output is None:
+    import tkinter.filedialog as tkFileDialog # only needed for the dialogs, and it's not always installed
+
+    if args.input is None:
+        args.input = tkFileDialog.askopenfilename(title='Please select the hooks.csv file')
+    if args.output is None:
+        args.output = tkFileDialog.asksaveasfilename(title='Please select the output MD file location', defaultextension=".md")
 
 @dataclass
 class Klass:

--- a/contrib/hooks2md.py
+++ b/contrib/hooks2md.py
@@ -79,8 +79,9 @@ def main():
         outf.write(f"## Stats ({sum(k.num_fn for k in klass_info.values())} functions, {len(klass_info)} classes)\n")
 
         def write_header(title: str, klasses: list[Klass]):
+            ratio = len(klasses) / num_total_klass if num_total_klass else 0
             outf.write("\n")
-            outf.write(f"#### {title} ({len(klasses)}/{num_total_klass}) [{len(klasses) / num_total_klass:.0%}]\n")
+            outf.write(f"#### {title} ({len(klasses)}/{num_total_klass}) [{ratio:.0%}]\n")
             outf.write("\n")
 
         @contextmanager

--- a/docs/CodingGuidelines.md
+++ b/docs/CodingGuidelines.md
@@ -9,7 +9,7 @@
 class Foo {
     int32 m_iPlayerHealth; // Bad
     int32 m_PlayerHealth; // Good
-}
+};
 ```
 * Variables are named in `camelCase` and types in `PascalCase`.
 * Class/struct members and functions are named in `CamelCase`
@@ -21,7 +21,7 @@ public:
 
 private:
     int m_FooCount; // Non-static member variable
-}
+};
 ```
 * For shared variables outside a class, use `g_` prefix, and define them in the header:
 ```cpp
@@ -38,14 +38,14 @@ static int s_StaticGlobalCounter = 0;
 class Foo {
 public:
     static inline int ms_StaticGlobalCounter = 0; // Static member variable
-}
+};
 ```
 * Static and global variables should reference back to the original game address using `StaticRef` (In cases the original data is const, eg. its some configuration the value can be copied directly instead of referencing it):
 ```cpp
 class Foo {
 public:
     static inline auto& ms_StaticGlobalCounter = StaticRef<int>(0xDEADBEEF); // Static member variable
-}
+};
 ``` 
 * If some rule about something is not specified here, refer to how it's done in the code
 * Some classes may have *helper* functions to make code more readable. (Denoted by *NOTSA*) - Try adding new ones, or looking for and using them.
@@ -81,7 +81,7 @@ for (auto& thing : m_things | rng::views::take(m_numThings));
 
 // ^ If these funcs are called more than once, make a helper function in the header. Like below:
 auto GetActiveThings() {
-    return std::span{ m_things, m_numThings }
+    return std::span{ m_things, m_numThings };
 }
 ```
 * Use `f` in float literals [As omitting it would make them a `double`] (e.g. `1.0f`)
@@ -95,7 +95,7 @@ class Foo {
     static uint32& ms_FooCount; // Bad
 
     static inline auto& ms_FooCount = StaticRef<uint32>(0xDEADBEEF); // Good
-}
+};
 ```
 
 #### Types

--- a/docs/CodingGuidelines.md
+++ b/docs/CodingGuidelines.md
@@ -86,7 +86,7 @@ auto GetActiveThings() {
 ```
 * Use `f` in float literals [As omitting it would make them a `double`] (e.g. `1.0f`)
 * Use `std` library for generic functions like `min`, `max`, `lerp`, etc...
-* `CVector` is interchangible with 3 floats [As is `CVector2D` with 2 floats] for function args
+* `CVector` is interchangeable with 3 floats [As is `CVector2D` with 2 floats] for function args
 * Use lambdas for repetitive procedures in functions
 * Use `constexpr` variables instead of macros
 * Use `static inline` instead of `extern` and `static` in headers:

--- a/docs/CodingGuidelines.md
+++ b/docs/CodingGuidelines.md
@@ -92,9 +92,9 @@ auto GetActiveThings() {
 * Use `static inline` instead of `extern` and `static` in headers:
 ```cpp
 class Foo {
-    static uint32& m_FooCount; // Bad
+    static uint32& ms_FooCount; // Bad
 
-    static inline auto& m_FooCount = StaticRef<uint32, 0xDEADBEEF>(); // Good
+    static inline auto& ms_FooCount = StaticRef<uint32>(0xDEADBEEF); // Good
 }
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ args = AP.parse_args()
 
 if not args.standalone and args.dump_hooks_only:
     AP.error("The --dump-hooks-only option can only be used with the --standalone option")
-    exit(1)
 
 try:
     # defines passed to cmake via -D<key>=<value> arguments

--- a/source/game_sa/GxtChar.cpp
+++ b/source/game_sa/GxtChar.cpp
@@ -13,7 +13,9 @@ void AsciiToGxtChar(const char* src, GxtChar* dst) {
 // NOTSA -- Derived from GxtCharToAscii (0x69F7E0)
 // FIX_BUGS (sorta): Make caller provide size instead of creating a static buffer.
 char* GxtCharToUTF8(char* out, const GxtChar* src, size_t size, size_t offset) {
-    src += offset ? offset : 0;
+    assert(out && size > 0);
+
+    src += offset; // `offset` only skips input, `out` is always written from the start
 
     static const auto gxtUtf8Map = notsa::make_mapping<uint8_t /*GXT code point*/, const char8_t* /*UTF-8 char*/>({
         { 0xb1, u8"´" }, { 0xaf, u8"¿" }, { 0x80, u8"À" }, { 0x81, u8"Á" }, { 0x82, u8"Â" },
@@ -30,7 +32,7 @@ char* GxtCharToUTF8(char* out, const GxtChar* src, size_t size, size_t offset) {
     });
 
     auto out_i = 0u;
-    for (auto i = 0u; out_i < size - offset && src && src[i]; i++) {
+    for (auto i = 0u; out_i + 1 < size && src && src[i]; i++) { // `+ 1` leaves room for the null terminator
         if (const char8_t* u8ch = notsa::find_value_or(gxtUtf8Map, src[i], u8"\0"); !*u8ch) {
             if (isascii(src[i])) {
                 out[out_i++] = static_cast<char>(src[i]);
@@ -40,8 +42,10 @@ char* GxtCharToUTF8(char* out, const GxtChar* src, size_t size, size_t offset) {
         } else {
             const auto utf8Size = std::strlen((const char*)u8ch);
 
-            assert(out_i + utf8Size <= size - offset);
-            std::memcpy(&out[out_i], u8ch, utf8Size + 1);
+            if (out_i + utf8Size >= size) { // multi-byte char + terminator wouldn't fit, truncate here
+                break;
+            }
+            std::memcpy(&out[out_i], u8ch, utf8Size);
             out_i += utf8Size;
         }
     }

--- a/source/game_sa/GxtChar.h
+++ b/source/game_sa/GxtChar.h
@@ -17,7 +17,7 @@ void AsciiToGxtChar(const char* src, GxtChar* dst);
  * @param   src        pointer to null-terminated source string
  * @param   size       size of the `out` buffer
  * @param   offset     start position
- * @return  pointer to static var containing null-terminated ASCII string
+ * @return  `out`, holding the null-terminated UTF-8 string
  */
 char* GxtCharToUTF8(char* out, const GxtChar* src, size_t size, size_t offset = 0);
 
@@ -26,6 +26,7 @@ char* GxtCharToUTF8(char (&out)[N], const GxtChar* src, size_t offset = 0) {
     return GxtCharToUTF8(out, src, N, offset);
 }
 
+// uses a shared static buffer, the returned string is overwritten by the next call
 inline const char* GxtCharToUTF8(const GxtChar* src, size_t offset = 0) {
     static char utf8Text[255];
     return GxtCharToUTF8(utf8Text, src, std::size(utf8Text), offset);


### PR DESCRIPTION
small fixes across the ci configs, docs and helper scripts

the two that actually break something: [`update-re-progress.yml#L45`](https://github.com/gta-reversed/gta-reversed/blob/38283e7254dd67b16d277e96c412e4193cca3511/.github/workflows/update-re-progress.yml#L45) reads `steps.get-user-id.outputs.user-id` from a step that doesn't exist, so the bot commits as `<+gta-reversed[bot]@users.noreply.github.com>`, and [`static-analysis.yml#L34-L37`](https://github.com/gta-reversed/gta-reversed/blob/38283e7254dd67b16d277e96c412e4193cca3511/.github/workflows/static-analysis.yml#L34-L37) passes `matrix.arch` and `matrix.preset` which that matrix never defines, so they arrive empty and beat the input defaults

rest is link rot, wrong version numbers, dead config, plus an out of bounds write in `GxtCharToUTF8` where the capacity math ignores that `offset` only applies to the input