### PR TITLE
fix(CCollision): constexpr .size() via reference parameter fails to compile on VS2022 (C2131)

### DIFF
--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1941,7 +1941,7 @@ int32 CCollision::ProcessColModels(const CMatrix& transformA, CColModel& cmA,
     // because each accepted collision also writes `m_fDepth = -1.f` into the *next* slot
     // (`sphereCPs[nNumSphereCPs + 1].m_fDepth`) as a "not-yet-written" sentinel - one trailing
     // index has to stay in-bounds for that.
-    constexpr auto maxSphereCPs = sphereCPs.size() - 1;
+    constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
 
     // Transform matrix from A's space to B's
     const auto transformAtoB = Invert(transformB) * transformA;


### PR DESCRIPTION
## Summary
`ProcessCollision` currently fails to compile with MSVC 19.4x (VS2022, `compiler.version=194`):

```
Collision.cpp(1944): error C2131: expression did not evaluate to a constant
```

`constexpr auto maxSphereCPs = sphereCPs.size() - 1;` reads through a reference parameter, which is not a constant expression per the standard. Newer MSVC versions accept it, VS2022 does not — and the README states VS2022 should still work.

Fixed by taking the size from the type instead:

```cpp
constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
```

## Testing
Project now builds on VS2022 (Release) — previously it did not compile at all. Game runs with the built .asi, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)