### PR TITLE
fix(CPedType): Return PED_TYPE_COUNT for unknown ped type names in FindPedType

### DIFF
--- a/source/game_sa/PedType.cpp
+++ b/source/game_sa/PedType.cpp
@@ -137,8 +137,9 @@ ePedType CPedType::FindPedType(const char* pedTypeName) {
         { "MISSION7",       PED_TYPE_MISSION7       },
         { "MISSION8",       PED_TYPE_MISSION8       },
     });
-    /* NOTE(pirulax): Original code returned `PED_TYPE_COUNT` as an `invalid value` sentinel, but we don't want to have quiet errors */
-    return notsa::find_value(s_PedTypeByNameMapping, pedTypeName); 
+    /* Return `PED_TYPE_COUNT` for unknown names, just like the original. Callers handle it
+       (e.g. `GetPedFlag(PED_TYPE_COUNT)` returns `0`). */
+    return notsa::find_value_or(s_PedTypeByNameMapping, pedTypeName, PED_TYPE_COUNT);
     /* NOTE(pirulax): There are 2 extra `strcmp`'s after this, but they both check values already present in the mapping above, so they're ok to omit */
 }
 


### PR DESCRIPTION
## Summary
Restores parity with the original in `CPedType::FindPedType` for unknown ped type names.

Current code uses `notsa::find_value` which hits `NOTSA_UNREACHABLE` on unknown names — in Release that is UB, where the original game simply returns `PED_TYPE_COUNT` (32) as the not-found sentinel. Callers already handle the sentinel (`GetPedFlag(PED_TYPE_COUNT)` returns `0`), so there is no quiet error being hidden.

```cpp
return notsa::find_value_or(s_PedTypeByNameMapping, pedTypeName, PED_TYPE_COUNT);
```

Fixes #1246

## Testing
Built (Release, VS2022) and launched the game — `PED.DAT` parses fine, no new exceptions in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)