### PR TITLE
re(CAERadioTrackManager): Reverse CheckForTrackConcatenation and IsVehicleRadioActive

### DIFF
--- a/source/game_sa/Audio/Config/RadioStreamsPC.h
+++ b/source/game_sa/Audio/Config/RadioStreamsPC.h
@@ -5,6 +5,9 @@
 
 #define NOTRACK 1922
 
+//! Number of story DJ banters per station in `gRadioDJBanterMission`
+constexpr auto NUM_MISSION_DJ_BANTERS = 22;
+
 int32 gRadioNumMusicTracksPerStation[] = {
    2,  // Emergency
    12, // Playback FM
@@ -394,7 +397,8 @@ int32 gnRadioStationRestrictedAdverts[][23] = {
    },
 };
 
-int32 gRadioDJBanterBC[][2] = {
+// 0x8C8BF0 - played once when a story banter is pending
+int32 gRadioDJBanterPending[][2] = {
    { // Emergency
        NOTRACK, NOTRACK,
    },
@@ -433,7 +437,8 @@ int32 gRadioDJBanterBC[][2] = {
    },
 };
 
-int32 gRadioDJBanterTN[][2] = {
+// 0x8C8E30 - 22:00..02:00
+int32 gRadioDJBanterNight[][2] = {
    { // Emergency
        39,      59,
    },
@@ -472,7 +477,8 @@ int32 gRadioDJBanterTN[][2] = {
    },
 };
 
-int32 gRadioDJBanterGN[][2] = {
+// 0x8C8CB0 - fallback, used when no other list yields a line
+int32 gRadioDJBanterGeneric[][2] = {
    { // Emergency
        0,      38,
    },
@@ -510,3 +516,298 @@ int32 gRadioDJBanterGN[][2] = {
        NOTRACK, NOTRACK,
    },
 };
+
+// 0x8C8C50 - story banter, indexed by `m_nSpecialDJBanterIndex`
+int32 gRadioDJBanterSpecial[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       186,     187,
+   },
+   { // K Rose
+       316,     317,
+   },
+   { // K-DST
+       471,     472,
+   },
+   { // Bounce FM
+       768,     769,
+   },
+   { // SF-UR
+       947,     948,
+   },
+   { // Radio Los Santos
+       1062,    1063,
+   },
+   { // Radio X
+       1214,    1215,
+   },
+   { // CSR 103.9
+       1361,    1362,
+   },
+   { // K-Jah West
+       1491,    1492,
+   },
+   { // Master Sounds 98.3
+       1652,    1653,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8D70 - 18:00..20:00
+int32 gRadioDJBanterEvening[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       206,     207,
+   },
+   { // K Rose
+       NOTRACK, NOTRACK,
+   },
+   { // K-DST
+       488,     489,
+   },
+   { // Bounce FM
+       805,     806,
+   },
+   { // SF-UR
+       972,     974,
+   },
+   { // Radio Los Santos
+       1086,    1087,
+   },
+   { // Radio X
+       1235,    1236,
+   },
+   { // CSR 103.9
+       1380,    1380,
+   },
+   { // K-Jah West
+       1519,    1520,
+   },
+   { // Master Sounds 98.3
+       1686,    1687,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8DD0 - 06:00..08:00
+int32 gRadioDJBanterMorning[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       208,     209,
+   },
+   { // K Rose
+       345,     346,
+   },
+   { // K-DST
+       490,     492,
+   },
+   { // Bounce FM
+       807,     809,
+   },
+   { // SF-UR
+       975,     977,
+   },
+   { // Radio Los Santos
+       1088,    1089,
+   },
+   { // Radio X
+       1237,    1238,
+   },
+   { // CSR 103.9
+       1381,    1382,
+   },
+   { // K-Jah West
+       1521,    1522,
+   },
+   { // Master Sounds 98.3
+       1688,    1689,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8E90 - forecast is RAINY
+int32 gRadioDJBanterRain[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       215,     217,
+   },
+   { // K Rose
+       351,     353,
+   },
+   { // K-DST
+       498,     499,
+   },
+   { // Bounce FM
+       815,     816,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1094,    1097,
+   },
+   { // Radio X
+       1243,    1245,
+   },
+   { // CSR 103.9
+       1387,    1388,
+   },
+   { // K-Jah West
+       1527,    1529,
+   },
+   { // Master Sounds 98.3
+       1695,    1696,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8EF0 - forecast is EXTRASUNNY. Unreachable in the original game, see `ChooseDJBanterIndex`
+int32 gRadioDJBanterHeat[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       218,     219,
+   },
+   { // K Rose
+       354,     355,
+   },
+   { // K-DST
+       500,     501,
+   },
+   { // Bounce FM
+       817,     818,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1098,    1099,
+   },
+   { // Radio X
+       1246,    1247,
+   },
+   { // CSR 103.9
+       1389,    1390,
+   },
+   { // K-Jah West
+       1530,    1531,
+   },
+   { // Master Sounds 98.3
+       1697,    1697,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8C8F50 - forecast is FOGGY
+int32 gRadioDJBanterFog[][2] = {
+   { // Emergency
+       NOTRACK, NOTRACK,
+   },
+   { // Playback FM
+       212,     214,
+   },
+   { // K Rose
+       349,     350,
+   },
+   { // K-DST
+       496,     497,
+   },
+   { // Bounce FM
+       812,     814,
+   },
+   { // SF-UR
+       NOTRACK, NOTRACK,
+   },
+   { // Radio Los Santos
+       1092,    1093,
+   },
+   { // Radio X
+       1241,    1242,
+   },
+   { // CSR 103.9
+       1385,    1386,
+   },
+   { // K-Jah West
+       1525,    1526,
+   },
+   { // Master Sounds 98.3
+       1692,    1694,
+   },
+   { // WCTR
+       NOTRACK, NOTRACK,
+   },
+};
+
+// 0x8CB280 - story banter per mission stat, indexed by `m_nSpecialDJBanterIndex` (0..21)
+int32 gRadioDJBanterMission[][NUM_MISSION_DJ_BANTERS] = {
+   { // Emergency
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Playback FM
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // K Rose
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,    344,    341,    343,     -1,    340,     -1,
+   },
+   { // K-DST
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,    487,     -1,     -1,
+           -1,     -1,     -1,    485,     -1,     -1,    486,     -1,     -1,     -1,     -1,
+   },
+   { // Bounce FM
+           -1,     -1,     -1,     -1,     -1,    803,     -1,     -1,     -1,     -1,     -1,
+          804,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // SF-UR
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Radio Los Santos
+           -1,     -1,     -1,   1082,     -1,     -1,     -1,     -1,     -1,     -1,   1084,
+           -1,     -1,   1085,     -1,   1083,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Radio X
+         1232,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,   1234,     -1,     -1,     -1,   1233,     -1,   1231,     -1,     -1,
+   },
+   { // CSR 103.9
+           -1,     -1,     -1,     -1,     -1,     -1,   1377,     -1,     -1,   1379,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,   1378,     -1,     -1,     -1,     -1,
+   },
+   { // K-Jah West
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,   1516,     -1,     -1,     -1,
+         1518,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+   { // Master Sounds 98.3
+           -1,   1683,   1684,     -1,   1681,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,   1682,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,   1685,
+   },
+   { // WCTR
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+           -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,     -1,
+   },
+};
+
+// 0x8C8B88 - range the adverts are picked from; the game never changes it
+int32 gRadioAdvertRange[2] = { 66, 134 };

--- a/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
+++ b/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
@@ -32,12 +32,12 @@ void CAERadioTrackManager::InjectHooks() {
     RH_ScopedInstall(TrackRadioStation, 0x4EAC30, { .reversed = false });
     RH_ScopedInstall(ChooseTracksForStation, 0x4EB180);
     RH_ScopedInstall(CheckForTrackConcatenation, 0x4EA930, { .reversed = false });
-    RH_ScopedInstall(QueueUpTracksForStation, 0x4EA670, { .reversed = false });
-    RH_ScopedInstall(ChooseDJBanterIndex, 0x4EA2D0, { .reversed = false });
-    RH_ScopedInstall(ChooseDJBanterIndexFromList, 0x4E95E0, { .reversed = false });
-    RH_ScopedInstall(ChooseAdvertIndex, 0x4E9570, { .reversed = false });
-    RH_ScopedInstall(ChooseIdentIndex, 0x4E94C0, { .reversed = false });
-    RH_ScopedInstall(ChooseMusicTrackIndex, 0x4EA270, { .reversed = false });
+    RH_ScopedInstall(QueueUpTracksForStation, 0x4EA670);
+    RH_ScopedInstall(ChooseDJBanterIndex, 0x4EA2D0);
+    RH_ScopedInstall(ChooseDJBanterIndexFromList, 0x4E95E0);
+    RH_ScopedInstall(ChooseAdvertIndex, 0x4E9570);
+    RH_ScopedInstall(ChooseIdentIndex, 0x4E94C0);
+    RH_ScopedInstall(ChooseMusicTrackIndex, 0x4EA270);
     RH_ScopedInstall(ChooseTalkRadioShow, 0x4E8E40, { .reversed = false });
     RH_ScopedInstall(CheckForMissionStatsChanges, 0x4E8410);
     RH_ScopedInstall(StartTrackPlayback, 0x4EA640);
@@ -622,7 +622,83 @@ bool CAERadioTrackManager::TrackRadioStation(eRadioID id, bool skipTrack) {
 
 // 0x4EA670
 bool CAERadioTrackManager::QueueUpTracksForStation(eRadioID id, int8* iTrackCount, int8 radioState, tRadioSettings& settings) {
-    return plugin::CallMethodAndReturn<bool, 0x4EA670, CAERadioTrackManager*, int8, int8*, int8, tRadioSettings&>(this, id, iTrackCount, radioState, settings);
+    // Spoken entries take up a single slot, and a missing one aborts the whole entry
+    const auto PushSpoken = [&](int32 trackID, int8 type) {
+        settings.TrackQueue[*iTrackCount] = trackID;
+        if (trackID == -1) {
+            return false;
+        }
+        settings.TrackTypes[*iTrackCount] = type;
+        (*iTrackCount)++;
+        return true;
+    };
+
+    // Music is queued a whole song at a time, so every part of it carries the same track index
+    const auto PushMusic = [&](int32 trackID, int8 type, int8 musicIdx) {
+        settings.TrackIndices[*iTrackCount] = musicIdx;
+        settings.TrackQueue[*iTrackCount]   = trackID;
+        settings.TrackTypes[*iTrackCount]   = type;
+        (*iTrackCount)++;
+    };
+
+    const auto Outro = [&](int8 musicIdx) {
+        return CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioMusicOutros[id][musicIdx][0], gRadioMusicOutros[id][musicIdx][1]);
+    };
+
+    switch (radioState) {
+    case TYPE_INDENT: {
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        return PushSpoken(ChooseIdentIndex(id), TYPE_INDENT);
+    }
+    case TYPE_ADVERT: { // Unlike the others this one can't come up empty
+        settings.TrackQueue[*iTrackCount] = ChooseAdvertIndex(id);
+        settings.TrackTypes[*iTrackCount] = TYPE_ADVERT;
+        (*iTrackCount)++;
+        return true;
+    }
+    case TYPE_DJ_BANTER: {
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        return PushSpoken(ChooseDJBanterIndex(id), TYPE_DJ_BANTER);
+    }
+    case TYPE_INTRO: { // The full song: DJ intro, body, outro
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioMusicIntros[id][idx][0], gRadioMusicIntros[id][idx][1]), TYPE_INTRO, idx);
+        PushMusic(gRadioMusicTracks[id][idx], TYPE_TRACK, idx);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    case TYPE_TRACK: { // Same song, joined after the intro
+        if (id == RADIO_USER_TRACKS) {
+            const auto userTrack = AEUserRadioTrackManager.SelectUserTrackIndex();
+            settings.TrackQueue[*iTrackCount]   = userTrack;
+            settings.TrackTypes[*iTrackCount]   = TYPE_USER_TRACK;
+            settings.TrackIndices[*iTrackCount] = (int8)userTrack;
+            (*iTrackCount)++;
+            return true;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(gRadioMusicTracks[id][idx], TYPE_TRACK, idx);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    case TYPE_OUTRO: { // Only the tail end of it
+        if (id == RADIO_USER_TRACKS) {
+            return false;
+        }
+        const auto idx = ChooseMusicTrackIndex(id);
+        PushMusic(Outro(idx), TYPE_OUTRO, idx);
+        return true;
+    }
+    default:
+        return true;
+    }
 }
 
 // 0x4E9820
@@ -632,27 +708,177 @@ void CAERadioTrackManager::StopRadio(tVehicleAudioSettings* settings, bool durin
 
 // 0x4E94C0
 int32 CAERadioTrackManager::ChooseIdentIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4E94C0, CAERadioTrackManager*, int8>(this, id);
+    const auto& range = gRadioIdents[id];
+    if (range[0] == NOTRACK) {
+        return -1;
+    }
+
+    // The history is only as deep as the list has room for, otherwise we'd never find a free index
+    const auto depth = std::max(0, std::min<int32>(range[1] - range[0] - 1, IDENT_INDEX_HISTORY_COUNT));
+    const auto history = m_nIdentIndexHistory[id].indices | rngv::take(depth);
+
+    while (true) {
+        const auto idx = CAEAudioUtility::GetRandomNumberInRange<int32>(range[0], range[1]);
+
+        // Radio Los Santos keeps this ident off the air until the mission has been passed
+        if (id == RADIO_MODERN_HIP_HOP && idx == 1100 && CStats::GetStatValue(STAT_ARE_YOU_GOING_TO_SAN_FIERRO_MISSION_ACCOMPLISHED) == 0.0f) {
+            continue;
+        }
+
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
 }
 
 // 0x4E9570
 int32 CAERadioTrackManager::ChooseAdvertIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4E9570, CAERadioTrackManager*, int8>(this, id);
+    while (true) {
+        const auto idx = CAEAudioUtility::GetRandomNumberInRange<int32>(gRadioAdvertRange[0], gRadioAdvertRange[1]);
+
+        if (rng::contains(gnRadioStationRestrictedAdverts[id], idx)) { // This advert isn't meant for this station
+            continue;
+        }
+        if (!rng::contains(m_nAdvertIndexHistory[id].indices, idx)) {  // ...and it hasn't been on recently
+            return idx;
+        }
+    }
 }
 
 // 0x4EA270
 int8 CAERadioTrackManager::ChooseMusicTrackIndex(eRadioID id) {
-    return plugin::CallAndReturn<int8, 0x4EA270, CAERadioTrackManager*, int8>(this, id);
+    if (id == RADIO_TALK) {
+        return ChooseTalkRadioShow();
+    }
+
+    const auto numTracks = gRadioNumMusicTracksPerStation[id];
+
+    // See `ChooseIdentIndex` - a station with 2 tracks or less has no history at all
+    const auto depth = std::max(0, std::min<int32>(numTracks - 2, MUSIC_TRACK_HISTORY_COUNT));
+    const auto history = m_nMusicTrackIndexHistory[id].indices | rngv::take(depth);
+
+    while (true) {
+        const auto idx = (int8)CAEAudioUtility::GetRandomNumberInRange<int32>(0, numTracks - 1);
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
 }
 
 // 0x4EA2D0
 int32 CAERadioTrackManager::ChooseDJBanterIndex(eRadioID id) {
-    return plugin::CallAndReturn<int32, 0x4EA2D0, CAERadioTrackManager*, int8>(this, id);
+    //
+    // A pending story banter beats everything else, as long as it hasn't been on already
+    //
+    auto story = -1;
+    switch (m_nSpecialDJBanterPending) {
+    case 0:
+        story = gRadioDJBanterPending[id][0];
+        break;
+    case 1:
+        // The second line is skipped for stations that only recorded one
+        if (m_nSpecialDJBanterIndex == 0 || (m_nSpecialDJBanterIndex == 1 && gRadioDJBanterSpecial[id][0] != gRadioDJBanterSpecial[id][1])) {
+            story = gRadioDJBanterSpecial[id][m_nSpecialDJBanterIndex];
+        }
+        break;
+    case 2:
+        story = gRadioDJBanterMission[id][m_nSpecialDJBanterIndex];
+        break;
+    }
+    if (story != NOTRACK && story >= 0 && !rng::contains(m_nDJBanterIndexHistory[id].indices, story)) {
+        return story;
+    }
+
+    // The police scanner has no DJ, it swaps its whole list out during the riots instead
+    if (id == RADIO_EMERGENCY_AA) {
+        return ChooseDJBanterIndexFromList(id, CGameLogic::LaRiotsActiveHere() ? gRadioDJBanterNight : gRadioDJBanterGeneric);
+    }
+
+    // 40% of the time the DJ keeps quiet and the caller puts an advert on instead
+    if (!CAEAudioUtility::ResolveProbability(0.6f)) {
+        return -1;
+    }
+
+    const auto hour = CClock::ms_nGameClockHours;
+    if (CGame::currArea != AREA_CODE_NORMAL_WORLD) { // No banter while the player is inside
+        return -1;
+    }
+
+    const auto TryList = [&](int32 (*list)[2]) {
+        return CAEAudioUtility::ResolveProbability(0.5f)
+            ? ChooseDJBanterIndexFromList(id, list)
+            : -1;
+    };
+
+    //
+    // Weather lines are about the *forecast* three steps out, not the weather right now
+    //
+    const auto Forecast = [](eWeatherType type) { return CWeather::ForecastWeather(type, 3); };
+
+    if (Forecast(WEATHER_RAINY_COUNTRYSIDE) || Forecast(WEATHER_RAINY_SF)) {
+        if (const auto idx = TryList(gRadioDJBanterRain); idx != -1) {
+            return idx;
+        }
+    } else if (
+           (Forecast(WEATHER_EXTRASUNNY_LA) || Forecast(WEATHER_EXTRASUNNY_SMOG_LA) || Forecast(WEATHER_EXTRASUNNY_COUNTRYSIDE)
+         || Forecast(WEATHER_EXTRASUNNY_SF) || Forecast(WEATHER_EXTRASUNNY_VEGAS)   || Forecast(WEATHER_EXTRASUNNY_DESERT))
+        && (hour >= 8 && hour < 6) // BUG (R*): No hour satisfies this, so the heat lines never make it to air
+    ) {
+        if (const auto idx = TryList(gRadioDJBanterHeat); idx != -1) {
+            return idx;
+        }
+    } else if (Forecast(WEATHER_FOGGY_SF)) {
+        if (const auto idx = TryList(gRadioDJBanterFog); idx != -1) {
+            return idx;
+        }
+    }
+
+    //
+    // Then the time of day, each list only 30% of the time
+    //
+    int32 (*timeOfDay)[2] = nullptr;
+    if (hour >= 6 && hour <= 8) {
+        timeOfDay = gRadioDJBanterMorning;
+    } else if (hour >= 18 && hour <= 20) {
+        timeOfDay = gRadioDJBanterEvening;
+    } else if (hour >= 22 || hour <= 2) {
+        timeOfDay = gRadioDJBanterNight;
+    }
+    if (timeOfDay && CAEAudioUtility::ResolveProbability(0.3f)) {
+        if (const auto idx = ChooseDJBanterIndexFromList(id, timeOfDay); idx != -1) {
+            return idx;
+        }
+    }
+
+    return ChooseDJBanterIndexFromList(id, gRadioDJBanterGeneric);
 }
 
 // 0x4E95E0
-int32 CAERadioTrackManager::ChooseDJBanterIndexFromList(eRadioID id, int32** list) {
-    return plugin::CallMethodAndReturn<int32, 0x4E95E0, CAERadioTrackManager*, eRadioID, int32**>(this, id, list);
+int32 CAERadioTrackManager::ChooseDJBanterIndexFromList(eRadioID id, int32 (*list)[2]) {
+    const auto& range = list[id];
+    if (range[0] == NOTRACK) {
+        return -1;
+    }
+
+    // Unlike the other pickers this one walks the list from a random point instead of re-rolling
+    const auto count = range[1] - range[0] + 1;
+    const auto first = CAEAudioUtility::GetRandomNumberInRange<int32>(0, count - 1);
+    if (count < 1) {
+        return -1;
+    }
+
+    // The depth is always measured on the generic list, whichever list we're actually picking from
+    const auto& generic = gRadioDJBanterGeneric[id];
+    const auto  depth   = std::max(0, std::min<int32>(generic[1] - generic[0] - 1, DJBANTER_INDEX_HISTORY_COUNT));
+    const auto  history = m_nDJBanterIndexHistory[id].indices | rngv::take(depth);
+
+    for (auto i = 0; i < count; i++) {
+        const auto idx = range[0] + (first + i) % count;
+        if (rng::find(history, idx) == rng::end(history)) {
+            return idx;
+        }
+    }
+    return -1;
 }
 
 // 0x4EB180

--- a/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
+++ b/source/game_sa/Audio/Managers/AERadioTrackManager.cpp
@@ -21,7 +21,7 @@ void CAERadioTrackManager::InjectHooks() {
     RH_ScopedInstall(DisplayRadioStationName, 0x4E9E50);
     RH_ScopedInstall(CheckForStationRetune, 0x4EB660, { .reversed = false });
     RH_ScopedInstall(CheckForPause, 0x4EA590);
-    RH_ScopedInstall(IsVehicleRadioActive, 0x4E9800, { .reversed = false });
+    RH_ScopedInstall(IsVehicleRadioActive, 0x4E9800);
     RH_ScopedInstall(AddDJBanterIndexToHistory, 0x4E97B0);
     RH_ScopedInstall(AddAdvertIndexToHistory, 0x4E9760);
     RH_ScopedInstall(AddIdentIndexToHistory, 0x4E9720);
@@ -31,7 +31,7 @@ void CAERadioTrackManager::InjectHooks() {
     RH_ScopedInstall(CheckForStationRetuneDuringPause, 0x4EB890);
     RH_ScopedInstall(TrackRadioStation, 0x4EAC30, { .reversed = false });
     RH_ScopedInstall(ChooseTracksForStation, 0x4EB180);
-    RH_ScopedInstall(CheckForTrackConcatenation, 0x4EA930, { .reversed = false });
+    RH_ScopedInstall(CheckForTrackConcatenation, 0x4EA930);
     RH_ScopedInstall(QueueUpTracksForStation, 0x4EA670);
     RH_ScopedInstall(ChooseDJBanterIndex, 0x4EA2D0);
     RH_ScopedInstall(ChooseDJBanterIndexFromList, 0x4E95E0);
@@ -367,43 +367,95 @@ void CAERadioTrackManager::CheckForMissionStatsChanges() {
 
 // 0x4EA930
 void CAERadioTrackManager::CheckForTrackConcatenation() {
-    plugin::CallMethod<0x4EA930, CAERadioTrackManager*>(this);
-    /*
-    const auto utPlayMode = AEUserRadioTrackManager.GetUserTrackPlayMode();
-    if (m_ActiveSettings.m_nCurrentRadioStation == RADIO_USER_TRACKS && utPlayMode != 0) {
-        if (utPlayMode == 2 && m_ActiveSettings.m_iTrackPlayTime != -4) { // ???
-            AEUserRadioTrackManager.SetUserTrackIndex(m_ActiveSettings.m_aTrackQueue.front());
+    // Slot 0 is whatever is on air, so anything queued up goes in after it
+    auto trackCount = (int8)1;
 
-            m_ActiveSettings.m_aTrackQueue[1] = AEUserRadioTrackManager.SelectUserTrackIndex();
-            m_ActiveSettings.m_aTrackTypes[1] = TYPE_USER_TRACK;
-            m_ActiveSettings.m_aTrackIndexes[1] = m_ActiveSettings.m_aTrackQueue[1];
+    const auto PlayQueuedPair = [this] {
+        AEAudioHardware.PlayTrack(
+            m_ActiveSettings.TrackQueue[0],
+            m_ActiveSettings.TrackQueue[1],
+            0u,
+            m_ActiveSettings.TrackFlags,
+            m_ActiveSettings.TrackTypes[0] == TYPE_USER_TRACK,
+            m_ActiveSettings.TrackTypes[1] == TYPE_USER_TRACK
+        );
+    };
 
-            AEAudioHardware.PlayTrack(
-                m_ActiveSettings.m_aTrackQueue[0],
-                m_ActiveSettings.m_aTrackQueue[1],
-                0u,
-                m_ActiveSettings.m_nTrackFlags,
-                m_ActiveSettings.m_aTrackTypes[0] == TYPE_USER_TRACK,
-                m_ActiveSettings.m_aTrackTypes[1] == TYPE_USER_TRACK // always true?
-            );
-        }
-        m_nUserTrackPlayMode = AEUserRadioTrackManager.GetUserTrackPlayMode();
-    }
+    // Switching the MP3 player in or out of random mode has to re-pick what comes next
+    if (m_ActiveSettings.StationID == RADIO_USER_TRACKS) {
+        const auto prevMode = m_nUserTrackPlayMode;
+        if (prevMode != AEUserRadioTrackManager.GetUserTrackPlayMode()) {
+            if ((prevMode == 2 || AEUserRadioTrackManager.GetUserTrackPlayMode() == 2) && m_ActiveSettings.PlayTime != -4) {
+                AEUserRadioTrackManager.SetUserTrackIndex(m_ActiveSettings.TrackQueue[0]);
 
-    const auto nextTrack = m_ActiveSettings.m_aTrackQueue[1];
-    if (AEAudioHardware.GetActiveTrackID() == nextTrack && nextTrack >= 0) {
-        m_ActiveSettings.SwitchToNextTrack();
+                m_ActiveSettings.TrackQueue[1]   = AEUserRadioTrackManager.SelectUserTrackIndex();
+                m_ActiveSettings.TrackTypes[1]   = TYPE_USER_TRACK;
+                m_ActiveSettings.TrackIndices[1] = (int8)m_ActiveSettings.TrackQueue[1];
+                trackCount = 2;
 
-        if (m_ActiveSettings.m_aTrackQueue[1] == -1) {
-            const auto radioId = m_ActiveSettings.m_nCurrentRadioStation;
-            if (radioId == RADIO_USER_TRACKS) {
-                if (!FrontEndMenuManager.m_nRadioMode && CAEAudioUtility::ResolveProbability(0.17f)) {
-                    m_ActiveSettings.m_aTrackQueue
-                }
+                PlayQueuedPair();
             }
+            m_nUserTrackPlayMode = AEUserRadioTrackManager.GetUserTrackPlayMode();
         }
     }
-    */
+
+    // Everything below only happens once the hardware has moved on to the track we lined up
+    const auto nextTrack = m_ActiveSettings.TrackQueue[1];
+    if (AEAudioHardware.GetActiveTrackID() != nextTrack || nextTrack < 0) {
+        return;
+    }
+    m_ActiveSettings.SwitchToNextTrack();
+
+    if (m_ActiveSettings.TrackQueue[1] == -1) { // Queue ran dry, top it back up
+        const auto id = m_ActiveSettings.StationID;
+        if (id == RADIO_USER_TRACKS) {
+            if (!FrontEndMenuManager.m_RadioMode && CAEAudioUtility::ResolveProbability(0.17f)) {
+                m_ActiveSettings.TrackQueue[trackCount] = ChooseAdvertIndex(RADIO_USER_TRACKS);
+                m_ActiveSettings.TrackTypes[trackCount] = TYPE_ADVERT;
+                trackCount++;
+            }
+            for (auto i = 0; i < 2; i++) { // Two ahead, so there's always something to cross into
+                const auto userTrack = AEUserRadioTrackManager.SelectUserTrackIndex();
+                m_ActiveSettings.TrackQueue[trackCount]   = userTrack;
+                m_ActiveSettings.TrackTypes[trackCount]   = TYPE_USER_TRACK;
+                m_ActiveSettings.TrackIndices[trackCount] = (int8)userTrack;
+                trackCount++;
+            }
+        } else {
+            auto next = TYPE_INTRO;
+
+            switch (m_ActiveSettings.TrackTypes[0]) {
+            case TYPE_INTRO:
+            case TYPE_TRACK:
+            case TYPE_OUTRO: { // A song just finished, so something may go in between
+                if (id == RADIO_EMERGENCY_AA) {
+                    next = TYPE_DJ_BANTER;
+                    break;
+                }
+                // Two songs back to back is as far as it goes before the DJ or an advert breaks them up
+                if (m_nTracksInARow[id] < 2 && CAEAudioUtility::ResolveProbability(0.5f)) {
+                    if (CAEAudioUtility::ResolveProbability(0.5f)) {
+                        QueueUpTracksForStation(id, &trackCount, TYPE_INDENT, m_ActiveSettings);
+                    }
+                    break;
+                }
+                if (CAEAudioUtility::ResolveProbability(0.5f)) {
+                    QueueUpTracksForStation(id, &trackCount, TYPE_INDENT, m_ActiveSettings);
+                }
+                if (QueueUpTracksForStation(id, &trackCount, TYPE_DJ_BANTER, m_ActiveSettings)) {
+                    PlayQueuedPair();
+                    return;
+                }
+                next = TYPE_ADVERT;
+                break;
+            }
+            }
+
+            QueueUpTracksForStation(id, &trackCount, next, m_ActiveSettings);
+        }
+    }
+
+    PlayQueuedPair();
 }
 
 // 0x4EB660

--- a/source/game_sa/Audio/Managers/AERadioTrackManager.h
+++ b/source/game_sa/Audio/Managers/AERadioTrackManager.h
@@ -249,7 +249,7 @@ protected:
     int32 ChooseIdentIndex(eRadioID id);
     int32 ChooseAdvertIndex(eRadioID id);
     int32 ChooseDJBanterIndex(eRadioID id);
-    int32 ChooseDJBanterIndexFromList(eRadioID id, int32** list);
+    int32 ChooseDJBanterIndexFromList(eRadioID id, int32 (*list)[2]);
     int8  ChooseMusicTrackIndex(eRadioID id);
     static int8  ChooseTalkRadioShow();
 


### PR DESCRIPTION
Builds on #1459 - please merge that one first, this branch contains its commit.

### `CheckForTrackConcatenation` (0x4EA930)

The function that keeps a station on the air. It hands the hardware the next
track before the current one ends, rotates the queue when the hardware moves on,
and refills the queue once it empties:

- User tracks are queued two ahead, with a 17% chance of an advert first when
  the radio menu isn't open.
- A normal station that just finished a song rolls twice at 0.5: once for
  whether an ident/DJ/advert breaks the run up, once for the ident itself.
  `m_nTracksInARow` caps it at two songs back to back.
- Toggling the MP3 player's random mode mid-track re-picks the next entry, so
  the change is audible immediately.

The commented-out sketch that was sitting in the function is dropped. It
referenced `tRadioSettings` members from before the rename (`m_aTrackQueue`,
`m_aTrackIndexes`, `m_nCurrentRadioStation`), trailed off mid-statement, and its
outer condition (`utPlayMode != 0`) doesn't match the binary, which compares the
*stored* play mode against the current one rather than testing for zero.

### `IsVehicleRadioActive` (0x4E9800)

Already implemented, just still flagged `.reversed = false`. It matches the
original exactly (`AE_RT_CIVILIAN`, `AE_RT_UNKNOWN`, `AE_RT_EMERGENCY`), so this
only flips the flag.

### Testing

**Not tested in-game** - same situation as #1459, no local MSVC/Wine build or
Compact exe here, so CI is doing the compiling. Runtime behaviour is unverified.

Worth a second pair of eyes on one spot: the order of the two 0.5 rolls relative
to the `m_nTracksInARow < 2` check. The decompiler output hoists the ident roll
above that check, which is wrong - the disassembly at 0x4EAB4D..0x4EAB74 shows
the `m_nTracksInARow` compare and its roll come first, and the ident roll is
duplicated into both branches. I went with the disassembly. It matters, because
getting it backwards changes how often idents play.

### Hook checklist

- `static void InjectHooks();` already declared.
- `CAERadioTrackManager::InjectHooks();` already called from `InjectHooksMain()`.
- No `friend void InjectHooksMain();` needed.
- Both keep their `RH_ScopedInstall` entries, now without `.reversed = false`.
