### PR TITLE
fix(CEntryExitManager): Iterate pool backwards in GetEntryExitIndex

### DIFF
--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1941,7 +1941,7 @@ int32 CCollision::ProcessColModels(const CMatrix& transformA, CColModel& cmA,
     // because each accepted collision also writes `m_fDepth = -1.f` into the *next* slot
     // (`sphereCPs[nNumSphereCPs + 1].m_fDepth`) as a "not-yet-written" sentinel - one trailing
     // index has to stay in-bounds for that.
-    constexpr auto maxSphereCPs = sphereCPs.size() - 1;
+    constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
 
     // Transform matrix from A's space to B's
     const auto transformAtoB = Invert(transformB) * transformA;

--- a/source/game_sa/EntryExitManager.cpp
+++ b/source/game_sa/EntryExitManager.cpp
@@ -330,11 +330,16 @@ void CEntryExitManager::LinkEntryExit(CEntryExit* enex) {
 
 // 0x43EFD0
 int32 CEntryExitManager::GetEntryExitIndex(const char* name, uint16 enabledFlags, uint16 disabledFlags) {
-    for (auto&& [i, enex] : mp_poolEntryExits->GetAllValidWithIndex()) {
+    // Original iterates the pool backwards, so on duplicate names the highest index wins
+    for (auto i = (int32)mp_poolEntryExits->GetSize() - 1; i >= 0; i--) {
+        const auto enex = mp_poolEntryExits->GetAt(i);
+        if (!enex) {
+            continue;
+        }
         // Remember: cast to `uint8` == mask by 0xFF
-        if ((uint8)(enex.m_nFlags & enabledFlags) == (uint8)enabledFlags
-            && (uint8)(enex.m_nFlags & disabledFlags) == 0) {
-            if (!_strnicmp(enex.m_szName, name, std::size(enex.m_szName))) {
+        if ((uint8)(enex->m_nFlags & enabledFlags) == (uint8)enabledFlags
+            && (uint8)(enex->m_nFlags & disabledFlags) == 0) {
+            if (!_strnicmp(enex->m_szName, name, std::size(enex->m_szName))) {
                 return i;
             }
         }


### PR DESCRIPTION
## Summary
`CEntryExitManager::GetEntryExitIndex` (0x43EFD0) iterates the pool from the last slot down to the first in the original (confirmed by the Android decompilation posted in the issue), so with duplicate names the **highest** matching index wins. The reversed code iterated forwards, returning the lowest one.

Also noted in the issue: in practice entry/exit names don't seem to duplicate, so this is a pure parity fix with no observable behavior change on vanilla data.

**Note:** based on #1463 (master doesn't compile on VS2022 without it) — rebase freely if that lands first.

Fixes #1286

## Testing
Built (Release, VS2022), game boots with the built .asi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)