### PR TITLE
re(MenuManager): AdditionalOptionInput

### DIFF
--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -330,7 +330,7 @@ void CMenuManager::ProcessUserInput(bool GoDownMenu, bool GoUpMenu, bool EnterMe
 void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
     const auto pad                       = CPad::GetPad(m_nPlayerNumber);
 
-    const auto GetMouseWorldPosScreenPos = [this] {
+    const auto GET_MOUSE_WORLD_POS_SCREEN_POS = [this] {
         auto radar = CRadar::TransformRealWorldPointToRadarSpace(m_vMousePos);
         CRadar::LimitRadarPoint(radar);
         return CRadar::TransformRadarPointToScreenSpace(radar);
@@ -365,9 +365,7 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         return;
     }
 
-    const auto panDelayPassed = [] {
-        return CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime > 20;
-    };
+    const auto panDelayPassed = CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime > 20;
 
     m_bDrawingMap                 = true;
 
@@ -404,8 +402,8 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
     // 0x57747D - If the legend options menu is open, don't process map controls
     if (m_nSysMenu < 0) {
         // 0x577483 - Waypoint blip toggle (Circle / RMB / T key)
-        if ((pad->NewState.ButtonCircle && !pad->OldState.ButtonCircle)
-            || (CPad::IsMouseRButtonPressed() && !CPad::NewMouseControllerState.isMouseLeftButtonPressed)
+        if (pad->IsCirclePressed()
+            || (CPad::IsMouseRButtonPressed() && !CPad::IsMouseLButton())
             || pad->IsStandardKeyJustPressed('T')
             || pad->IsStandardKeyJustPressed('t')) {
             if (!CTheScripts::HideAllFrontEndMapBlips && !CTheScripts::bPlayerIsOffTheMap) {
@@ -428,50 +426,52 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         }
 
         // 0x5775E5 - Zoom in (LeftShoulder2 only / wheel up / PgUp)
-        if ((pad->NewState.LeftShoulder2 && !pad->NewState.RightShoulder2)
-            || CPad::NewMouseControllerState.isMouseWheelMovedUp
-            || CPad::NewKeyState.pgup) {
-            if (panDelayPassed()) {
+        if ((pad->IsLeftShoulder2() && !pad->IsRightShoulder2())
+            || CPad::IsMouseWheelUp()
+            || CPad::IsPgUpDown()) {
+            if (panDelayPassed) {
                 if (m_fMapZoom >= 1100.0f) {
                     m_fMapZoom = 1100.0f;
                 } else {
+                    // TODO: Frame-rate dependent
                     m_fMapZoom += 7.0f;
-                    if (CPad::NewMouseControllerState.isMouseWheelMovedUp) {
+                    if (CPad::IsMouseWheelUp()) {
                         m_fMapZoom += 21.0f;
                     }
                     m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
                     m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;
                 }
-                auto screen = GetMouseWorldPosScreenPos();
+                auto screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                 while (screen.x > MAP_VIEW_RIGHT) {
                     m_vMousePos.x -= 1.0f;
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                 }
                 while (screen.x < MAP_VIEW_LEFT) {
                     m_vMousePos.x += 1.0f;
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                 }
                 while (screen.y < MAP_VIEW_TOP) {
                     m_vMousePos.y -= 1.0f;
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                 }
                 while (screen.y > MAP_VIEW_BOTTOM) {
                     m_vMousePos.y += 1.0f;
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                 }
             }
         }
 
         // 0x577918 - Zoom out (RightShoulder2 only / wheel down / PgDn)
-        if ((pad->NewState.RightShoulder2 && !pad->NewState.LeftShoulder2)
-            || CPad::NewMouseControllerState.isMouseWheelMovedDown
-            || CPad::NewKeyState.pgdn) {
-            if (panDelayPassed()) {
+        if ((pad->IsRightShoulder2() && !pad->IsLeftShoulder2())
+            || CPad::IsMouseWheelDown()
+            || CPad::IsPgDnDown()) {
+            if (panDelayPassed) {
                 if (m_fMapZoom <= 300.0f) {
                     m_fMapZoom = 300.0f;
                 } else {
+                    // TODO: Frame-rate dependent
                     m_fMapZoom -= 7.0f;
-                    if (CPad::NewMouseControllerState.isMouseWheelMovedDown) {
+                    if (CPad::IsMouseWheelDown()) {
                         m_fMapZoom -= 21.0f;
                     }
                     m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
@@ -481,28 +481,28 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         }
 
         // 0x5779FE - Compute marker pos in map-screen space
-        auto screen = GetMouseWorldPosScreenPos();
+        auto screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
 
         // 0x577A55 - Read directional input (keyboard / analog sticks / DPad)
         int16 panX = 0;
         int16 panY = 0;
-        if (CPad::NewKeyState.up) {
+        if (CPad::IsUpDown()) {
             panY = -128;
         }
-        if (CPad::NewKeyState.down) {
+        if (CPad::IsDownDown()) {
             panY = 128;
         }
-        if (CPad::NewKeyState.left) {
+        if (CPad::IsLeftDown()) {
             panX = -128;
         }
-        if (CPad::NewKeyState.right) {
+        if (CPad::IsRightDown()) {
             panX = 128;
         }
-        if (pad->NewState.LeftStickX) {
-            panX = pad->NewState.LeftStickX;
+        if (pad->GetLeftStickX()) {
+            panX = pad->GetLeftStickX();
         }
-        if (pad->NewState.LeftStickY) {
-            panY = pad->NewState.LeftStickY;
+        if (pad->GetLeftStickY()) {
+            panY = pad->GetLeftStickY();
         }
         if (pad->NewState.DPadUp) {
             panY = static_cast<int16>(pad->NewState.DPadUp * -0.6f);
@@ -529,8 +529,8 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
             if (m_nMousePosX > StretchX(MAP_FRAME_LEFT) && m_nMousePosX < StretchX(MAP_FRAME_RIGHT)
                 && m_nMousePosY > StretchY(MAP_FRAME_TOP) && m_nMousePosY < StretchY(MAP_FRAME_BOTTOM)) {
                 // 0x577CE4 - Cursor inside the map area
-                screen = GetMouseWorldPosScreenPos();
-                if (CPad::NewMouseControllerState.isMouseLeftButtonPressed) {
+                screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                if (CPad::IsMouseLButton()) {
                     // 0x577D43 - LMB held: pan according to cursor offset from screen centre
                     markerFreeFromEdge = true;
                     if (m_nMousePosX < RsGlobal.maximumWidth / 2) {
@@ -548,19 +548,19 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     markerTrackMouse = true;
                     while (StretchX(screen.x) > float(m_nMousePosX) && screen.x > MAP_VIEW_LEFT) {
                         m_vMousePos.x -= 14.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
                     while (StretchX(screen.x) < float(m_nMousePosX) && screen.x < MAP_VIEW_RIGHT) {
                         m_vMousePos.x += 14.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
                     while (StretchY(screen.y) > float(m_nMousePosY) && screen.y > MAP_VIEW_TOP) {
                         m_vMousePos.y += 14.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
                     while (StretchY(screen.y) < float(m_nMousePosY) && screen.y < MAP_VIEW_BOTTOM) {
                         m_vMousePos.y -= 14.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
                 }
             }
@@ -570,57 +570,57 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
             // 0x577E10 - Move the map origin / marker
             if (panX > 0) {
                 if (mapRight > MAP_FRAME_RIGHT && screen.x >= MAP_CENTER_X && markerFreeFromEdge) {
-                    if (panDelayPassed()) {
+                    if (panDelayPassed) {
                         m_vMapOrigin.x -= float(panX) * PAN_STRIDE;
                     }
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     while (mapRight > MAP_FRAME_RIGHT && screen.x < MAP_CENTER_X) {
                         m_vMousePos.x += 1.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
-                } else if (panDelayPassed() && screen.x < MAP_VIEW_RIGHT) {
+                } else if (panDelayPassed && screen.x < MAP_VIEW_RIGHT) {
                     m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
                 }
             }
             if (panX < 0) {
                 if (mapLeft < MAP_FRAME_LEFT && screen.x <= MAP_CENTER_X && markerFreeFromEdge) {
-                    if (panDelayPassed()) {
+                    if (panDelayPassed) {
                         m_vMapOrigin.x += float(-panX) * PAN_STRIDE;
                     }
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     while (mapLeft < MAP_FRAME_LEFT && screen.x > MAP_CENTER_X) {
                         m_vMousePos.x -= 1.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
-                } else if (panDelayPassed() && screen.x > MAP_VIEW_LEFT) {
+                } else if (panDelayPassed && screen.x > MAP_VIEW_LEFT) {
                     m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
                 }
             }
             if (panY > 0) {
                 if (mapTop > MAP_FRAME_BOTTOM && screen.y >= MAP_CENTER_Y && markerFreeFromEdge) {
-                    if (panDelayPassed()) {
+                    if (panDelayPassed) {
                         m_vMapOrigin.y -= float(panY) * PAN_STRIDE;
                     }
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     while (mapTop > MAP_FRAME_BOTTOM && screen.y < MAP_CENTER_Y) {
                         m_vMousePos.y -= 1.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
-                } else if (panDelayPassed() && screen.y < MAP_VIEW_BOTTOM) {
+                } else if (panDelayPassed && screen.y < MAP_VIEW_BOTTOM) {
                     m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
                 }
             }
             if (panY < 0) {
                 if (mapBottom < MAP_FRAME_TOP && screen.y <= MAP_CENTER_Y && markerFreeFromEdge) {
-                    if (panDelayPassed()) {
+                    if (panDelayPassed) {
                         m_vMapOrigin.y += float(-panY) * PAN_STRIDE;
                     }
-                    screen = GetMouseWorldPosScreenPos();
+                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     while (mapBottom < MAP_FRAME_TOP && screen.y > MAP_CENTER_Y) {
                         m_vMousePos.y += 1.0f;
-                        screen = GetMouseWorldPosScreenPos();
+                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
                     }
-                } else if (panDelayPassed() && screen.y > MAP_VIEW_TOP) {
+                } else if (panDelayPassed && screen.y > MAP_VIEW_TOP) {
                     m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
                 }
             }
@@ -648,11 +648,11 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
     }
 
     // NOTSA: Rebuild the ON/OFF column of the legend options menu from the current blip prefs
-    const auto InsertBlipToggleRows = [this] {
-        const auto OnOff = [](bool on) {
-            return (char*)(on ? "FEM_ON" : "FEM_OFF");
+    const auto INSERT_BLIP_TOGGLE_ROWS = [this] {
+        const auto ON_OFF = [](bool on) {
+            return on ? "FEM_ON" : "FEM_OFF";
         };
-        CMenuSystem::InsertMenu(m_nSysMenu, 1, nullptr, OnOff(m_ShowLocationsBlips), OnOff(m_ShowContactsBlips), OnOff(m_ShowMissionBlips), OnOff(m_ShowOtherBlips), OnOff(m_ShowGangAreaBlips));
+        CMenuSystem::InsertMenu(m_nSysMenu, 1, nullptr, ON_OFF(m_ShowLocationsBlips), ON_OFF(m_ShowContactsBlips), ON_OFF(m_ShowMissionBlips), ON_OFF(m_ShowOtherBlips), ON_OFF(m_ShowGangAreaBlips));
     };
 
     // 0x578877 - Open the legend options menu (Space held)
@@ -669,8 +669,8 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
             true,
             eFontAlignment::ALIGN_LEFT
         );
-        CMenuSystem::InsertMenu(m_nSysMenu, 0, nullptr, (char*)"FED_BL1", (char*)"FED_BL2", (char*)"FED_BL3", (char*)"FED_BL4", (char*)"FED_BL5");
-        InsertBlipToggleRows();
+        CMenuSystem::InsertMenu(m_nSysMenu, 0, nullptr, "FED_BL1", "FED_BL2", "FED_BL3", "FED_BL4", "FED_BL5");
+        INSERT_BLIP_TOGGLE_ROWS();
     }
 
     // 0x578A36 - Legend options menu is open
@@ -678,12 +678,12 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         const auto item = CMenuSystem::CheckForAccept(m_nSysMenu);
         if (item >= 0) {
             m_abPrefsMapBlips[item] = !m_abPrefsMapBlips[item];
-            InsertBlipToggleRows();
+            INSERT_BLIP_TOGGLE_ROWS();
             const auto selected = CMenuSystem::CheckForSelected(m_nSysMenu);
             CMenuSystem::SetActiveMenuItem(m_nSysMenu, selected == 4 ? 0 : selected + 1);
         }
         // 0x578B8F - Close the menu once Space is fully released
-        if (!CPad::NewKeyState.standardKeys[' '] && !CPad::OldKeyState.standardKeys[' ']) {
+        if (pad->IsStandardKeyUp(' ')) {
             AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_BACK);
             CMenuSystem::SwitchOffMenu(m_nSysMenu);
             m_nSysMenu = CMenuSystem::MENU_UNDEFINED;
@@ -695,7 +695,7 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         m_bMapLegend = !m_bMapLegend;
     }
 
-    if (panDelayPassed()) {
+    if (panDelayPassed) {
         FrontEndMenuManager.m_LastActionTime = CTimer::GetTimeInMSPauseMode();
     }
     m_bDrawingMap = false;

--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -509,36 +509,19 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         // 0x577A55 - Read directional input (keyboard / analog sticks / DPad)
         int16 panX = 0;
         int16 panY = 0;
-        if (CPad::IsUpDown()) {
-            panY = -128;
-        }
-        if (CPad::IsDownDown()) {
-            panY = 128;
-        }
-        if (CPad::IsLeftDown()) {
-            panX = -128;
-        }
-        if (CPad::IsRightDown()) {
-            panX = 128;
-        }
-        if (pad->GetLeftStickX()) {
-            panX = pad->GetLeftStickX();
-        }
-        if (pad->GetLeftStickY()) {
-            panY = pad->GetLeftStickY();
-        }
-        if (pad->NewState.DPadUp) {
-            panY = static_cast<int16>(pad->NewState.DPadUp * -0.6f);
-        }
-        if (pad->NewState.DPadDown) {
-            panY = static_cast<int16>(pad->NewState.DPadDown * 0.6f);
-        }
-        if (pad->NewState.DPadLeft) {
-            panX = static_cast<int16>(pad->NewState.DPadLeft * -0.6f);
-        }
-        if (pad->NewState.DPadRight) {
-            panX = static_cast<int16>(pad->NewState.DPadRight * 0.6f);
-        }
+
+        if (CPad::IsUpDown())    panY = -128;
+        if (CPad::IsDownDown())  panY =  128;
+        if (CPad::IsLeftDown())  panX = -128;
+        if (CPad::IsRightDown()) panX =  128;
+
+        if (auto x = pad->GetLeftStickX()) panX = x;
+        if (auto y = pad->GetLeftStickY()) panY = y;
+
+        if (pad->NewState.DPadUp)    panY = -static_cast<int16>(pad->NewState.DPadUp    * 0.6f);
+        if (pad->NewState.DPadDown)  panY =  static_cast<int16>(pad->NewState.DPadDown  * 0.6f);
+        if (pad->NewState.DPadLeft)  panX = -static_cast<int16>(pad->NewState.DPadLeft  * 0.6f);
+        if (pad->NewState.DPadRight) panX =  static_cast<int16>(pad->NewState.DPadRight * 0.6f);
 
         // 0x577C50 - Pan the map
         int8 edgePanMultiplier  = 2;

--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -328,7 +328,377 @@ void CMenuManager::ProcessUserInput(bool GoDownMenu, bool GoUpMenu, bool EnterMe
  * @addr 0x5773D0
  */
 void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
-    plugin::CallMethod<0x5773D0, CMenuManager*, bool*, bool*>(this, upPressed, downPressed);
+    const auto pad                       = CPad::GetPad(m_nPlayerNumber);
+
+    const auto GetMouseWorldPosScreenPos = [this] {
+        auto radar = CRadar::TransformRealWorldPointToRadarSpace(m_vMousePos);
+        CRadar::LimitRadarPoint(radar);
+        return CRadar::TransformRadarPointToScreenSpace(radar);
+    };
+
+    switch (m_nCurrentScreen) {
+    case SCREEN_STATS: {
+        if (pad->IsStandardKeyJustPressed('S') || pad->IsStandardKeyJustPressed('s')) {
+            SaveStatsToFile();
+        }
+        return;
+    }
+    case SCREEN_BRIEF: {
+        if (CheckFrontEndUpInput() && m_nSelectedRow < 0x13 && CMessages::PreviousBriefs[m_nSelectedRow + 1].Text) {
+            m_nSelectedRow++;
+            *upPressed = true;
+        }
+        if (CheckFrontEndDownInput() && m_nSelectedRow > 3) {
+            m_nSelectedRow--;
+            *downPressed = true;
+        }
+        return;
+    }
+    case SCREEN_MAP:
+        break;
+    default:
+        return;
+    }
+
+    // 0x577403 - Map not fully streamed in yet - no input allowed
+    if (m_bAllStreamingStuffLoaded) {
+        return;
+    }
+
+    const auto panDelayPassed = [] {
+        return CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime > 20;
+    };
+
+    m_bDrawingMap                 = true;
+
+    constexpr auto PAN_AXIS_SCALE = 1.0f / 128.0f; // 0.0078125f
+    constexpr auto PAN_STRIDE     = PAN_AXIS_SCALE * 7.0f;
+
+    // Map frame in screen space
+    constexpr auto MAP_FRAME_LEFT   = 60.0f;
+    constexpr auto MAP_FRAME_RIGHT  = 580.0f;
+    constexpr auto MAP_FRAME_TOP    = 60.0f;
+    constexpr auto MAP_FRAME_BOTTOM = 388.0f;
+
+    // Visible area sticks 4.0f from the frame
+    constexpr auto MAP_VIEW_LEFT   = MAP_FRAME_LEFT + 4.0f;   // 64.0f
+    constexpr auto MAP_VIEW_RIGHT  = MAP_FRAME_RIGHT - 4.0f;  // 576.0f
+    constexpr auto MAP_VIEW_TOP    = MAP_FRAME_TOP + 4.0f;    // 64.0f
+    constexpr auto MAP_VIEW_BOTTOM = MAP_FRAME_BOTTOM - 4.0f; // 384.0f
+
+    // Reference screen centre the map code is written against
+    constexpr auto MAP_CENTER_X = 320.0f; // 640.0f / 2
+    constexpr auto MAP_CENTER_Y = 224.0f; // 448.0f / 2
+
+    // 0x577415 - Compute map view bounds (in map-screen space)
+    float       mapBottom     = m_vMapOrigin.y - m_fMapZoom;   // v116
+    float       mapTop        = m_vMapOrigin.y + m_fMapZoom;   // v104
+    float       mapLeft       = m_vMapOrigin.x - m_fMapZoom;   // v114
+    float       mapRight      = m_vMapOrigin.x + m_fMapZoom;   // v105
+    const float distToCenterX = MAP_CENTER_X - m_vMapOrigin.x; // v103
+    const float distToCenterY = MAP_CENTER_Y - m_vMapOrigin.y; // v115
+    const float invZoom       = 1.0f / m_fMapZoom;
+    const float relCenterX    = distToCenterX * invZoom; // v117
+    const float relCenterY    = distToCenterY * invZoom; // v82
+
+    // 0x57747D - If the legend options menu is open, don't process map controls
+    if (m_nSysMenu < 0) {
+        // 0x577483 - Waypoint blip toggle (Circle / RMB / T key)
+        if ((pad->NewState.ButtonCircle && !pad->OldState.ButtonCircle)
+            || (CPad::IsMouseRButtonPressed() && !CPad::NewMouseControllerState.isMouseLeftButtonPressed)
+            || pad->IsStandardKeyJustPressed('T')
+            || pad->IsStandardKeyJustPressed('t')) {
+            if (!CTheScripts::HideAllFrontEndMapBlips && !CTheScripts::bPlayerIsOffTheMap) {
+                if (m_nTargetBlipIndex) {
+                    AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_BACK);
+                    CRadar::ClearBlip(m_nTargetBlipIndex);
+                    m_nTargetBlipIndex = 0;
+                } else {
+                    AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_SELECT);
+                    m_nTargetBlipIndex = CRadar::SetCoordBlip(
+                        BLIP_COORD,
+                        { m_vMousePos.x, m_vMousePos.y, 0.0f },
+                        BLIP_COLOUR_RED,
+                        BLIP_DISPLAY_BLIPONLY,
+                        "CODEWAY"
+                    );
+                    CRadar::SetBlipSprite(m_nTargetBlipIndex, RADAR_SPRITE_WAYPOINT);
+                }
+            }
+        }
+
+        // 0x5775E5 - Zoom in (LeftShoulder2 only / wheel up / PgUp)
+        if ((pad->NewState.LeftShoulder2 && !pad->NewState.RightShoulder2)
+            || CPad::NewMouseControllerState.isMouseWheelMovedUp
+            || CPad::NewKeyState.pgup) {
+            if (panDelayPassed()) {
+                if (m_fMapZoom >= 1100.0f) {
+                    m_fMapZoom = 1100.0f;
+                } else {
+                    m_fMapZoom += 7.0f;
+                    if (CPad::NewMouseControllerState.isMouseWheelMovedUp) {
+                        m_fMapZoom += 21.0f;
+                    }
+                    m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
+                    m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;
+                }
+                auto screen = GetMouseWorldPosScreenPos();
+                while (screen.x > MAP_VIEW_RIGHT) {
+                    m_vMousePos.x -= 1.0f;
+                    screen = GetMouseWorldPosScreenPos();
+                }
+                while (screen.x < MAP_VIEW_LEFT) {
+                    m_vMousePos.x += 1.0f;
+                    screen = GetMouseWorldPosScreenPos();
+                }
+                while (screen.y < MAP_VIEW_TOP) {
+                    m_vMousePos.y -= 1.0f;
+                    screen = GetMouseWorldPosScreenPos();
+                }
+                while (screen.y > MAP_VIEW_BOTTOM) {
+                    m_vMousePos.y += 1.0f;
+                    screen = GetMouseWorldPosScreenPos();
+                }
+            }
+        }
+
+        // 0x577918 - Zoom out (RightShoulder2 only / wheel down / PgDn)
+        if ((pad->NewState.RightShoulder2 && !pad->NewState.LeftShoulder2)
+            || CPad::NewMouseControllerState.isMouseWheelMovedDown
+            || CPad::NewKeyState.pgdn) {
+            if (panDelayPassed()) {
+                if (m_fMapZoom <= 300.0f) {
+                    m_fMapZoom = 300.0f;
+                } else {
+                    m_fMapZoom -= 7.0f;
+                    if (CPad::NewMouseControllerState.isMouseWheelMovedDown) {
+                        m_fMapZoom -= 21.0f;
+                    }
+                    m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
+                    m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;
+                }
+            }
+        }
+
+        // 0x5779FE - Compute marker pos in map-screen space
+        auto screen = GetMouseWorldPosScreenPos();
+
+        // 0x577A55 - Read directional input (keyboard / analog sticks / DPad)
+        int16 panX = 0;
+        int16 panY = 0;
+        if (CPad::NewKeyState.up) {
+            panY = -128;
+        }
+        if (CPad::NewKeyState.down) {
+            panY = 128;
+        }
+        if (CPad::NewKeyState.left) {
+            panX = -128;
+        }
+        if (CPad::NewKeyState.right) {
+            panX = 128;
+        }
+        if (pad->NewState.LeftStickX) {
+            panX = pad->NewState.LeftStickX;
+        }
+        if (pad->NewState.LeftStickY) {
+            panY = pad->NewState.LeftStickY;
+        }
+        if (pad->NewState.DPadUp) {
+            panY = static_cast<int16>(pad->NewState.DPadUp * -0.6f);
+        }
+        if (pad->NewState.DPadDown) {
+            panY = static_cast<int16>(pad->NewState.DPadDown * 0.6f);
+        }
+        if (pad->NewState.DPadLeft) {
+            panX = static_cast<int16>(pad->NewState.DPadLeft * -0.6f);
+        }
+        if (pad->NewState.DPadRight) {
+            panX = static_cast<int16>(pad->NewState.DPadRight * 0.6f);
+        }
+
+        // 0x577C50 - Pan the map
+        int8 edgePanMultiplier  = 2;
+        bool markerFreeFromEdge = false; // Marker may be moved without the cursor being at the map edge
+        bool markerTrackMouse   = false; // Marker follows the mouse cursor (no panning)
+
+        if (!m_DisplayTheMouse) {
+            markerFreeFromEdge = true;
+        } else {
+            edgePanMultiplier = 50;
+            if (m_nMousePosX > StretchX(MAP_FRAME_LEFT) && m_nMousePosX < StretchX(MAP_FRAME_RIGHT)
+                && m_nMousePosY > StretchY(MAP_FRAME_TOP) && m_nMousePosY < StretchY(MAP_FRAME_BOTTOM)) {
+                // 0x577CE4 - Cursor inside the map area
+                screen = GetMouseWorldPosScreenPos();
+                if (CPad::NewMouseControllerState.isMouseLeftButtonPressed) {
+                    // 0x577D43 - LMB held: pan according to cursor offset from screen centre
+                    markerFreeFromEdge = true;
+                    if (m_nMousePosX < RsGlobal.maximumWidth / 2) {
+                        panX = static_cast<int16>(float(m_nMousePosX) / StretchX(MAP_CENTER_X) * 128.0f - 128.0f);
+                    } else if (m_nMousePosX > RsGlobal.maximumWidth / 2) {
+                        panX = static_cast<int16>((float(m_nMousePosX) - StretchX(MAP_CENTER_X)) / StretchX(MAP_CENTER_X) * 128.0f);
+                    }
+                    if (m_nMousePosY < RsGlobal.maximumHeight / 2) {
+                        panY = static_cast<int16>(float(m_nMousePosY) / StretchY(MAP_CENTER_Y) * 128.0f - 128.0f);
+                    } else if (m_nMousePosY > RsGlobal.maximumHeight / 2) {
+                        panY = static_cast<int16>((float(m_nMousePosY) - StretchY(MAP_CENTER_Y)) / StretchY(MAP_CENTER_Y) * 128.0f);
+                    }
+                } else {
+                    // 0x577F95 - No LMB: marker tracks the mouse cursor, no panning
+                    markerTrackMouse = true;
+                    while (StretchX(screen.x) > float(m_nMousePosX) && screen.x > MAP_VIEW_LEFT) {
+                        m_vMousePos.x -= 14.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                    while (StretchX(screen.x) < float(m_nMousePosX) && screen.x < MAP_VIEW_RIGHT) {
+                        m_vMousePos.x += 14.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                    while (StretchY(screen.y) > float(m_nMousePosY) && screen.y > MAP_VIEW_TOP) {
+                        m_vMousePos.y += 14.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                    while (StretchY(screen.y) < float(m_nMousePosY) && screen.y < MAP_VIEW_BOTTOM) {
+                        m_vMousePos.y -= 14.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                }
+            }
+        }
+
+        if (!markerTrackMouse) {
+            // 0x577E10 - Move the map origin / marker
+            if (panX > 0) {
+                if (mapRight > MAP_FRAME_RIGHT && screen.x >= MAP_CENTER_X && markerFreeFromEdge) {
+                    if (panDelayPassed()) {
+                        m_vMapOrigin.x -= float(panX) * PAN_STRIDE;
+                    }
+                    screen = GetMouseWorldPosScreenPos();
+                    while (mapRight > MAP_FRAME_RIGHT && screen.x < MAP_CENTER_X) {
+                        m_vMousePos.x += 1.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                } else if (panDelayPassed() && screen.x < MAP_VIEW_RIGHT) {
+                    m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
+                }
+            }
+            if (panX < 0) {
+                if (mapLeft < MAP_FRAME_LEFT && screen.x <= MAP_CENTER_X && markerFreeFromEdge) {
+                    if (panDelayPassed()) {
+                        m_vMapOrigin.x += float(-panX) * PAN_STRIDE;
+                    }
+                    screen = GetMouseWorldPosScreenPos();
+                    while (mapLeft < MAP_FRAME_LEFT && screen.x > MAP_CENTER_X) {
+                        m_vMousePos.x -= 1.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                } else if (panDelayPassed() && screen.x > MAP_VIEW_LEFT) {
+                    m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
+                }
+            }
+            if (panY > 0) {
+                if (mapTop > MAP_FRAME_BOTTOM && screen.y >= MAP_CENTER_Y && markerFreeFromEdge) {
+                    if (panDelayPassed()) {
+                        m_vMapOrigin.y -= float(panY) * PAN_STRIDE;
+                    }
+                    screen = GetMouseWorldPosScreenPos();
+                    while (mapTop > MAP_FRAME_BOTTOM && screen.y < MAP_CENTER_Y) {
+                        m_vMousePos.y -= 1.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                } else if (panDelayPassed() && screen.y < MAP_VIEW_BOTTOM) {
+                    m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
+                }
+            }
+            if (panY < 0) {
+                if (mapBottom < MAP_FRAME_TOP && screen.y <= MAP_CENTER_Y && markerFreeFromEdge) {
+                    if (panDelayPassed()) {
+                        m_vMapOrigin.y += float(-panY) * PAN_STRIDE;
+                    }
+                    screen = GetMouseWorldPosScreenPos();
+                    while (mapBottom < MAP_FRAME_TOP && screen.y > MAP_CENTER_Y) {
+                        m_vMousePos.y += 1.0f;
+                        screen = GetMouseWorldPosScreenPos();
+                    }
+                } else if (panDelayPassed() && screen.y > MAP_VIEW_TOP) {
+                    m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
+                }
+            }
+        }
+
+        // 0x578785 - Clamp map view into valid bounds
+        mapBottom = m_vMapOrigin.y - m_fMapZoom;
+        mapTop    = m_vMapOrigin.y + m_fMapZoom;
+        mapLeft   = m_vMapOrigin.x - m_fMapZoom;
+        mapRight  = m_vMapOrigin.x + m_fMapZoom;
+        if (mapLeft > MAP_FRAME_LEFT) {
+            m_vMapOrigin.x -= mapLeft - MAP_FRAME_LEFT;
+        }
+        if (mapRight < MAP_FRAME_RIGHT) {
+            m_vMapOrigin.x += MAP_FRAME_RIGHT - mapRight;
+        }
+        if (mapBottom > MAP_FRAME_TOP) {
+            m_vMapOrigin.y -= mapBottom - MAP_FRAME_TOP;
+        }
+        if (mapTop < MAP_FRAME_BOTTOM) {
+            m_vMapOrigin.y += MAP_FRAME_BOTTOM - mapTop;
+        }
+        m_vMousePos.x = std::clamp(m_vMousePos.x, -3000.0f, 3000.0f);
+        m_vMousePos.y = std::clamp(m_vMousePos.y, -3000.0f, 3000.0f);
+    }
+
+    // NOTSA: Rebuild the ON/OFF column of the legend options menu from the current blip prefs
+    const auto InsertBlipToggleRows = [this] {
+        const auto OnOff = [](bool on) {
+            return (char*)(on ? "FEM_ON" : "FEM_OFF");
+        };
+        CMenuSystem::InsertMenu(m_nSysMenu, 1, nullptr, OnOff(m_ShowLocationsBlips), OnOff(m_ShowContactsBlips), OnOff(m_ShowMissionBlips), OnOff(m_ShowOtherBlips), OnOff(m_ShowGangAreaBlips));
+    };
+
+    // 0x578877 - Open the legend options menu (Space held)
+    if (pad->IsStandardKeyJustDown(' ') && m_nSysMenu == CMenuSystem::MENU_UNDEFINED) {
+        AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_SELECT);
+        m_nSysMenu = CMenuSystem::CreateNewMenu(
+            CMenuSystem::MENU_TYPE_DEFAULT,
+            "FEP_OPT",
+            StretchX(77.0f),
+            StretchY(250.0f),
+            StretchX(100.0f),
+            2,
+            true,
+            true,
+            eFontAlignment::ALIGN_LEFT
+        );
+        CMenuSystem::InsertMenu(m_nSysMenu, 0, nullptr, (char*)"FED_BL1", (char*)"FED_BL2", (char*)"FED_BL3", (char*)"FED_BL4", (char*)"FED_BL5");
+        InsertBlipToggleRows();
+    }
+
+    // 0x578A36 - Legend options menu is open
+    if (m_nSysMenu >= 0) {
+        const auto item = CMenuSystem::CheckForAccept(m_nSysMenu);
+        if (item >= 0) {
+            m_abPrefsMapBlips[item] = !m_abPrefsMapBlips[item];
+            InsertBlipToggleRows();
+            const auto selected = CMenuSystem::CheckForSelected(m_nSysMenu);
+            CMenuSystem::SetActiveMenuItem(m_nSysMenu, selected == 4 ? 0 : selected + 1);
+        }
+        // 0x578B8F - Close the menu once Space is fully released
+        if (!CPad::NewKeyState.standardKeys[' '] && !CPad::OldKeyState.standardKeys[' ']) {
+            AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_BACK);
+            CMenuSystem::SwitchOffMenu(m_nSysMenu);
+            m_nSysMenu = CMenuSystem::MENU_UNDEFINED;
+        }
+    }
+
+    // 0x578BE8 - Toggle blip legend (L key)
+    if (pad->IsStandardKeyJustPressed('L') || pad->IsStandardKeyJustPressed('l')) {
+        m_bMapLegend = !m_bMapLegend;
+    }
+
+    if (panDelayPassed()) {
+        FrontEndMenuManager.m_LastActionTime = CTimer::GetTimeInMSPauseMode();
+    }
+    m_bDrawingMap = false;
 }
 
 // 0x57EF50

--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -9,6 +9,8 @@
 #include "VideoMode.h" // todo
 #include "ControllerConfigManager.h"
 #include "extensions/Configs/FastLoader.hpp"
+#include "extensions/utility.hpp"
+#include "reversiblebugfixes/Bugs.hpp"
 
 /*!
  * @addr 0x57FD70
@@ -365,7 +367,10 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         return;
     }
 
-    const auto panDelayPassed = CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime > 20;
+    // Original tick rate for map pan/zoom: one step every 20ms of wall-clock time
+    constexpr auto PAN_TICK_MS = 20;
+
+    const auto panDelayPassed = CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime > PAN_TICK_MS;
 
     m_bDrawingMap                 = true;
 
@@ -433,10 +438,19 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                 if (m_fMapZoom >= 1100.0f) {
                     m_fMapZoom = 1100.0f;
                 } else {
-                    // TODO: Frame-rate dependent
-                    m_fMapZoom += 7.0f;
-                    if (CPad::IsMouseWheelUp()) {
-                        m_fMapZoom += 21.0f;
+                    if (notsa::bugfixes::GenericFrameRate) {
+                        // Scale step by elapsed wall-clock ms so the zoom rate is framerate-independent.
+                        // divide by PAN_TICK_MS to match the original +7 per 20ms tick.
+                        const float frameTickScale = float(CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime) / PAN_TICK_MS;
+                        m_fMapZoom += 7.0f * frameTickScale;
+                        if (CPad::IsMouseWheelUp()) {
+                            m_fMapZoom += 21.0f * frameTickScale;
+                        }
+                    } else {
+                        m_fMapZoom += 7.0f;
+                        if (CPad::IsMouseWheelUp()) {
+                            m_fMapZoom += 21.0f;
+                        }
                     }
                     m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
                     m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;
@@ -469,10 +483,19 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                 if (m_fMapZoom <= 300.0f) {
                     m_fMapZoom = 300.0f;
                 } else {
-                    // TODO: Frame-rate dependent
-                    m_fMapZoom -= 7.0f;
-                    if (CPad::IsMouseWheelDown()) {
-                        m_fMapZoom -= 21.0f;
+                    if (notsa::bugfixes::GenericFrameRate) {
+                        // Scale step by elapsed wall-clock ms so the zoom rate is framerate-independent.
+                        // divide by PAN_TICK_MS to match the original +7 per 20ms tick.
+                        const float frameTickScale = float(CTimer::GetTimeInMSPauseMode() - FrontEndMenuManager.m_LastActionTime) / PAN_TICK_MS;
+                        m_fMapZoom -= 7.0f * frameTickScale;
+                        if (CPad::IsMouseWheelDown()) {
+                            m_fMapZoom -= 21.0f * frameTickScale;
+                        }
+                    } else {
+                        m_fMapZoom -= 7.0f;
+                        if (CPad::IsMouseWheelDown()) {
+                            m_fMapZoom -= 21.0f;
+                        }
                     }
                     m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
                     m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;

--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -331,7 +331,7 @@ void CMenuManager::ProcessUserInput(bool GoDownMenu, bool GoUpMenu, bool EnterMe
 void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
     const auto pad                       = CPad::GetPad(m_nPlayerNumber);
 
-    const auto GET_MOUSE_WORLD_POS_SCREEN_POS = [this] {
+    const auto GetMouseWorldPosScreenPos = [this] {
         auto radar = CRadar::TransformRealWorldPointToRadarSpace(m_vMousePos);
         CRadar::LimitRadarPoint(radar);
         return CRadar::TransformRadarPointToScreenSpace(radar);
@@ -454,22 +454,22 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     m_vMapOrigin.x -= relCenterX * m_fMapZoom - distToCenterX;
                     m_vMapOrigin.y -= relCenterY * m_fMapZoom - distToCenterY;
                 }
-                auto screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                auto screen = GetMouseWorldPosScreenPos();
                 while (screen.x > MAP_VIEW_RIGHT) {
                     m_vMousePos.x -= 1.0f;
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                 }
                 while (screen.x < MAP_VIEW_LEFT) {
                     m_vMousePos.x += 1.0f;
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                 }
                 while (screen.y < MAP_VIEW_TOP) {
                     m_vMousePos.y -= 1.0f;
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                 }
                 while (screen.y > MAP_VIEW_BOTTOM) {
                     m_vMousePos.y += 1.0f;
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                 }
             }
         }
@@ -503,24 +503,41 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
         }
 
         // 0x5779FE - Compute marker pos in map-screen space
-        auto screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+        auto screen = GetMouseWorldPosScreenPos();
 
         // 0x577A55 - Read directional input (keyboard / analog sticks / DPad)
         int16 panX = 0;
         int16 panY = 0;
-
-        if (CPad::IsUpDown())    panY = -128;
-        if (CPad::IsDownDown())  panY =  128;
-        if (CPad::IsLeftDown())  panX = -128;
-        if (CPad::IsRightDown()) panX =  128;
-
-        if (auto x = pad->GetLeftStickX()) panX = x;
-        if (auto y = pad->GetLeftStickY()) panY = y;
-
-        if (pad->NewState.DPadUp)    panY = -static_cast<int16>(pad->NewState.DPadUp    * 0.6f);
-        if (pad->NewState.DPadDown)  panY =  static_cast<int16>(pad->NewState.DPadDown  * 0.6f);
-        if (pad->NewState.DPadLeft)  panX = -static_cast<int16>(pad->NewState.DPadLeft  * 0.6f);
-        if (pad->NewState.DPadRight) panX =  static_cast<int16>(pad->NewState.DPadRight * 0.6f);
+        if (CPad::IsUpDown()) {
+            panY = -128;
+        }
+        if (CPad::IsDownDown()) {
+            panY = 128;
+        }
+        if (CPad::IsLeftDown()) {
+            panX = -128;
+        }
+        if (CPad::IsRightDown()) {
+            panX = 128;
+        }
+        if (pad->GetLeftStickX()) {
+            panX = pad->GetLeftStickX();
+        }
+        if (pad->GetLeftStickY()) {
+            panY = pad->GetLeftStickY();
+        }
+        if (pad->NewState.DPadUp) {
+            panY = static_cast<int16>(pad->NewState.DPadUp * -0.6f);
+        }
+        if (pad->NewState.DPadDown) {
+            panY = static_cast<int16>(pad->NewState.DPadDown * 0.6f);
+        }
+        if (pad->NewState.DPadLeft) {
+            panX = static_cast<int16>(pad->NewState.DPadLeft * -0.6f);
+        }
+        if (pad->NewState.DPadRight) {
+            panX = static_cast<int16>(pad->NewState.DPadRight * 0.6f);
+        }
 
         // 0x577C50 - Pan the map
         int8 edgePanMultiplier  = 2;
@@ -534,7 +551,7 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
             if (m_nMousePosX > StretchX(MAP_FRAME_LEFT) && m_nMousePosX < StretchX(MAP_FRAME_RIGHT)
                 && m_nMousePosY > StretchY(MAP_FRAME_TOP) && m_nMousePosY < StretchY(MAP_FRAME_BOTTOM)) {
                 // 0x577CE4 - Cursor inside the map area
-                screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                screen = GetMouseWorldPosScreenPos();
                 if (CPad::IsMouseLButton()) {
                     // 0x577D43 - LMB held: pan according to cursor offset from screen centre
                     markerFreeFromEdge = true;
@@ -553,19 +570,19 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     markerTrackMouse = true;
                     while (StretchX(screen.x) > float(m_nMousePosX) && screen.x > MAP_VIEW_LEFT) {
                         m_vMousePos.x -= 14.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                     while (StretchX(screen.x) < float(m_nMousePosX) && screen.x < MAP_VIEW_RIGHT) {
                         m_vMousePos.x += 14.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                     while (StretchY(screen.y) > float(m_nMousePosY) && screen.y > MAP_VIEW_TOP) {
                         m_vMousePos.y += 14.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                     while (StretchY(screen.y) < float(m_nMousePosY) && screen.y < MAP_VIEW_BOTTOM) {
                         m_vMousePos.y -= 14.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                 }
             }
@@ -578,10 +595,10 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     if (panDelayPassed) {
                         m_vMapOrigin.x -= float(panX) * PAN_STRIDE;
                     }
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                     while (mapRight > MAP_FRAME_RIGHT && screen.x < MAP_CENTER_X) {
                         m_vMousePos.x += 1.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                 } else if (panDelayPassed && screen.x < MAP_VIEW_RIGHT) {
                     m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
@@ -592,10 +609,10 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     if (panDelayPassed) {
                         m_vMapOrigin.x += float(-panX) * PAN_STRIDE;
                     }
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                     while (mapLeft < MAP_FRAME_LEFT && screen.x > MAP_CENTER_X) {
                         m_vMousePos.x -= 1.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                 } else if (panDelayPassed && screen.x > MAP_VIEW_LEFT) {
                     m_vMousePos.x += float(panX) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
@@ -606,10 +623,10 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     if (panDelayPassed) {
                         m_vMapOrigin.y -= float(panY) * PAN_STRIDE;
                     }
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                     while (mapTop > MAP_FRAME_BOTTOM && screen.y < MAP_CENTER_Y) {
                         m_vMousePos.y -= 1.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                 } else if (panDelayPassed && screen.y < MAP_VIEW_BOTTOM) {
                     m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;
@@ -620,10 +637,10 @@ void CMenuManager::AdditionalOptionInput(bool* upPressed, bool* downPressed) {
                     if (panDelayPassed) {
                         m_vMapOrigin.y += float(-panY) * PAN_STRIDE;
                     }
-                    screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                    screen = GetMouseWorldPosScreenPos();
                     while (mapBottom < MAP_FRAME_TOP && screen.y > MAP_CENTER_Y) {
                         m_vMousePos.y += 1.0f;
-                        screen = GET_MOUSE_WORLD_POS_SCREEN_POS();
+                        screen = GetMouseWorldPosScreenPos();
                     }
                 } else if (panDelayPassed && screen.y > MAP_VIEW_TOP) {
                     m_vMousePos.y -= float(panY) * float(7 * edgePanMultiplier) * PAN_AXIS_SCALE;

--- a/source/game_sa/Frontend/MenuManager_Input.cpp
+++ b/source/game_sa/Frontend/MenuManager_Input.cpp
@@ -9,7 +9,6 @@
 #include "VideoMode.h" // todo
 #include "ControllerConfigManager.h"
 #include "extensions/Configs/FastLoader.hpp"
-#include "extensions/utility.hpp"
 #include "reversiblebugfixes/Bugs.hpp"
 
 /*!

--- a/source/game_sa/MenuManager.cpp
+++ b/source/game_sa/MenuManager.cpp
@@ -85,7 +85,7 @@ void CMenuManager::InjectHooks() {
     RH_ScopedInstall(PrintRadioStationList, 0x5746F0);
 
     RH_ScopedInstall(UserInput, 0x57FD70);
-    RH_ScopedInstall(AdditionalOptionInput, 0x5773D0, { .reversed = false });
+    RH_ScopedInstall(AdditionalOptionInput, 0x5773D0);
     RH_ScopedInstall(CheckRedefineControlInput, 0x57E4D0);
     RH_ScopedInstall(RedefineScreenUserInput, 0x57EF50);
 

--- a/source/game_sa/MenuSystem.cpp
+++ b/source/game_sa/MenuSystem.cpp
@@ -147,7 +147,7 @@ void CMenuSystem::InputStandardMenu(MenuId id) {
         AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_BACK);
     }
 
-    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsEnterJustPressed()) {
+    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && pad->IsEnterJustPressed()) {
         if (!CTimer::GetIsPaused())
             AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_SELECT);
 
@@ -214,7 +214,7 @@ void CMenuSystem::InputGridMenu(MenuId id) {
     auto menu = MenuNumber[id];
     auto pad = CPad::GetPad();
 
-    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsEnterJustPressed()) {
+    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && pad->IsEnterJustPressed()) {
         if (menu->m_abRowSelectable[menu->m_nSelectedRow])
             menu->m_nAcceptedRow = menu->m_nSelectedRow;
     }
@@ -608,7 +608,7 @@ void CMenuSystem::FillGridWithCarColours(MenuId id) {
 
 // Insert menu column
 // 0x581E00
-void CMenuSystem::InsertMenu(MenuId id, uint8 column, char* colHeader, char* row0, char* row1, char* row2, char* row3, char* row4, char* row5, char* row6, char* row7, char* row8, char* row9, char* row10, char* row11) {
+void CMenuSystem::InsertMenu(MenuId id, uint8 column, const char* colHeader, const char* row0, const char* row1, const char* row2, const char* row3, const char* row4, const char* row5, const char* row6, const char* row7, const char* row8, const char* row9, const char* row10, const char* row11) {
     assert(column < MENU_COL_COUNT);
     auto* menu = MenuNumber[id];
 

--- a/source/game_sa/MenuSystem.cpp
+++ b/source/game_sa/MenuSystem.cpp
@@ -94,12 +94,12 @@ void CMenuSystem::GetMenuPosition(MenuId id, float* outX, float* outY) {
 }
 
 // 0x5807C0
-MenuId CMenuSystem::CheckForAccept(MenuId id) {
+int8 CMenuSystem::CheckForAccept(MenuId id) {
     return MenuInUse[id] ? MenuNumber[id]->m_nAcceptedRow : MENU_UNDEFINED;
 }
 
 // 0x5807E0
-MenuId CMenuSystem::CheckForSelected(MenuId id) {
+int8 CMenuSystem::CheckForSelected(MenuId id) {
     return MenuInUse[id] ? MenuNumber[id]->m_nSelectedRow : MENU_UNDEFINED;
 }
 
@@ -147,7 +147,7 @@ void CMenuSystem::InputStandardMenu(MenuId id) {
         AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_BACK);
     }
 
-    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsReturnJustPressed()) {
+    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsEnterJustPressed()) {
         if (!CTimer::GetIsPaused())
             AudioEngine.ReportFrontendAudioEvent(AE_FRONTEND_SELECT);
 
@@ -186,10 +186,10 @@ void CMenuSystem::InputStandardMenu(MenuId id) {
     }
 
     if (menu->m_nSelectedRow < 0) {
-        auto m_nNumRows = menu->m_nNumRows;
+        menu->m_nSelectedRow = menu->m_nNumRows;
         do {
             menu->m_nSelectedRow -= 1;
-        } while ((!menu->m_abRowSelectable[m_nNumRows] || !menu->m_aaacRowTitles[0][m_nNumRows][0]) && m_nNumRows >= 0);
+        } while ((!menu->m_abRowSelectable[menu->m_nSelectedRow] || !menu->m_aaacRowTitles[0][menu->m_nSelectedRow][0]) && menu->m_nSelectedRow >= 0);
     }
 
     if (menu->m_nSelectedRow >= menu->m_nNumRows) {
@@ -214,7 +214,7 @@ void CMenuSystem::InputGridMenu(MenuId id) {
     auto menu = MenuNumber[id];
     auto pad = CPad::GetPad();
 
-    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsReturnJustPressed()) {
+    if (pad->IsCrossPressed() || CTimer::GetIsPaused() && CPad::IsEnterJustPressed()) {
         if (menu->m_abRowSelectable[menu->m_nSelectedRow])
             menu->m_nAcceptedRow = menu->m_nSelectedRow;
     }

--- a/source/game_sa/MenuSystem.h
+++ b/source/game_sa/MenuSystem.h
@@ -51,8 +51,8 @@ public:
         float          m_afColumnWidth[MENU_COL_COUNT];
         CVector2D      m_vPosn;
         bool           m_bColumnBackground;
-        MenuId         m_nSelectedRow;
-        MenuId         m_nAcceptedRow;
+        int8           m_nSelectedRow;
+        int8           m_nAcceptedRow;
     };
 
     static inline auto& MenuInUse = StaticRef<std::array<bool, CMenuSystem::MENU_COUNT>>(0xBA82E0);
@@ -65,8 +65,8 @@ public:
     static void Initialise();
     static void Process(int8 menu = MENU_UNDEFINED);
 
-    static MenuId CheckForAccept(MenuId id);
-    static MenuId CheckForSelected(MenuId id);
+    static int8 CheckForAccept(MenuId id);
+    static int8 CheckForSelected(MenuId id);
 
     static void Input(MenuId id);
     static void InputStandardMenu(MenuId id);

--- a/source/game_sa/MenuSystem.h
+++ b/source/game_sa/MenuSystem.h
@@ -78,9 +78,9 @@ public:
     static MenuId CreateNewMenu(eMenuType type, const char* title, float x, float y, float width, uint8 columns, bool interactive, bool background, eFontAlignment alignment);
     static void ActivateItems(MenuId id, bool b1, bool b2, bool b3, bool b4, bool b5, bool b6, bool b7, bool b8, bool b9, bool b10, bool b11, bool b12);
     static void ActivateOneItem(MenuId id, uint8 rowId, bool enable);
-    static void InsertMenu(MenuId id, uint8 column, char* colHeader, char* row0 = nullptr, char* row1 = nullptr, char* row2 = nullptr, char* row3 = nullptr,
-                           char* row4 = nullptr, char* row5 = nullptr, char* row6 = nullptr, char* row7 = nullptr, char* row8 = nullptr, char* row9 = nullptr,
-                           char* row10 = nullptr, char* row11 = nullptr);
+    static void InsertMenu(MenuId id, uint8 column, const char* colHeader, const char* row0 = nullptr, const char* row1 = nullptr, const char* row2 = nullptr, const char* row3 = nullptr,
+                           const char* row4 = nullptr, const char* row5 = nullptr, const char* row6 = nullptr, const char* row7 = nullptr, const char* row8 = nullptr, const char* row9 = nullptr,
+                           const char* row10 = nullptr, const char* row11 = nullptr);
     static void FillGridWithCarColours(MenuId id);
 
     static void HighlightOneItem(MenuId id, uint8 item, bool bought);

--- a/source/game_sa/Pad.h
+++ b/source/game_sa/Pad.h
@@ -241,6 +241,7 @@ public:
 
     [[nodiscard]] bool IsStandardKeyJustDown(uint8 key) const noexcept      { return NewKeyState.standardKeys[key] && OldKeyState.standardKeys[key]; }                       //
     [[nodiscard]] bool IsStandardKeyJustPressed(uint8 key) const noexcept   { return NewKeyState.standardKeys[key] && !OldKeyState.standardKeys[key]; }                      // 0x4D59B0
+    [[nodiscard]] bool IsStandardKeyUp(uint8 key) const noexcept            { return !NewKeyState.standardKeys[key] && !OldKeyState.standardKeys[key]; }                     //
     [[nodiscard]] bool IsLeftCtrlJustPressed() const noexcept               { return KEY_IS_PRESSED(lctrl); }                                                                //
     [[nodiscard]] bool IsRightCtrlJustPressed() const noexcept              { return KEY_IS_PRESSED(rctrl); }                                                                //
     [[nodiscard]] bool IsCtrlJustDown() const noexcept                      { return IsLeftCtrlJustPressed() || IsRightCtrlJustPressed(); }                                  //
@@ -251,6 +252,8 @@ public:
     [[nodiscard]] static bool IsLeftDown() noexcept                         { return KEY_IS_DOWN(left); }                                                                    //
     [[nodiscard]] static bool IsUpDown() noexcept                           { return KEY_IS_DOWN(up); }                                                                      //
     [[nodiscard]] static bool IsDownDown() noexcept                         { return KEY_IS_DOWN(down); }                                                                    //
+    [[nodiscard]] static bool IsPgUpDown() noexcept                         { return KEY_IS_DOWN(pgup); }                                                                    //
+    [[nodiscard]] static bool IsPgDnDown() noexcept                         { return KEY_IS_DOWN(pgdn); }                                                                    //
     [[nodiscard]] static bool IsUpPressed() noexcept                        { return KEY_IS_PRESSED(up); }                                                                   //
     [[nodiscard]] static bool IsDownPressed() noexcept                      { return KEY_IS_PRESSED(down); }                                                                 //
     [[nodiscard]] static bool IsLeftPressed() noexcept                      { return KEY_IS_PRESSED(left); }                                                                 //
@@ -309,12 +312,14 @@ public:
 
     [[nodiscard]] bool IsLeftShoulder2JustUp() const noexcept               { return BUTTON_JUST_UP(LeftShoulder2); }                                                        // 0x53EE00
     [[nodiscard]] bool IsLeftShoulder2Pressed() const noexcept              { return BUTTON_IS_PRESSED(LeftShoulder2); }                                                     // 0x53EDE0
+    [[nodiscard]] bool IsLeftShoulder2() const noexcept                     { return BUTTON_IS_DOWN(LeftShoulder2); }                                                        //
 
     [[nodiscard]] bool IsRightShoulder1Pressed() const noexcept             { return BUTTON_IS_PRESSED(RightShoulder1); }                                                    // 0x53EE20
     [[nodiscard]] bool IsRightShoulder1Up() const noexcept                  { return BUTTON_JUST_UP(RightShoulder1); }                                                       //
 
     [[nodiscard]] bool IsRightShoulder2Pressed() const noexcept             { return BUTTON_IS_PRESSED(RightShoulder2); }                                                    //
     [[nodiscard]] bool IsRightShoulder2JustUp() const noexcept              { return BUTTON_JUST_UP(RightShoulder2); }                                                       // 0x53EE40
+    [[nodiscard]] bool IsRightShoulder2() const noexcept                    { return BUTTON_IS_DOWN(RightShoulder2); }                                                       //
 
     [[nodiscard]] bool IsRadioTrackSkipJustUp() const noexcept              { return BUTTON_JUST_UP(m_bRadioTrackSkip); }                                                    //
     [[nodiscard]] bool IsRadioTrackSkipPressed() const noexcept             { return BUTTON_IS_PRESSED(m_bRadioTrackSkip); }                                                 // 0x4E7F20


### PR DESCRIPTION
Reversed `AdditionalOptionInput` function

Additional bugfixes:

1. `CMenuSystem::Menu::m_nSelectedRow` and `m_nAcceptedRow` were typed as **unsigned** `MenuId` (uint8), so the `MENU_UNDEFINED` (-99) sentinel became 157.
**Consequence**: in `AdditionalOptionInput`, `CheckForAccept` returned 157, so if (item >= 0) was always true, making the accept branch fire every frame — toggling `m_abPrefsMapBlips[157]` (out of bounds, real size 5) and advancing the highlighted row constantly = the rapid focus cycling.
**Fix**: changed those two Menu fields and the CheckForAccept/CheckForSelected return types to signed int8 (matching the original game layout) in MenuSystem.h and MenuSystem.cpp. This also fixed related broken logic in InputStandardMenu (>= 0, < 0, decrement).

2. In InputStandardMenu (MenuSystem.cpp:188), the "wrap to bottom when going up past the top" block kept decrementing `m_nSelectedRow` into negative territory (out-of-bounds index → crash).
**Fix**: set `m_nSelectedRow` = `m_nNumRows` then scan backward to the nearest valid row, mirroring the (working) down-wrap logic.

3. in the SDL input port (Pad_SDL.cpp), the main Return key -> ks.enter (`SDLK_RETURN`, line 99), while numpad Enter -> ks.extenter (`SDLK_KP_ENTER`, line 103). InputStandardMenu only checked `CPad::IsReturnJustPressed()` (= extenter, numpad only), so the main Enter key was never registered as accept - independent of the `AdditionalOptionInput` wiring.
**Fix**: changed `InputStandardMenu` and `InputGridMenu` (MenuSystem.cpp:150,217) to use `CPad::IsEnterJustPressed()` (catches both enter and extenter), matching how the main menu handles accept.

### Testing
Compiled and tested the map menu. All functionality works as expected.