### PR TITLE
fix(CCollision): DistToMathematicalLine divides by |l|², not |p|²

### DIFF
--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1941,7 +1941,7 @@ int32 CCollision::ProcessColModels(const CMatrix& transformA, CColModel& cmA,
     // because each accepted collision also writes `m_fDepth = -1.f` into the *next* slot
     // (`sphereCPs[nNumSphereCPs + 1].m_fDepth`) as a "not-yet-written" sentinel - one trailing
     // index has to stay in-bounds for that.
-    constexpr auto maxSphereCPs = sphereCPs.size() - 1;
+    constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
 
     // Transform matrix from A's space to B's
     const auto transformAtoB = Invert(transformB) * transformA;

--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -438,8 +438,9 @@ float CCollision::DistToMathematicalLine(CVector const* lineStart, CVector const
     // Simple Pythagorean here, we gotta find side `a`
 
     const auto pMagSq = p.SquaredMagnitude();
+    const auto lMagSq = l.SquaredMagnitude();
     const auto cSq = pMagSq;
-    const auto bSq = pMagSq > 0.f ? (float)std::pow(DotProduct(p, l), 2) / pMagSq : 0.0f; // Dot product is scaled by `pMagSq` - guard against 0/0
+    const auto bSq = lMagSq > 0.f ? (float)std::pow(DotProduct(p, l), 2) / lMagSq : 0.0f; // Projection of `p` onto `l`: (p·l)²/|l|² - guard against 0/0
 
     const auto aSq = cSq - bSq;
     return aSq > 0.0f ? std::sqrt(aSq) : 0.0f; // Little optimization to not call `sqrt` if the dist is 0 (it wont ever be negative)


### PR DESCRIPTION
## Summary
`CCollision::DistToMathematicalLine` (0x412970) computes the projection term with the wrong denominator: it divides `(p·l)²` by `|p|²` instead of `|l|²`. The original (0x4129DF-0x4129EF) computes `l.x²+l.y²+l.z²` on the FPU stack and divides by that.

Example (line (0,0,0)→(10,0,0), point (5,3,0)): correct distance is 3; the buggy code computes `sqrt(34 - 2500/34) = sqrt(-39.5)`, clamped to 0.

```cpp
const auto lMagSq = l.SquaredMagnitude();
const auto bSq = lMagSq > 0.f ? (float)std::pow(DotProduct(p, l), 2) / lMagSq : 0.0f;
```

Fixes #1359

**Note:** based on #1463 (master doesn't compile on VS2022 without it) — rebase freely if that lands first.

## Testing
Built (Release, VS2022), game boots and runs with the built .asi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)