### PR TITLE
fix(CWeather): StreamAfterRainTimer type from bool to int32

### DIFF
--- a/source/game_sa/Weather.cpp
+++ b/source/game_sa/Weather.cpp
@@ -55,7 +55,7 @@ void CWeather::Init() {
     InTunnelness = 0.0f;
     LightningStartX = 0;
     LightningStartY = 0;
-    StreamAfterRainTimer = false;
+    StreamAfterRainTimer = 0;
 }
 
 // 0x72A9A0

--- a/source/game_sa/Weather.h
+++ b/source/game_sa/Weather.h
@@ -59,7 +59,7 @@ public:
     static inline auto& NewWeatherType = StaticRef<eWeatherType>(0xC8131C);
     static inline auto& OldWeatherType = StaticRef<eWeatherType>(0xC81320);
     static inline auto& m_WeatherAudioEntity = StaticRef<CAEWeatherAudioEntity>(0xC81360);
-    static inline auto& StreamAfterRainTimer = StaticRef<bool>(0x8D5EAC);
+    static inline auto& StreamAfterRainTimer = StaticRef<int32>(0x8D5EAC);
 
     // in entity.cpp:
 


### PR DESCRIPTION
StreamAfterRainTimer is not a bool. Weather.h:64 declares
StaticRef<bool>(0x8D5EAC). The binary writes a full dword there in Init
(mov [0x8D5EAC], eax, 0x72A4CF), performs a dec on it in AddRain, and
reloads it with 0x320 = 800. The bytes in the image are 20 03 00 00.
It is a 32-bit counter