### PR TITLE
re(CProjectileInfo): Reverse Initialise

### DIFF
--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1941,7 +1941,7 @@ int32 CCollision::ProcessColModels(const CMatrix& transformA, CColModel& cmA,
     // because each accepted collision also writes `m_fDepth = -1.f` into the *next* slot
     // (`sphereCPs[nNumSphereCPs + 1].m_fDepth`) as a "not-yet-written" sentinel - one trailing
     // index has to stay in-bounds for that.
-    constexpr auto maxSphereCPs = sphereCPs.size() - 1;
+    constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
 
     // Transform matrix from A's space to B's
     const auto transformAtoB = Invert(transformB) * transformA;

--- a/source/game_sa/ProjectileInfo.cpp
+++ b/source/game_sa/ProjectileInfo.cpp
@@ -13,7 +13,7 @@ void CProjectileInfo::InjectHooks() {
     RH_ScopedCategoryGlobal();
 
     // Install("CProjectileInfo", "", , &CProjectileInfo::);
-    RH_ScopedInstall(Initialise, 0x737B40, { .reversed = false });
+    RH_ScopedInstall(Initialise, 0x737B40);
     RH_ScopedInstall(Shutdown, 0x737BC0, { .reversed = false });
     RH_ScopedInstall(GetProjectileInfo, 0x737BF0, { .reversed = false });
     RH_ScopedInstall(RemoveNotAdd, 0x737C00, { .reversed = false });
@@ -29,7 +29,17 @@ void CProjectileInfo::InjectHooks() {
 
 // 0x737B40
 void CProjectileInfo::Initialise() {
-    plugin::Call<0x737B40>();
+    for (auto& projectile : ms_apProjectile) {
+        projectile = nullptr;
+    }
+
+    for (auto& info : ms_aProjectileInfo) {
+        info.m_nWeaponType  = WEAPON_GRENADE;
+        info.m_pCreator     = nullptr;
+        info.m_nDestroyTime = 0;
+        info.m_bActive      = false;
+        info.m_pFxSystem    = nullptr;
+    }
 }
 
 // 0x737BC0

--- a/source/game_sa/ProjectileInfo.h
+++ b/source/game_sa/ProjectileInfo.h
@@ -26,7 +26,8 @@ public:
     FxSystem_c* m_pFxSystem;
 
 public:
-    static inline auto& ms_apProjectile = StaticRef<std::array<CProjectile*, MAX_PROJECTILES>>(0xC89110);
+    static inline auto& ms_apProjectile     = StaticRef<std::array<CProjectile*, MAX_PROJECTILES>>(0xC89110);
+    static inline auto& ms_aProjectileInfo  = StaticRef<std::array<CProjectileInfo, MAX_PROJECTILES>>(0xC891A8);
 
     static void Initialise();
     static void Shutdown();


### PR DESCRIPTION
## Summary
Reverses `CProjectileInfo::Initialise` (0x737B40) — nulls out `ms_apProjectile` and resets each `CProjectileInfo` slot (weapon type to `WEAPON_GRENADE`, creator/destroy time/FX system to zero, inactive). Also adds the missing `ms_aProjectileInfo` StaticRef (0xC891A8).

**Note:** based on #1463 (master doesn't compile on VS2022 without it).

## Testing
Built (Release, VS2022); boot test: game launches and runs with the reversed function active, no new exceptions in the log compared to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)