### PR TITLE
fix(CDamageManager): Correct GetComponentGroup component group mapping

### DIFF
--- a/source/game_sa/DamageManager.cpp
+++ b/source/game_sa/DamageManager.cpp
@@ -376,21 +376,17 @@ bool CDamageManager::GetComponentGroup(tComponent nComp, tComponentGroup& outCom
     case tComponent::COMPONENT_WING_LF:
     case tComponent::COMPONENT_WING_RF:
     case tComponent::COMPONENT_WING_LR:
-    case tComponent::COMPONENT_WING_RR: 
-    case tComponent::COMPONENT_WINDSCREEN: {
+    case tComponent::COMPONENT_WING_RR: {
         outCompGroup = tComponentGroup::COMPGROUP_LIGHT;
         outComponentRelativeIdx = (uint8)nComp - (uint8)tComponent::COMPONENT_WING_LF;
         return true;
     }
+    case tComponent::COMPONENT_NA:
+    case tComponent::COMPONENT_WINDSCREEN:
     case tComponent::COMPONENT_BUMP_FRONT:
     case tComponent::COMPONENT_BUMP_REAR: {
         outCompGroup = tComponentGroup::COMPGROUP_PANEL;
         outComponentRelativeIdx = (uint8)nComp - (uint8)tComponent::COMPONENT_WING_LF;
-        return true;
-    }
-    case tComponent::COMPONENT_NA: {
-        outCompGroup = tComponentGroup::COMPGROUP_NA;
-        outComponentRelativeIdx = 0;
         return true;
     }
     }


### PR DESCRIPTION
## Summary
The mapping in `CDamageManager::GetComponentGroup` doesn't match the original:

- `COMPONENT_NA` (0) currently returns `COMPGROUP_NA` / idx 0, but the original falls into the PANEL group with idx `0 - COMPONENT_WING_LF` = 245 (`uint8` wrap) — found by differential testing in #1252.
- `COMPONENT_WINDSCREEN` belongs to the PANEL group as well, not LIGHT.

This is the same fix as the one sitting unmerged on the `copilot/fix-component-group-mapping` branch (80628bd4, co-authored by Pirulax) — cherry-picked here so it can finally land.

Fixes #1252

## Testing
Built (Release, VS2022). Not tested in-game (car damage behavior); per the diff-test report the original returns `group=0, idx=245` for component 0, which this restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)