### PR TITLE
re(CAERadioTrackManager): Reverse the track pickers and QueueUpTracksForStation

### DIFF
--- a/source/game_sa/Audio/Config/RadioStreamsPC.h
+++ b/source/game_sa/Audio/Config/RadioStreamsPC.h
@@ -5,6 +5,9 @@
 
 #define NOTRACK 1922
 
+//! Number of story DJ banters per station in `gRadioDJBanterMission`
+constexpr auto NUM_MISSION_DJ_BANTERS = 22;
+
 int32 gRadioNumMusicTracksPerStation[] = {
    2,  // Emergency
    12, // Playback FM
@@ -394,7 +397,8 @@ int32 gnRadioStationRestrictedAdverts[][23] = {
    },
 };
 
-int32 gRadioDJBanterBC[][2] = {
+// 0x8C8BF0 - played once when a story banter is pending
+int32 gRadioDJBanterPending[][2] = {
    { // Emergency
        NOTRACK, NOTRACK,
    },
@@ -433,7 +437,8 @@ int32 gRadioDJBanterBC[][2] = {
    },
 };
 
-int32 gRadioDJBanterTN[][2] = {
+// 0x8C8E30 - 22:00..02:00
+int32 gRadioDJBanterNight[][2] = {
    { // Emergency
        39,      59,
    },
@@ -472,7 +477,8 @@ int32 gRadioDJBanterTN[][2] = {
    },
 };
 
-int32 gRadioDJBanterGN[][2] = {
+// 0x8C8CB0 - fallback, used when no other list yields a line
+int32 gRadioDJBanterGeneric[][2] = {
    { // Emergency
        0,      38,
    },
@@ -510,3 +516,298 @@ int32 gRadioDJBanterGN[][2] = {
        NOTRACK, NOTRACK,
    },
 };
+
+// 0x8C8C50 - story banter, indexed by `m_nSpecialDJBanterIndex`
+int32 gRadioDJBanterSpecial[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       186,     187,
+   },
+   { // K Rose
+       316,     317,
+   },
+   { // K-DST
+       471,     472,
+   },
+   { // Bounce FM
+       768,     769,
+   },
+   { // SF-UR
+       947,     948,
+   },
+   { // Radio Los Santos
+       1062,    1063,
+   },
+   { // Radio X
+       1214,    1215,
+   },
+   { // CSR 103.9
+       1361,    1362,
+   },
+   { // K-Jah West
+       1491,    1492,
+   },
+   { // Master Sounds 98.3
+       1652,    1653,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8D70 - 18:00..20:00
+int32 gRadioDJBanterEvening[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       206,     207,
+   },
+   { // K Rose
+       NOTRACK, NOTRACK,
+   },
+   { // K-DST
+       488,     489,
+   },
+   { // Bounce FM
+       805,     806,
+   },
+   { // SF-UR
+       972,     974,
+   },
+   { // Radio Los Santos
+       1086,    1087,
+   },
+   { // Radio X
+       1235,    1236,
+   },
+   { // CSR 103.9
+       1380,    1380,
+   },
+   { // K-Jah West
+       1519,    1520,
+   },
+   { // Master Sounds 98.3
+       1686,    1687,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8DD0 - 06:00..08:00
+int32 gRadioDJBanterMorning[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       208,     209,
+   },
+   { // K Rose
+       345,     346,
+   },
+   { // K-DST
+       490,     492,
+   },
+   { // Bounce FM
+       807,     809,
+   },
+   { // SF-UR
+       975,     977,
+   },
+   { // Radio Los Santos
+       1088,    1089,
+   },
+   { // Radio X
+       1237,    1238,
+   },
+   { // CSR 103.9
+       1381,    1382,
+   },
+   { // K-Jah West
+       1521,    1522,
+   },
+   { // Master Sounds 98.3
+       1688,    1689,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8E90 - forecast is RAINY
+int32 gRadioDJBanterRain[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       215,     217,
+   },
+   { // K Rose
+       351,     353,
+   },
+   { // K-DST
+       498,     499,
+   },
+   { // Bounce FM
+       815,     816,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1094,    1097,
+   },
+   { // Radio X
+       1243,    1245,
+   },
+   { // CSR 103.9
+       1387,    1388,
+   },
+   { // K-Jah West
+       1527,    1529,
+   },
+   { // Master Sounds 98.3
+       1695,    1696,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8EF0 - forecast is EXTRASUNNY. Unreachable in the original game, see `ChooseDJBanterIndex`
+int32 gRadioDJBanterHeat[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       218,     219,
+   },
+   { // K Rose
+       354,     355,
+   },
+   { // K-DST
+       500,     501,
+   },
+   { // Bounce FM
+       817,     818,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1098,    1099,
+   },
+   { // Radio X
+       1246,    1247,
+   },
+   { // CSR 103.9
+       1389,    1390,
+   },
+   { // K-Jah West
+       1530,    1531,
+   },
+   { // Master Sounds 98.3
+       1697,    1697,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8F50 - forecast is FOGGY
+int32 gRadioDJBanterFog[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       212,     214,
+   },
+   { // K Rose
+       349,     350,
+   },
+   { // K-DST
+       496,     497,
+   },
+   { // Bounce FM
+       812,     814,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1092,    1093,
+   },
+   { // Radio X
+       1241,    1242,
+   },
+   { // CSR 103.9
+       1385,    1386,
+   },
+   { // K-Jah West
+       1525,    1526,
+   },
+   { // Master Sounds 98.3
+       1692,    1694,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8CB280 - story banter per mission stat, indexed by `m_nSpecialDJBanterIndex` (0..21)
+int32 gRadioDJBanterMission[][NUM_MISSION_DJ_BANTERS] = {
+   { // Emergency
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Playback FM
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // K Rose
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,    344,    341,    343,     -1,    340,     -1,
+   },
+   { // K-DST
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,    487,     -1,     -1,
+           -1,     -1,     -1,    485,     -1,     -1,    486,     -1,     -1,     -1,     -1,
+   },
+   { // Bounce FM
+           -1,     -1,     -1,     -1,     -1,    803,     -1,     -1,     -1,     -1,     -1,
+          804,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // SF-UR
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Radio Los Santos
+           -1,     -1,     -1,   1082,     -1,     -1,     -1,     -1,     -1,     -1,   1084,
+           -1,     -1,   1085,     -1,   1083,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Radio X
+         1232,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,   1234,     -1,     -1,     -1,   1233,     -1,   1231,     -1,     -1,
+   },
+   { // CSR 103.9
+           -1,     -1,     -1,     -1,     -1,     -1,   1377,     -1,     -1,   1379,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,   1378,     -1,     -1,     -1,     -1,
+   },
+   { // K-Jah West
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,   1516,     -1,     -1,     -1,
+         1518,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Master Sounds 98.3
+           -1,   1683,   1684,     -1,   1681,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,   1682,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,   1685,
+   },
+   { // WCTR
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+};
+
+// 0x8C8B88 - range the adverts are picked from; the game never changes it
+int32 gRadioAdvertRange[2] = { 66, 134 };

--- a/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
+++ b/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
@@ -32,12 +32,12 @@ void CAERadioTrackManager::InjectHooks() {
     RH_ScopedInstall(TrackRadioStation, 0x4EAC30, { .reversed = false });
     RH_ScopedInstall(ChooseTracksForStation, 0x4EB180);
     RH_ScopedInstall(CheckForTrackConcatenation, 0x4EA930, { .reversed = false });
-    RH_ScopedInstall(QueueUpTracksForStation, 0x4EA670, { .reversed = false });
-    RH_ScopedInstall(ChooseDJBanterIndex, 0x4EA2D0, { .reversed = false });
-    RH_ScopedInstall(ChooseDJBanterIndexFromList, 0x4E95E0, { .reversed = false });
-    RH_ScopedInstall(ChooseAdvertIndex, 0x4E9570, { .reversed = false });
-    RH_ScopedInstall(ChooseIdentIndex, 0x4E94C0, { .reversed = false });
-    RH_ScopedInstall(ChooseMusicTrackIndex, 0x4EA270, { .reversed = false });
+    RH_ScopedInstall(QueueUpTracksForStation, 0x4EA670);
+    RH_ScopedInstall(ChooseDJBanterIndex, 0x4EA2D0);
+    RH_ScopedInstall(ChooseDJBanterIndexFromList, 0x4E95E0);
+    RH_ScopedInstall(ChooseAdvertIndex, 0x4E9570);
+    RH_ScopedInstall(ChooseIdentIndex, 0x4E94C0);
+    RH_ScopedInstall(ChooseMusicTrackIndex, 0x4EA270);
     RH_ScopedInstall(ChooseTalkRadioShow, 0x4E8E40, { .reversed = false });
     RH_ScopedInstall(CheckForMissionStatsChanges, 0x4E8410);
     RH_ScopedInstall(StartTrackPlayback, 0x4EA640);
@@ -622,7 +622,83 @@ bool CAERadioTrackManager::TrackRadioStation(eRadioID id, bool skipTrack) {
 
 // 0x4EA670
 bool CAERadioTrackManager::QueueUpTracksForStation(eRadioID id, int8* iTrackCount, int8 radioState, tRadioSettings& settings) {
-    return plugin::CallMethodAndReturn<bool, 0x4EA670, CAERadioTrackManager*, int8, int8*, int8, tRadioSettings&>(this, id, iTrackCount, radioState, settings);
+    // Spoken entries take up a single slot, and a missing one aborts the whole entry
+    const auto PushSpoken = [&](int32 trackID, int8 type) {
+        settings.TrackQueue[*iTrackCount] = trackID;
+        if (trackID == -1) {
+            return false;
+        }
+        settings.TrackTypes[*iTrackCount] = type;
+        (*iTrackCount)++;
+        return true;
+    };
+
+    // Music is queued a whole song at a time, so every part of it carries the same track index
+    const auto PushMusic = [&](int32 trackID, int8 type, int8 musicIdx) {
+        settings.TrackIndices[*iTrackCount] = musicIdx;
+        settings.TrackQueue[*iTrackCount]   = trackID;
+        settings.TrackTypes[*iTrackCount]   = type;
+        (*iTrackCount)++;
+    };
+
+    const auto Outro = [&](int8 musicIdx) {
+        return CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioMusicOutros[id][musicIdx][0], gRadioMusicOutros[id][musicIdx][1]);
+    };
+
+    switch (radioState) {
+    case TYPE_INDENT: {
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        return PushSpoken(ChooseIdentIndex(id), TYPE_INDENT);
+    }
+    case TYPE_ADVERT: { // Unlike the others this one can't come up empty
+        settings.TrackQueue[*iTrackCount] = ChooseAdvertIndex(id);
+        settings.TrackTypes[*iTrackCount] = TYPE_ADVERT;
+        (*iTrackCount)++;
+        return true;
+    }
+    case TYPE_DJ_BANTER: {
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        return PushSpoken(ChooseDJBanterIndex(id), TYPE_DJ_BANTER);
+    }
+    case TYPE_INTRO: { // The full song: DJ intro, body, outro
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioMusicIntros[id][idx][0], gRadioMusicIntros[id][idx][1]), TYPE_INTRO, idx);
+        PushMusic(gRadioMusicTracks[id][idx], TYPE_TRACK, idx);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    case TYPE_TRACK: { // Same song, joined after the intro
+        if (id == RADIO_USER_TRACKS) {
+            const auto userTrack = AEUserRadioTrackManager.SelectUserTrackIndex();
+            settings.TrackQueue[*iTrackCount]   = userTrack;
+            settings.TrackTypes[*iTrackCount]   = TYPE_USER_TRACK;
+            settings.TrackIndices[*iTrackCount] = (int8)userTrack;
+            (*iTrackCount)++;
+            return true;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(gRadioMusicTracks[id][idx], TYPE_TRACK, idx);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    case TYPE_OUTRO: { // Only the tail end of it
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    default:
+        return true;
+    }
 }
 
 // 0x4E9820
@@ -632,27 +708,177 @@ void CAERadioTrackManager::StopRadio(tVehicleAudioSettings* settings, bool durin
 
 // 0x4E94C0
 int32 CAERadioTrackManager::ChooseIdentIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4E94C0, CAERadioTrackManager*, int8>(this, id);
+    const auto& range = gRadioIdents[id];
+    if (range[0] == NOTRACK) {
+        return -1;
+    }
+
+    // The history is only as deep as the list has room for, otherwise we'd never find a free index
+    const auto depth = std::max(0, std::min<int32>(range[1] - range[0] - 1, IDENT_INDEX_HISTORY_COUNT));
+    const auto history = m_nIdentIndexHistory[id].indices | rngv::take(depth);
+
+    while (true) {
+        const auto idx = CAEAudioUtility::GetRandomNumberInRange<int32>(range[0], range[1]);
+
+        // Radio Los Santos keeps this ident off the air until the mission has been passed
+        if (id == RADIO_MODERN_HIP_HOP && idx == 1100 && CStats::GetStatValue(STAT_ARE_YOU_GOING_TO_SAN_FIERRO_MISSION_ACCOMPLISHED) == 0.0f) {
+            continue;
+        }
+
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
 }
 
 // 0x4E9570
 int32 CAERadioTrackManager::ChooseAdvertIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4E9570, CAERadioTrackManager*, int8>(this, id);
+    while (true) {
+        const auto idx = CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioAdvertRange[0], gRadioAdvertRange[1]);
+
+        if (rng::contains(gnRadioStationRestrictedAdverts[id], idx)) { // This advert isn't meant for this station
+            continue;
+        }
+        if (!rng::contains(m_nAdvertIndexHistory[id].indices, idx)) {  // ...and it hasn't been on recently
+            return idx;
+        }
+    }
 }
 
 // 0x4EA270
 int8 CAERadioTrackManager::ChooseMusicTrackIndex(eRadioID id) {
-    return plugin::CallAndReturn<int8, 0x4EA270, CAERadioTrackManager*, int8>(this, id);
+    if (id == RADIO_TALK) {
+        return ChooseTalkRadioShow();
+    }
+
+    const auto numTracks = gRadioNumMusicTracksPerStation[id];
+
+    // See `ChooseIdentIndex` - a station with 2 tracks or less has no history at all
+    const auto depth = std::max(0, std::min<int32>(numTracks - 2, MUSIC_TRACK_HISTORY_COUNT));
+    const auto history = m_nMusicTrackIndexHistory[id].indices | rngv::take(depth);
+
+    while (true) {
+        const auto idx = (int8)CAEAudioUtility::GetRandomNumberInRange<int32>(0, numTracks - 1);
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
 }
 
 // 0x4EA2D0
 int32 CAERadioTrackManager::ChooseDJBanterIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4EA2D0, CAERadioTrackManager*, int8>(this, id);
+    //
+    // A pending story banter beats everything else, as long as it hasn't been on already
+    //
+    auto story = -1;
+    switch (m_nSpecialDJBanterPending) {
+    case 0:
+        story = gRadioDJBanterPending[id][0];
+        break;
+    case 1:
+        // The second line is skipped for stations that only recorded one
+        if (m_nSpecialDJBanterIndex == 0 || (m_nSpecialDJBanterIndex == 1 && gRadioDJBanterSpecial[id][0] != gRadioDJBanterSpecial[id][1])) {
+            story = gRadioDJBanterSpecial[id][m_nSpecialDJBanterIndex];
+        }
+        break;
+    case 2:
+        story = gRadioDJBanterMission[id][m_nSpecialDJBanterIndex];
+        break;
+    }
+    if (story != NOTRACK && story >= 0 && !rng::contains(m_nDJBanterIndexHistory[id].indices, story)) {
+        return story;
+    }
+
+    // The police scanner has no DJ, it swaps its whole list out during the riots instead
+    if (id == RADIO_EMERGENCY_AA) {
+        return ChooseDJBanterIndexFromList(id, CGameLogic::LaRiotsActiveHere() ? gRadioDJBanterNight : gRadioDJBanterGeneric);
+    }
+
+    // 40% of the time the DJ keeps quiet and the caller puts an advert on instead
+    if (!CAEAudioUtility::ResolveProbability(0.6f)) {
+        return -1;
+    }
+
+    const auto hour = CClock::ms_nGameClockHours;
+    if (CGame::currArea != AREA_CODE_NORMAL_WORLD) { // No banter while the player is inside
+        return -1;
+    }
+
+    const auto TryList = [&](int32 (*list)[2]) {
+        return CAEAudioUtility::ResolveProbability(0.5f)
+            ? ChooseDJBanterIndexFromList(id, list)
+            : -1;
+    };
+
+    //
+    // Weather lines are about the *forecast* three steps out, not the weather right now
+    //
+    const auto Forecast = [](eWeatherType type) { return CWeather::ForecastWeather(type, 3); };
+
+    if (Forecast(WEATHER_RAINY_COUNTRYSIDE) || Forecast(WEATHER_RAINY_SF)) {
+        if (const auto idx = TryList(gRadioDJBanterRain); idx != -1) {
+            return idx;
+        }
+    } else if (
+           (Forecast(WEATHER_EXTRASUNNY_LA) || Forecast(WEATHER_EXTRASUNNY_SMOG_LA) || Forecast(WEATHER_EXTRASUNNY_COUNTRYSIDE)
+         || Forecast(WEATHER_EXTRASUNNY_SF) || Forecast(WEATHER_EXTRASUNNY_VEGAS)   || Forecast(WEATHER_EXTRASUNNY_DESERT))
+        && (hour >= 8 && hour < 6) // BUG (R*): No hour satisfies this, so the heat lines never make it to air
+    ) {
+        if (const auto idx = TryList(gRadioDJBanterHeat); idx != -1) {
+            return idx;
+        }
+    } else if (Forecast(WEATHER_FOGGY_SF)) {
+        if (const auto idx = TryList(gRadioDJBanterFog); idx != -1) {
+            return idx;
+        }
+    }
+
+    //
+    // Then the time of day, each list only 30% of the time
+    //
+    int32 (*timeOfDay)[2] = nullptr;
+    if (hour >= 6 && hour <= 8) {
+        timeOfDay = gRadioDJBanterMorning;
+    } else if (hour >= 18 && hour <= 20) {
+        timeOfDay = gRadioDJBanterEvening;
+    } else if (hour >= 22 || hour <= 2) {
+        timeOfDay = gRadioDJBanterNight;
+    }
+    if (timeOfDay && CAEAudioUtility::ResolveProbability(0.3f)) {
+        if (const auto idx = ChooseDJBanterIndexFromList(id, timeOfDay); idx != -1) {
+            return idx;
+        }
+    }
+
+    return ChooseDJBanterIndexFromList(id, gRadioDJBanterGeneric);
 }
 
 // 0x4E95E0
-int32 CAERadioTrackManager::ChooseDJBanterIndexFromList(eRadioID id, int32** list) {
-    return plugin::CallMethodAndReturn<int32, 0x4E95E0, CAERadioTrackManager*, eRadioID, int32**>(this, id, list);
+int32 CAERadioTrackManager::ChooseDJBanterIndexFromList(eRadioID id, int32 (*list)[2]) {
+    const auto& range = list[id];
+    if (range[0] == NOTRACK) {
+        return -1;
+    }
+
+    // Unlike the other pickers this one walks the list from a random point instead of re-rolling
+    const auto count = range[1] - range[0] + 1;
+    const auto first = CAEAudioUtility::GetRandomNumberInRange<int32>(0, count - 1);
+    if (count < 1) {
+        return -1;
+    }
+
+    // The depth is always measured on the generic list, whichever list we're actually picking from
+    const auto& generic = gRadioDJBanterGeneric[id];
+    const auto  depth   = std::max(0, std::min<int32>(generic[1] - generic[0] - 1, DJBANTER_INDEX_HISTORY_COUNT));
+    const auto  history = m_nDJBanterIndexHistory[id].indices | rngv::take(depth);
+
+    for (auto i = 0; i < count; i++) {
+        const auto idx = range[0] + (first + i) % count;
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
+    return -1;
 }
 
 // 0x4EB180

--- a/source/game_sa/Audio/Managers/AERadioTrackManager.h
+++ b/source/game_sa/Audio/Managers/AERadioTrackManager.h
@@ -249,7 +249,7 @@ protected:
     int32 ChooseIdentIndex(eRadioID id);
     int32 ChooseAdvertIndex(eRadioID id);
     int32 ChooseDJBanterIndex(eRadioID id);
-    int32 ChooseDJBanterIndexFromList(eRadioID id, int32** list);
+    int32 ChooseDJBanterIndexFromList(eRadioID id, int32 (*list)[2]);
     int8  ChooseMusicTrackIndex(eRadioID id);
     static int8  ChooseTalkRadioShow();
 


### PR DESCRIPTION
Reverses the six functions that decide what a station actually plays:

| Function | Address |
| --- | --- |
| `ChooseIdentIndex` | 0x4E94C0 |
| `ChooseAdvertIndex` | 0x4E9570 |
| `ChooseDJBanterIndexFromList` | 0x4E95E0 |
| `ChooseMusicTrackIndex` | 0x4EA270 |
| `ChooseDJBanterIndex` | 0x4EA2D0 |
| `QueueUpTracksForStation` | 0x4EA670 |

`ChooseTracksForStation` was already reversed and drives all of these, so this
fills in the layer directly under it. `CAEAudioUtility::GetRandomNumberInRange`
and the history helpers it needs were already in place too.

### Data tables

`RadioStreamsPC.h` only had three of the DJ banter tables, so this adds the rest:
story banter (0x8C8C50), per-mission banter (0x8CB280), morning and evening
(0x8C8DD0, 0x8C8D70), the weather lists (0x8C8E90 rain, 0x8C8EF0 heat,
0x8C8F50 fog), and the advert range (0x8C8B88).

While checking the existing three against the addresses they came from, `TN`
turned out to be the 22:00..02:00 list rather than the story one the name
suggests, so `gRadioDJBanterBC` / `TN` / `GN` are renamed to `Pending` / `Night`
/ `Generic`. They had no references anywhere, so this touches nothing else.

### Behaviour worth flagging

- **The heat banter never plays in the original game.** It is gated on
  `hour >= 8 && hour < 6` (0x4EA46D), which no hour satisfies - most likely
  `&&` where `||` was meant. Kept exactly as-is with a comment, since matching
  the original is the point here. Happy to move it behind a `notsa::bugfixes`
  entry instead if you'd prefer, but that restores lines that never shipped,
  which seemed like its own discussion rather than something to smuggle in here.
- Radio Los Santos keeps ident 1100 off the air until
  `STAT_ARE_YOU_GOING_TO_SAN_FIERRO_MISSION_ACCOMPLISHED` is non-zero.
- No station banters while the player is inside an interior (`CGame::currArea`).
- The police scanner (`RADIO_EMERGENCY_AA`) has no DJ; during the riots its
  whole list is swapped for the night one via `CGameLogic::LaRiotsActiveHere()`.

### Signature change

`ChooseDJBanterIndexFromList` was declared as taking `int32** list`, but the
game passes an array of `{first, last}` pairs indexed by station, so it becomes
`int32 (*list)[2]`.

### Testing

**Not tested in-game.** I develop on Linux and don't currently have a working
MSVC/Wine build or a Compact exe, so I'm relying on CI to compile this. Please
treat the runtime behaviour as unverified - if someone can put it on the air for
a few minutes I'd appreciate it.

What I did verify:

- Every table added or renamed was diffed byte for byte against the 1.0 US
  `.data` section, including the three pre-existing ones (which is how the `TN`
  mislabel turned up).
- The control flow of all six functions was taken from the decompiled 1.0 US
  code, including RNG call ordering, since that decides the outcome. The one
  place I reordered anything is `ChooseDJBanterIndexFromList`, where the
  original draws its random start before the `count < 1` early-out; I kept the
  draw first so the RNG stream matches, even though `count < 1` can't happen
  with the shipped tables.
- The same broadcast logic is running in a personal project against the game's
  own audio, which is what prompted this PR.

### Hook checklist

- `static void InjectHooks();` is already declared on the class.
- `CAERadioTrackManager::InjectHooks();` is already called from `InjectHooksMain()`.
- No `friend void InjectHooksMain();` needed.
- All six keep their `RH_ScopedInstall` entries, now without `.reversed = false`.
