### PR TITLE
fix(TaskComplexWalkAlongsidePed): Fetch targetPedWalkAnim from m_TargetPed clump 

### DIFF
--- a/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
+++ b/source/game_sa/Tasks/TaskTypes/TaskComplexWalkAlongsidePed.cpp
@@ -100,7 +100,7 @@ CTask* CTaskComplexWalkAlongsidePed::ControlSubTask(CPed* ped) {
     const auto pedPos       = ped->GetPosition();
 
     const auto pedWalkAnim       = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
-    const auto targetPedWalkAnim = RpAnimBlendClumpGetAssociation(ped->GetRpClump(), ANIM_ID_WALK);
+    const auto targetPedWalkAnim = RpAnimBlendClumpGetAssociation(m_TargetPed->GetRpClump(), ANIM_ID_WALK);
 
     const auto isTargetMoving = notsa::contains({PEDMOVE_WALK, PEDMOVE_RUN, PEDMOVE_SPRINT}, m_TargetPed->GetIntelligence()->GetMoveStateFromGoToTask());
 


### PR DESCRIPTION
In "CTaskComplexWalkAlongsidePed::ControlSubTask", "targetPedWalkAnim" was mistakenly fetched from "ped->GetRpClump()" instead of "m_TargetPed->GetRpClump()".

At `0x6851B3`, the first call to `RpAnimBlendClumpGetAssociation` takes `ped->GetRpClump()` (`edi + 0x18`).
At `0x6851B8`, the second call loads `m_TargetPed` from `this + 0x0C` and passes its clump (`+0x18`) to `RpAnimBlendClumpGetAssociation`.

Line 103 was most likely a copy-paste error from line 102.

Fixes #1388 