### PR TITLE
fix(win32): Fix exception handling, write mini dump on crash

### DIFF
--- a/source/InjectHooksMain.cpp
+++ b/source/InjectHooksMain.cpp
@@ -1434,7 +1434,7 @@ void InjectHooksMain() {
         VideoPlayer::InjectHooks();
         Securom::InjectHooks();
         AppInjectHooks();
-        Win32InjectHooks();
+        notsa::Win32::InjectHooks();
         RsInjectHooks();
         VideoModeInjectHooks();
     };

--- a/source/app/app_debug.cpp
+++ b/source/app/app_debug.cpp
@@ -2,8 +2,6 @@
 
 #include "app_debug.h"
 #include <windows.h>
-#include <TlHelp32.h>
-#include <Psapi.h>
 #include <DbgHelp.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -59,143 +57,6 @@ void FlushObrsPrintfs() {
 #endif
 }
 
-// This probably should be in winps :D
-LONG WINAPI WindowsExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo) {
-    // If this function itself crashes it's invoked again
-    // So let's prevent the recusion with this simple hack
-    static bool s_HasHandled = false;
-    if (s_HasHandled) {
-        return EXCEPTION_CONTINUE_EXECUTION;
-    }
-    s_HasHandled = true;
-
-    spdlog::apply_all([](auto&& logger) {
-        logger->dump_backtrace();
-    });
-    
-    const auto Section = [](const char* name) {
-        SPDLOG_INFO("*********{}**********", name);
-    };
-
-    Section("UNHANDLED EXCEPTION");
-
-    SPDLOG_INFO("Exception Code: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionCode);
-    SPDLOG_INFO("Exception Flags: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionFlags);
-    SPDLOG_INFO("Exception Address: {:#010x}", (uintptr_t)pExceptionInfo->ExceptionRecord->ExceptionAddress);
-
-    // Dump exception parameters
-    Section("PARAMETERS");
-    {
-        SPDLOG_INFO("Parameters[{}]:", pExceptionInfo->ExceptionRecord->NumberParameters);
-        for (DWORD i = 0; i < pExceptionInfo->ExceptionRecord->NumberParameters; i++) {
-            SPDLOG_INFO("{:>8}: {:#010x}", i, pExceptionInfo->ExceptionRecord->ExceptionInformation[i]);
-        }
-    }
-
-    CONTEXT& context = *pExceptionInfo->ContextRecord;
-
-    Section("REGISTERS");
-    {
-        const auto DumpRegister = [](auto name, auto value) {
-            SPDLOG_INFO("\t{}: {:#010x}", name, value);
-        };
-        DumpRegister("EAX", context.Eax);
-        DumpRegister("EBX", context.Ebx);
-        DumpRegister("ECX", context.Ecx);
-        DumpRegister("EDX", context.Edx);
-        DumpRegister("ESI", context.Esi);
-        DumpRegister("EDI", context.Edi);
-        DumpRegister("EBP", context.Ebp);
-        DumpRegister("ESP", context.Esp);
-        DumpRegister("EIP", context.Eip);
-        DumpRegister("EFLAGS", context.EFlags);
-    }
-
-#if 0
-    Section("LOADED MODULES");
-    {
-        HANDLE hProcess = GetCurrentProcess();
-
-        HMODULE hModules[1024];
-        DWORD cbNeeded;
-
-        if (EnumProcessModules(hProcess, hModules, sizeof(hModules), &cbNeeded)) {
-            const DWORD numModules = cbNeeded / sizeof(HMODULE);
-            for (DWORD i = 0; i < numModules; i++) {
-                MODULEINFO moduleInfo;
-                if (GetModuleInformation(hProcess, hModules[i], &moduleInfo, sizeof(moduleInfo))) {
-                    char moduleName[MAX_PATH];
-                    GetModuleBaseName (hProcess, hModules[i], moduleName, sizeof(moduleName));
-
-                    SPDLOG_INFO("\t{:#010x}: {}", LOG_PTR(moduleInfo.lpBaseOfDll), moduleName);
-                }
-            }
-        }
-    }
-#endif
-
-    Section("CALL STACK");
-    {
-        HANDLE hProcess = GetCurrentProcess();
-        HANDLE hThread = GetCurrentThread();
-    
-        // Initialize symbol handler
-        SymInitialize(hProcess, NULL, TRUE);
-
-        STACKFRAME stackFrame = {};
-        stackFrame.AddrPC.Mode = AddrModeFlat;
-        stackFrame.AddrStack.Mode = AddrModeFlat;
-        stackFrame.AddrFrame.Mode = AddrModeFlat;
-        stackFrame.AddrPC.Offset = context.Eip;
-        stackFrame.AddrStack.Offset = context.Esp;
-        stackFrame.AddrFrame.Offset = context.Ebp;
-
-        DWORD prevFrameOffset = 0;
-        while (StackWalk(
-            IMAGE_FILE_MACHINE_I386, hProcess, hThread, &stackFrame, &context, NULL,
-            SymFunctionTableAccess, SymGetModuleBase, NULL))
-        {
-            DWORD pcOffset = stackFrame.AddrPC.Offset;
-            DWORD moduleBase = SymGetModuleBase(hProcess, pcOffset);
-            if (moduleBase == NULL) {
-                break;
-            }
-
-            DWORD displacement = 0;
-            IMAGEHLP_LINE lineInfo = { sizeof(IMAGEHLP_LINE) };
-            BOOL hasLineInfo = SymGetLineFromAddr(hProcess, pcOffset, &displacement, &lineInfo);
-
-            IMAGEHLP_MODULE moduleInfo{ sizeof(IMAGEHLP_MODULE) };
-            BOOL hasModuleInfo = SymGetModuleInfo(hProcess, moduleBase, &moduleInfo);
-        
-            char symbolBuffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = { 0 };
-            PSYMBOL_INFO sym = (PSYMBOL_INFO)symbolBuffer;
-            sym->SizeOfStruct = sizeof(SYMBOL_INFO);
-            sym->MaxNameLen = MAX_SYM_NAME;
-            BOOL hasSym = SymFromAddr(hProcess, pcOffset, NULL, sym);
-
-            SPDLOG_INFO(
-                "\t{:#010x}: {}!{}:{}",
-                pcOffset,
-                hasModuleInfo ? moduleInfo.ModuleName : "<unknown>",
-                hasSym ? sym->Name : "<unknown>",
-                hasLineInfo ? lineInfo.LineNumber : 0
-            );
-        }
-
-        // Cleanup symbol handler
-        SymCleanup(hProcess);
-    }
-
-    Section("END OF UNHANDLED EXCEPTION");
-
-    spdlog::apply_all([](auto&& logger) {
-        logger->flush();
-    });
-
-    return EXCEPTION_EXECUTE_HANDLER;
-}
-
 notsa::Logging::Logging() {
     using namespace std::chrono_literals;
 #if 0
@@ -215,8 +76,6 @@ notsa::Logging::Logging() {
 
     spdlog::set_default_logger(Create("default"));
     spdlog::flush_every(100ms);
-    
-    AddVectoredExceptionHandler(1, WindowsExceptionHandler);
 }
 
 notsa::Logging::~Logging() {

--- a/source/app/platform/win/WinMain.cpp
+++ b/source/app/platform/win/WinMain.cpp
@@ -368,18 +368,18 @@ void MainLoopWithSEH(INT nCmdShow) {
     }
 }
 
-auto SEHWrapper(std::invocable auto&& fn, const char* where) {
+INT WinMainSEHWrapper(std::invocable auto&& fn, const char* where) {
     __try {
         return std::invoke(fn);
     } __except (notsa::Win32::ExceptionHandler(GetExceptionInformation())) {
         NOTSA_LOG_CRIT("Exception in `{}`, exiting...", where);
+        exit(1);
     }
-    return 1;
 }
 
 // 0x748710
 INT WINAPI NOTSA_WinMain(HINSTANCE instance, HINSTANCE hPrevInstance, LPSTR cmdLine, INT nCmdShow) {
-    return SEHWrapper([&]() -> INT {
+    return WinMainSEHWrapper([&]() -> INT {
         SystemParametersInfo(SPI_SETFOREGROUNDLOCKTIMEOUT, 0u, nullptr, 2);
         if (IsAlreadyRunning()) {
             return false;
@@ -517,7 +517,7 @@ INT WINAPI NOTSA_WinMain(HINSTANCE instance, HINSTANCE hPrevInstance, LPSTR cmdL
 
 #ifdef NOTSA_STANDALONE
 INT WINAPI WinMain(HINSTANCE instance, HINSTANCE hPrevInstance, LPSTR cmdLine, INT nCmdShow) {
-    return SEHWrapper([&] () -> INT {
+    return WinMainSEHWrapper([&] () -> INT {
         notsa::debug::DisplayConsole();
         CommandLine::Load(__argc, __argv);
         if (CommandLine::s_WaitForDebugger) {

--- a/source/app/platform/win/WinMain.cpp
+++ b/source/app/platform/win/WinMain.cpp
@@ -360,161 +360,182 @@ void MainLoop(INT nCmdShow) {
 
 }
 
+void MainLoopWithSEH(INT nCmdShow) {
+    __try {
+        MainLoop(nCmdShow);
+    } __except (notsa::Win32::ExceptionHandler(GetExceptionInformation())) {
+        NOTSA_LOG_CRIT("Exception in `MainLoop`, exiting...");
+    }
+}
+
+auto SEHWrapper(std::invocable auto&& fn, const char* where) {
+    __try {
+        return std::invoke(fn);
+    } __except (notsa::Win32::ExceptionHandler(GetExceptionInformation())) {
+        NOTSA_LOG_CRIT("Exception in `{}`, exiting...", where);
+    }
+    return 1;
+}
+
 // 0x748710
 INT WINAPI NOTSA_WinMain(HINSTANCE instance, HINSTANCE hPrevInstance, LPSTR cmdLine, INT nCmdShow) {
-    SystemParametersInfo(SPI_SETFOREGROUNDLOCKTIMEOUT, 0u, nullptr, 2);
-    if (IsAlreadyRunning()) {
-        return false;
-    }
+    return SEHWrapper([&]() -> INT {
+        SystemParametersInfo(SPI_SETFOREGROUNDLOCKTIMEOUT, 0u, nullptr, 2);
+        if (IsAlreadyRunning()) {
+            return false;
+        }
 
-    if (rsEVENTERROR == RsEventHandler(rsINITIALIZE, nullptr)) {
-        return false;
-    }
+        if (rsEVENTERROR == RsEventHandler(rsINITIALIZE, nullptr)) {
+            return false;
+        }
 
-#ifdef NOTSA_USE_SDL3
-    if (!SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC)) {
-        NOTSA_UNREACHABLE("Failed to initialize SDL: {}", SDL_GetError());
-        return -1;
-    }
-#else
-    if (!Win32_InitApplication(instance)) {
-        return false;
-    }
-#endif
+    #ifdef NOTSA_USE_SDL3
+        if (!SDL_Init(SDL_INIT_GAMEPAD | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC)) {
+            NOTSA_UNREACHABLE("Failed to initialize SDL: {}", SDL_GetError());
+            return -1;
+        }
+    #else
+        if (!Win32_InitApplication(instance)) {
+            return false;
+        }
+    #endif
 
-    char** argv = __argv;
-    int    argc = __argc;
-    for (int i = 0; i < argc; i++) {
-        RsEventHandler(rsPREINITCOMMANDLINE, argv[i]);
-    }
+        char** argv = __argv;
+        int    argc = __argc;
+        for (int i = 0; i < argc; i++) {
+            RsEventHandler(rsPREINITCOMMANDLINE, argv[i]);
+        }
 
-    // Dirty fix for crash in crt when trying to free cmd line args
-    // Yeah we leak memory, but who cares
-    // Crash was in `uninitialize_allocated_io_buffers` (`C:\Program Files (x86)\Windows Kits\10\Source\<Win 10 SDK Version>\ucrt\internal\initialization.cpp`)
-    __argc  = 0;
-    __argv  = nullptr;
-    __wargv = nullptr;
+        // Dirty fix for crash in crt when trying to free cmd line args
+        // Yeah we leak memory, but who cares
+        // Crash was in `uninitialize_allocated_io_buffers` (`C:\Program Files (x86)\Windows Kits\10\Source\<Win 10 SDK Version>\ucrt\internal\initialization.cpp`)
+        __argc  = 0;
+        __argv  = nullptr;
+        __wargv = nullptr;
 
-#ifdef NOTSA_USE_SDL3
-    SDL_Window* sdlWnd = SDL_CreateWindow(
-        APP_CLASS,
-        APP_DEFAULT_WIDTH, APP_DEFAULT_HEIGHT,
-        SDL_WINDOW_RESIZABLE  //| SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS// | SDL_WINDOW_MOUSE_GRABBED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS
-    );
-    PSGLOBAL(sdlWindow) = sdlWnd;
-    PSGLOBAL(window) = (HWND)(SDL_GetPointerProperty(SDL_GetWindowProperties(sdlWnd), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL)); // NOTE/TODO: Hacky, but required due to RW
-#else
-    PSGLOBAL(window) = Win32_InitInstance(instance);
-#endif
+    #ifdef NOTSA_USE_SDL3
+        SDL_Window* sdlWnd = SDL_CreateWindow(
+            APP_CLASS,
+            APP_DEFAULT_WIDTH, APP_DEFAULT_HEIGHT,
+            SDL_WINDOW_RESIZABLE  //| SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS// | SDL_WINDOW_MOUSE_GRABBED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS
+        );
+        PSGLOBAL(sdlWindow) = sdlWnd;
+        PSGLOBAL(window) = (HWND)(SDL_GetPointerProperty(SDL_GetWindowProperties(sdlWnd), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL)); // NOTE/TODO: Hacky, but required due to RW
+    #else
+        PSGLOBAL(window) = Win32_InitInstance(instance);
+    #endif
 
-    if (!PSGLOBAL(window)) {
-        return false;
-    }
-    PSGLOBAL(instance) = instance; // Not used anywhere, just set here
+        if (!PSGLOBAL(window)) {
+            return false;
+        }
+        PSGLOBAL(instance) = instance; // Not used anywhere, just set here
 
-    // 0x7487CF
-#ifndef NOTSA_USE_SDL3
-    VERIFY(WinInput::Initialise());
-#endif
-    ControlsManager.ReinitControls();
+        // 0x7487CF
+    #ifndef NOTSA_USE_SDL3
+        VERIFY(WinInput::Initialise());
+    #endif
+        ControlsManager.ReinitControls();
 
-    // 0x748847
-    if (RsEventHandler(rsRWINITIALIZE, PSGLOBAL(window)) == rsEVENTERROR) {
+        // 0x748847
+        if (RsEventHandler(rsRWINITIALIZE, PSGLOBAL(window)) == rsEVENTERROR) {
+            DestroyWindow(PSGLOBAL(window));
+            RsEventHandler(rsTERMINATE, nullptr);
+            return false;
+        }
+
+        // 0x7488EE
+        for (auto i = 0; i < argc; i++) {
+            RsEventHandler(rsCOMMANDLINE, argv[i]);
+        }
+
+    #ifndef NOTSA_USE_SDL3
+        if (MultipleSubSystems || PSGLOBAL(fullScreen)) {
+            SetWindowLongPtr(PSGLOBAL(window), GWL_STYLE, (LONG_PTR)WS_POPUP);
+            SetWindowPos(PSGLOBAL(window), nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+        }
+    #endif
+
+        RwRect rect{ 0, 0, RsGlobal.maximumWidth, RsGlobal.maximumHeight };
+        RsEventHandler(rsCAMERASIZE, &rect);
+
+        SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, 0u, nullptr, 2u);
+        SystemParametersInfo(SPI_SETPOWEROFFACTIVE, 0u, nullptr, 2u);
+        SystemParametersInfo(SPI_SETLOWPOWERACTIVE, 0u, nullptr, 2u);
+        STICKYKEYS pvParam { .cbSize = sizeof(STICKYKEYS) };
+        SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam, 2u);
+        STICKYKEYS pvParam1 = { .cbSize = sizeof(STICKYKEYS), .dwFlags = SKF_TWOKEYSOFF };
+        SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam1, 2u);
+
+        UpdateWindow(PSGLOBAL(window));
+    #ifdef NOTSA_USE_SDL3
+        SDL_SetWindowFocusable(sdlWnd, true);
+        SDL_SetWindowPosition(sdlWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+        SDL_RaiseWindow(sdlWnd);
+    #else
+        ShowWindow(PSGLOBAL(window), nCmdShow);
+    #endif
+
+        // 0x748995
+        CFileMgr::SetDirMyDocuments();
+        if (auto* file = CFileMgr::OpenFile("gta_sa.set", "rb")) {
+            if (!ControlsManager.LoadSettings(file)) {
+                ControlsManager.ReinitControls();
+            }
+            CFileMgr::CloseFile(file);
+        }
+        CFileMgr::SetDir("");
+
+        SetErrorMode(SEM_FAILCRITICALERRORS);
+
+        // 0x7489FB
+        MainLoopWithSEH(nCmdShow);
+
+        // if game is loaded, shut it down
+        if (gGameState == GAME_STATE_IDLE) {
+            CGame::Shutdown();
+        }
+
+        // now quit 0x748E75
+        AudioEngine.Shutdown();
+        FreeVideoModeList();
+        RsEventHandler(rsRWTERMINATE, nullptr);
         DestroyWindow(PSGLOBAL(window));
         RsEventHandler(rsTERMINATE, nullptr);
-        return false;
-    }
+        free(argv);
+        ShowCursor(true);
 
-    // 0x7488EE
-    for (auto i = 0; i < argc; i++) {
-        RsEventHandler(rsCOMMANDLINE, argv[i]);
-    }
+        SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam, 2u);
+        SystemParametersInfo(SPI_SETPOWEROFFACTIVE, 1u, nullptr, 2u); // TODO: GUID_VIDEO_POWERDOWN_TIMEOUT
+        SystemParametersInfo(SPI_SETLOWPOWERACTIVE, 1u, nullptr, 2u);
+        SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, 1u, nullptr, 2u);
+        // nullsub_0x72F3C0()
+        SetErrorMode(0);
 
-#ifndef NOTSA_USE_SDL3
-    if (MultipleSubSystems || PSGLOBAL(fullScreen)) {
-        SetWindowLongPtr(PSGLOBAL(window), GWL_STYLE, (LONG_PTR)WS_POPUP);
-        SetWindowPos(PSGLOBAL(window), nullptr, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
-    }
-#endif
-
-    RwRect rect{ 0, 0, RsGlobal.maximumWidth, RsGlobal.maximumHeight };
-    RsEventHandler(rsCAMERASIZE, &rect);
-
-    SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, 0u, nullptr, 2u);
-    SystemParametersInfo(SPI_SETPOWEROFFACTIVE, 0u, nullptr, 2u);
-    SystemParametersInfo(SPI_SETLOWPOWERACTIVE, 0u, nullptr, 2u);
-    STICKYKEYS pvParam { .cbSize = sizeof(STICKYKEYS) };
-    SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam, 2u);
-    STICKYKEYS pvParam1 = { .cbSize = sizeof(STICKYKEYS), .dwFlags = SKF_TWOKEYSOFF };
-    SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam1, 2u);
-
-    UpdateWindow(PSGLOBAL(window));
-#ifdef NOTSA_USE_SDL3
-    SDL_SetWindowFocusable(sdlWnd, true);
-    SDL_SetWindowPosition(sdlWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-    SDL_RaiseWindow(sdlWnd);
-#else
-    ShowWindow(PSGLOBAL(window), nCmdShow);
-#endif
-
-    // 0x748995
-    CFileMgr::SetDirMyDocuments();
-    if (auto* file = CFileMgr::OpenFile("gta_sa.set", "rb")) {
-        if (!ControlsManager.LoadSettings(file)) {
-            ControlsManager.ReinitControls();
-        }
-        CFileMgr::CloseFile(file);
-    }
-    CFileMgr::SetDir("");
-
-    SetErrorMode(SEM_FAILCRITICALERRORS);
-
-    // 0x7489FB
-    MainLoop(nCmdShow);
-
-    // if game is loaded, shut it down
-    if (gGameState == GAME_STATE_IDLE) {
-        CGame::Shutdown();
-    }
-
-    // now quit 0x748E75
-    AudioEngine.Shutdown();
-    FreeVideoModeList();
-    RsEventHandler(rsRWTERMINATE, nullptr);
-    DestroyWindow(PSGLOBAL(window));
-    RsEventHandler(rsTERMINATE, nullptr);
-    free(argv);
-    ShowCursor(true);
-
-    SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &pvParam, 2u);
-    SystemParametersInfo(SPI_SETPOWEROFFACTIVE, 1u, nullptr, 2u); // TODO: GUID_VIDEO_POWERDOWN_TIMEOUT
-    SystemParametersInfo(SPI_SETLOWPOWERACTIVE, 1u, nullptr, 2u);
-    SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, 1u, nullptr, 2u);
-    // nullsub_0x72F3C0()
-    SetErrorMode(0);
-
-    return 0; // Msg.wParam
+        return 0; // Msg.wParam
+    }, "WinMain");
 }
 
 #ifdef NOTSA_STANDALONE
 INT WINAPI WinMain(HINSTANCE instance, HINSTANCE hPrevInstance, LPSTR cmdLine, INT nCmdShow) {
-    notsa::debug::DisplayConsole();
-    CommandLine::Load(__argc, __argv);
-    if (CommandLine::s_WaitForDebugger) {
-        notsa::debug::WaitForDebugger();
-    }
+    return SEHWrapper([&] () -> INT {
+        notsa::debug::DisplayConsole();
+        CommandLine::Load(__argc, __argv);
+        if (CommandLine::s_WaitForDebugger) {
+            notsa::debug::WaitForDebugger();
+        }
 #ifdef NOTSA_DUMP_HOOKS_ONLY
-    NOTSA_LOG_INFO("Dumping hooks only, no memory writing will be performed");
-    if (CommandLine::s_DumpHooksPath.empty()) {
-        NOTSA_LOG_ERR("No path provided for dumping hooks, use `--dump-hooks-to` CLI argument");
-        return 1;
-    }
-    InjectHooksMain(GetModuleHandle(nullptr)); // this will call injecthooks which then ends up dumping the data
-    return 0;
+        NOTSA_LOG_INFO("Dumping hooks only, no memory writing will be performed");
+        if (CommandLine::s_DumpHooksPath.empty()) {
+            NOTSA_LOG_ERR("No path provided for dumping hooks, use `--dump-hooks-to` CLI argument");
+            return 1;
+        }
+        InjectHooksMain(GetModuleHandle(nullptr)); // this will call injecthooks which then ends up dumping the data
+        return 0;
 #else
-    NOTSA_LOG_ERROR("This executable is meant to be used for dumping hooks only, see `NOTSA_DUMP_HOOKS_ONLY` option");
-    return 1;
+        NOTSA_LOG_ERROR("This executable is meant to be used for dumping hooks only, see `NOTSA_DUMP_HOOKS_ONLY` option");
+        return 1;
 #endif
+    }, "WinMain");
 }
 #endif
 

--- a/source/app/platform/win/WinPlatform.cpp
+++ b/source/app/platform/win/WinPlatform.cpp
@@ -151,9 +151,41 @@ DWORD ExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo) {
 
     Section("UNHANDLED EXCEPTION");
 
-    SPDLOG_INFO("Exception Code: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionCode);
-    SPDLOG_INFO("Exception Flags: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionFlags);
-    SPDLOG_INFO("Exception Address: {:#010x}", (uintptr_t)pExceptionInfo->ExceptionRecord->ExceptionAddress);
+    // Write minidump
+    SPDLOG_INFO("Writing minidump...");
+    {
+        std::error_code ec{};
+        fs::create_directory("dumps", ec);
+        if (ec && ec.value() != ERROR_ALREADY_EXISTS) {
+            NOTSA_LOG_WARN("Failed to create dumps directory: {}", ec.message());
+        }
+        HANDLE hFile = CreateFileA(
+            std::format("dumps/dump_{:%Y_%m_%d_%H_%M_%S}.dmp", std::chrono::utc_clock::now()).c_str(),
+            GENERIC_WRITE,
+            0,
+            NULL,
+            CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL
+        );
+        if (hFile != INVALID_HANDLE_VALUE) {
+            MINIDUMP_EXCEPTION_INFORMATION dumpInfo;
+            dumpInfo.ThreadId          = GetCurrentThreadId();
+            dumpInfo.ExceptionPointers = pExceptionInfo;
+            dumpInfo.ClientPointers    = FALSE;
+            MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpWithThreadInfo, &dumpInfo, NULL, NULL);
+            CloseHandle(hFile);
+        } else {
+            NOTSA_LOG_WARN("Failed to create minidump file: {}", GetLastError());
+        }
+    }
+    SPDLOG_INFO("Writing minidump done");
+
+    Section("DETAILS");
+
+    SPDLOG_INFO("Code: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionCode);
+    SPDLOG_INFO("Flags: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionFlags);
+    SPDLOG_INFO("Address: {:#010x}", (uintptr_t)pExceptionInfo->ExceptionRecord->ExceptionAddress);
 
     Section("PARAMETERS");
     {
@@ -263,30 +295,6 @@ DWORD ExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo) {
     spdlog::apply_all([](auto&& logger) {
         logger->flush();
     });
-
-    // Write minidump
-    {
-        fs::create_directory("/dumps/");
-        HANDLE hFile = CreateFileA(
-            std::format("dumps/dump_{:%Y_%m_%d_%H_%M_%S}.dmp", std::chrono::utc_clock::now()).c_str(),
-            GENERIC_WRITE,
-            0,
-            NULL,
-            CREATE_ALWAYS,
-            FILE_ATTRIBUTE_NORMAL,
-            NULL
-        );
-        if (hFile != INVALID_HANDLE_VALUE) {
-            MINIDUMP_EXCEPTION_INFORMATION dumpInfo;
-            dumpInfo.ThreadId          = GetCurrentThreadId();
-            dumpInfo.ExceptionPointers = pExceptionInfo;
-            dumpInfo.ClientPointers    = FALSE;
-            MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpWithThreadInfo, &dumpInfo, NULL, NULL);
-            CloseHandle(hFile);
-        } else {
-            NOTSA_LOG_WARN("Failed to create minidump file: {}", GetLastError());
-        }
-    }
 
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/source/app/platform/win/WinPlatform.cpp
+++ b/source/app/platform/win/WinPlatform.cpp
@@ -3,12 +3,15 @@
 */
 
 #include "StdInc.h"
-
+#include <chrono>
 #include "WinPlatform.h"
 #include "WndProc.h"
 #include "WinMain.h"
 #include "WinInput.h"
 #include "Gamma.h"
+#include <TlHelp32.h>
+#include <Psapi.h>
+#include <DbgHelp.h>
 
 #define SHIFTED 0x8000
 #define KEY_DOWN(keystate) ((keystate & SHIFTED) != 0)
@@ -134,7 +137,161 @@ BOOL GTATranslateKey(RsKeyCodes* ck, LPARAM lParam, UINT vk) {
 }
 
 void WinPsInjectHooks();
-void Win32InjectHooks() {
+
+namespace notsa {
+namespace Win32 {
+DWORD ExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo) {
+    spdlog::apply_all([](auto&& logger) {
+        logger->dump_backtrace();
+    });
+    
+    const auto Section = [](const char* name) {
+        SPDLOG_INFO("*********{}**********", name);
+    };
+
+    Section("UNHANDLED EXCEPTION");
+
+    SPDLOG_INFO("Exception Code: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionCode);
+    SPDLOG_INFO("Exception Flags: {:#010x}", pExceptionInfo->ExceptionRecord->ExceptionFlags);
+    SPDLOG_INFO("Exception Address: {:#010x}", (uintptr_t)pExceptionInfo->ExceptionRecord->ExceptionAddress);
+
+    Section("PARAMETERS");
+    {
+        SPDLOG_INFO("Parameters[{}]:", pExceptionInfo->ExceptionRecord->NumberParameters);
+        for (DWORD i = 0; i < pExceptionInfo->ExceptionRecord->NumberParameters; i++) {
+            SPDLOG_INFO("{:>8}: {:#010x}", i, pExceptionInfo->ExceptionRecord->ExceptionInformation[i]);
+        }
+    }
+
+    CONTEXT& context = *pExceptionInfo->ContextRecord;
+
+    Section("REGISTERS");
+    {
+        const auto DumpRegister = [](auto name, auto value) {
+            SPDLOG_INFO("\t{}: {:#010x}", name, value);
+        };
+        DumpRegister("EAX", context.Eax);
+        DumpRegister("EBX", context.Ebx);
+        DumpRegister("ECX", context.Ecx);
+        DumpRegister("EDX", context.Edx);
+        DumpRegister("ESI", context.Esi);
+        DumpRegister("EDI", context.Edi);
+        DumpRegister("EBP", context.Ebp);
+        DumpRegister("ESP", context.Esp);
+        DumpRegister("EIP", context.Eip);
+        DumpRegister("EFLAGS", context.EFlags);
+    }
+
+#if 0
+    Section("LOADED MODULES");
+    {
+        HANDLE hProcess = GetCurrentProcess();
+
+        HMODULE hModules[1024];
+        DWORD cbNeeded;
+
+        if (EnumProcessModules(hProcess, hModules, sizeof(hModules), &cbNeeded)) {
+            const DWORD numModules = cbNeeded / sizeof(HMODULE);
+            for (DWORD i = 0; i < numModules; i++) {
+                MODULEINFO moduleInfo;
+                if (GetModuleInformation(hProcess, hModules[i], &moduleInfo, sizeof(moduleInfo))) {
+                    char moduleName[MAX_PATH];
+                    GetModuleBaseName (hProcess, hModules[i], moduleName, sizeof(moduleName));
+
+                    SPDLOG_INFO("\t{:#010x}: {}", LOG_PTR(moduleInfo.lpBaseOfDll), moduleName);
+                }
+            }
+        }
+    }
+#endif
+
+    Section("CALL STACK");
+    {
+        HANDLE hProcess = GetCurrentProcess();
+        HANDLE hThread = GetCurrentThread();
+    
+        // Initialize symbol handler
+        SymInitialize(hProcess, NULL, TRUE);
+
+        STACKFRAME stackFrame = {};
+        stackFrame.AddrPC.Mode = AddrModeFlat;
+        stackFrame.AddrStack.Mode = AddrModeFlat;
+        stackFrame.AddrFrame.Mode = AddrModeFlat;
+        stackFrame.AddrPC.Offset = context.Eip;
+        stackFrame.AddrStack.Offset = context.Esp;
+        stackFrame.AddrFrame.Offset = context.Ebp;
+
+        DWORD prevFrameOffset = 0;
+        while (StackWalk(
+            IMAGE_FILE_MACHINE_I386, hProcess, hThread, &stackFrame, &context, NULL,
+            SymFunctionTableAccess, SymGetModuleBase, NULL))
+        {
+            DWORD pcOffset = stackFrame.AddrPC.Offset;
+            DWORD moduleBase = SymGetModuleBase(hProcess, pcOffset);
+            if (moduleBase == NULL) {
+                break;
+            }
+
+            DWORD displacement = 0;
+            IMAGEHLP_LINE lineInfo = { sizeof(IMAGEHLP_LINE) };
+            BOOL hasLineInfo = SymGetLineFromAddr(hProcess, pcOffset, &displacement, &lineInfo);
+
+            IMAGEHLP_MODULE moduleInfo{ sizeof(IMAGEHLP_MODULE) };
+            BOOL hasModuleInfo = SymGetModuleInfo(hProcess, moduleBase, &moduleInfo);
+        
+            char symbolBuffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME] = { 0 };
+            PSYMBOL_INFO sym = (PSYMBOL_INFO)symbolBuffer;
+            sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+            sym->MaxNameLen = MAX_SYM_NAME;
+            BOOL hasSym = SymFromAddr(hProcess, pcOffset, NULL, sym);
+
+            SPDLOG_INFO(
+                "\t{:#010x}: {}!{}:{}",
+                pcOffset,
+                hasModuleInfo ? moduleInfo.ModuleName : "<unknown>",
+                hasSym ? sym->Name : "<unknown>",
+                hasLineInfo ? lineInfo.LineNumber : 0
+            );
+        }
+
+        // Cleanup symbol handler
+        SymCleanup(hProcess);
+    }
+
+    Section("END OF UNHANDLED EXCEPTION");
+
+    spdlog::apply_all([](auto&& logger) {
+        logger->flush();
+    });
+
+    // Write minidump
+    {
+        fs::create_directory("/dumps/");
+        HANDLE hFile = CreateFileA(
+            std::format("dumps/dump_{:%Y_%m_%d_%H_%M_%S}.dmp", std::chrono::utc_clock::now()).c_str(),
+            GENERIC_WRITE,
+            0,
+            NULL,
+            CREATE_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL
+        );
+        if (hFile != INVALID_HANDLE_VALUE) {
+            MINIDUMP_EXCEPTION_INFORMATION dumpInfo;
+            dumpInfo.ThreadId          = GetCurrentThreadId();
+            dumpInfo.ExceptionPointers = pExceptionInfo;
+            dumpInfo.ClientPointers    = FALSE;
+            MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpWithThreadInfo, &dumpInfo, NULL, NULL);
+            CloseHandle(hFile);
+        } else {
+            NOTSA_LOG_WARN("Failed to create minidump file: {}", GetLastError());
+        }
+    }
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+void InjectHooks() {
     RH_ScopedCategory("Win");
     RH_ScopedNamespaceName("Win");
 
@@ -148,3 +305,5 @@ void Win32InjectHooks() {
     InjectWinMainStuff();
     WinPsInjectHooks();
 }
+}; // namespace Win32
+}; // namespace notsa

--- a/source/app/platform/win/WinPlatform.h
+++ b/source/app/platform/win/WinPlatform.h
@@ -43,9 +43,15 @@ inline auto& anisotropySupportedByGFX = StaticRef<bool>(0xC87FFC);
 inline auto& isForeground = StaticRef<bool>(0xC920EC);
 inline auto& Windowed = StaticRef<bool>(0xC920CC);
 
-void Win32InjectHooks();
 
 BOOL GTATranslateShiftKey(RsKeyCodes*);
 BOOL GTATranslateKey(RsKeyCodes* ck, LPARAM lParam, UINT vk);
+
+namespace notsa {
+namespace Win32 {
+void InjectHooks();
+DWORD ExceptionHandler(PEXCEPTION_POINTERS pExceptionPointers);
+};
+};
 
 #define IDI_MAIN_ICON                   1042


### PR DESCRIPTION
Previously even exceptions that were handled in a `try`/`catch` were logged.
Turns out the `CShadowCamera` issue we "were having" was actually just d3d9 throwing an exception that it handled internally...
So that's fixed now as well.
Minidumps are written to `/dumps/`.