### PR TITLE
fix(cHandlingDataMgr): Use exact match in FindExactWord

### DIFF
--- a/source/game_sa/cHandlingDataMgr.cpp
+++ b/source/game_sa/cHandlingDataMgr.cpp
@@ -364,7 +364,7 @@ void cHandlingDataMgr::ConvertBikeDataToGameUnits(tBikeHandlingData* bikeHandlin
 int32 cHandlingDataMgr::FindExactWord(const char* name, const char* nameTable, uint32 entrySize, uint32 entryCount) {
     for (auto i = 0u; i < entryCount; i++) {
         const auto entry = &nameTable[entrySize * i];
-        if (!strncmp(name, entry, strlen(entry))) {
+        if (!strcmp(name, entry)) {
             return i;
         }
     }


### PR DESCRIPTION
## Summary
`cHandlingDataMgr::FindExactWord` used `strncmp(name, entry, strlen(entry))` (prefix matching) while the original at `0x6F4F30` uses `strcmp` (exact match). A name that is a prefix of a longer table entry could match the wrong entry.

Fixes #1256

## Testing
Built (Release, VS2022) and launched the game — `handling.cfg` still loads (same handlings count in the log as before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)