### PR TITLE
re(CProjectileInfo): Reverse RemoveNotAdd

### DIFF
--- a/source/game_sa/Collision/Collision.cpp
+++ b/source/game_sa/Collision/Collision.cpp
@@ -1941,7 +1941,7 @@ int32 CCollision::ProcessColModels(const CMatrix& transformA, CColModel& cmA,
     // because each accepted collision also writes `m_fDepth = -1.f` into the *next* slot
     // (`sphereCPs[nNumSphereCPs + 1].m_fDepth`) as a "not-yet-written" sentinel - one trailing
     // index has to stay in-bounds for that.
-    constexpr auto maxSphereCPs = sphereCPs.size() - 1;
+    constexpr auto maxSphereCPs = std::tuple_size_v<std::remove_reference_t<decltype(sphereCPs)>> - 1;
 
     // Transform matrix from A's space to B's
     const auto transformAtoB = Invert(transformB) * transformA;


### PR DESCRIPTION
## Summary
Reverses `CProjectileInfo::RemoveNotAdd` (0x737C00) — explodes a projectile that was never fired (ped holding it died / switched weapon). Maps the weapon type to the explosion type (grenade/satchel → `EXPLOSION_GRENADE`, molotov → `EXPLOSION_MOLOTOV`, rocket/HS → `EXPLOSION_ROCKET`) and calls `CExplosion::AddExplosion(nullptr, creator, type, pos, 0, 1, -1.f, 0)` — same tail call as the original.

**Note:** based on #1463 (master doesn't compile on VS2022 without it).

## Testing
Built (Release, VS2022); boot test green. Not tested in-game (needs a ped holding a grenade to die) — flagging for reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)