### PR TITLE
fix(AEMP3TrackLoader): Fix data truncation and corruption from text-mode file reading

### DIFF
--- a/source/game_sa/Audio/Loaders/AEMP3TrackLoader.cpp
+++ b/source/game_sa/Audio/Loaders/AEMP3TrackLoader.cpp
@@ -61,7 +61,7 @@ bool CAEMP3TrackLoader::Initialise() {
 // 0x4E0970
 bool CAEMP3TrackLoader::LoadStreamPackTable(void) {
     // NOTSA: Originally Win32 file API was used.
-    auto* fp = fopen("AUDIO\\CONFIG\\STRMPAKS.DAT", "r");
+    auto* fp = fopen("AUDIO\\CONFIG\\STRMPAKS.DAT", "rb");
     if (!fp) {
         // Win32 API creates a file if it doesn't exists, and reads 0 bytes.
         fp = fopen("AUDIO\\CONFIG\\STRMPAKS.DAT", "w");
@@ -92,7 +92,7 @@ bool CAEMP3TrackLoader::LoadStreamPackTable(void) {
 // 0x4E09F0
 bool CAEMP3TrackLoader::LoadTrackLookupTable(void) {
     // NOTSA: Originally Win32 file API was used.
-    auto* fp = fopen("AUDIO\\CONFIG\\TRAKLKUP.DAT", "r");
+    auto* fp = fopen("AUDIO\\CONFIG\\TRAKLKUP.DAT", "rb");
     if (!fp) {
         // Win32 API creates a file if it doesn't exists, and reads 0 bytes.
         fp = fopen("AUDIO\\CONFIG\\TRAKLKUP.DAT", "w");


### PR DESCRIPTION
STRMPAKS.DAT and TRAKLKUP.DAT are binary files. If you try to read them as text you get several issues in-game. One way to reproduce it is going inside the Old Reece barbershop and you will notice that police radio is playing inside it because of corruption. 